### PR TITLE
use makeOrGetOverlay 

### DIFF
--- a/hearth/media/js/feedback.js
+++ b/hearth/media/js/feedback.js
@@ -3,14 +3,9 @@
 define(
     ['capabilities', 'utils', 'urls', 'z', 'requests', 'templates'],
     function(capabilities, utils, urls, z, requests, nunjucks) {
-    var overlay = $('#feedback-overlay');
+    var overlay = utils.makeOrGetOverlay('feedback-overlay');
 
-    if (!overlay.length) {
-        overlay = $('<div id="feedback-overlay" class="overlay">');
-        z.container.append(overlay);
-    }
-
-    z.container.on('submit', '.feedback-form', utils._pd(function(e) {
+    z.body.on('submit', '.feedback-form', utils._pd(function(e) {
         // Submit feedback form
         var $this = $(this);
 


### PR DESCRIPTION
So I just realized there was a helper for creating this overlay but it requires z.body not z.container. Wanna merge or is this just not a good idea and we should copy pasta similar functionality whenever we need overlay support? (I'm thinking the former)
