### PR TITLE
remove notification after any click event (bug 855374)

### DIFF
--- a/hearth/media/js/overlay.js
+++ b/hearth/media/js/overlay.js
@@ -31,6 +31,10 @@ define('overlay', ['keys', 'l10n', 'utils', 'z'], function(keys, l10n, utils, z)
             e.stopPropagation();
         });
 
+        z.body.on('click', function() {
+            $('#notification').removeClass('show');
+        });
+
         z.page.on('loaded', function(e) {
             // Dismiss overlay when we load a new fragment.
             dismiss();


### PR DESCRIPTION
This appears to be the highest level that I could find where click events are listened to - makes sense to close any open notifications in a single spot. Not sure if this is the correct spot?
