### PR TITLE
Move hiding of splash back to loaded event

### DIFF
--- a/hearth/media/js/cat-dropdown.js
+++ b/hearth/media/js/cat-dropdown.js
@@ -101,7 +101,6 @@ define('cat-dropdown',
             cat_list.html(
                 nunjucks.env.getTemplate('cat_list.html').render(context));
             handleCatsRendered();
-            z.page.trigger('cats_rendered');
         });
     }
 

--- a/hearth/media/js/marketplace.js
+++ b/hearth/media/js/marketplace.js
@@ -73,7 +73,7 @@ require.config({
             z.body.addClass(settings.body_classes);
         }
 
-        z.page.one('cats_rendered', function() {
+        z.page.one('loaded', function() {
             console.log('[mkt] Hiding splash screen');
             $('#splash-overlay').addClass('hide');
         });


### PR DESCRIPTION
Now the cat dropdown data is fetched up-front we can move the hiding of the splash back to the loaded event and the cats_rendered event becomes redundant.
