### PR TITLE
Preserve scroll (bug 868249, 870008)

### DIFF
--- a/flue/main.py
+++ b/flue/main.py
@@ -22,7 +22,7 @@ import defaults
 import persona
 
 
-PER_PAGE = 10
+PER_PAGE = 5
 LATENCY = 0
 
 

--- a/hearth/media/js/requests.js
+++ b/hearth/media/js/requests.js
@@ -170,7 +170,9 @@ define('requests',
             requests.push(req);
             req.always(function() {
                 initiated--;
-                finish();
+                // Prevent race condition causing early
+                // closing of pool.
+                setTimeout(finish, 0);
             });
             return req;
         }

--- a/hearth/templates/category/main.html
+++ b/hearth/templates/category/main.html
@@ -37,8 +37,8 @@
   {% if paginated %}
     <header class="featured-header c">
       <nav class="tabs">
-        <a{% if not sort %} class="active"{% endif %} href="{{ popular_url }}">{{ _('Popular') }}</a>
-        <a{% if sort == 'created' %} class="active"{% endif %} href="{{ new_url }}">{{ _('New') }}</a>
+        <a{% if not sort %} class="active"{% endif %} href="{{ popular_url }}" data-preserve-scroll>{{ _('Popular') }}</a>
+        <a{% if sort == 'created' %} class="active"{% endif %} href="{{ new_url }}" data-preserve-scroll>{{ _('New') }}</a>
       </nav>
       <a href="{{ search_url }}" class="view-all">{{ _('View All') }}</a>
     </header>

--- a/smokealarm/casper.js
+++ b/smokealarm/casper.js
@@ -108,8 +108,16 @@ function Suite(options) {
         });
     };
 
+    this.back = function() {
+        return cobj.back();
+    };
+
     this.capture = function(filename) {
         cobj.capture('captures/' + filename);
+    };
+
+    this.evaluate = function() {
+        return cobj.evaluate.apply(cobj, arguments);
     };
 
     this.fill = function(form_selector, data) {
@@ -126,6 +134,10 @@ function Suite(options) {
         return cobj.exists(selector);
     };
 
+    this.getElementBounds = function(selector) {
+        return cobj.getElementBounds(selector);
+    };
+
     this.visible = function(selector) {
         return cobj.visible(selector);
     };
@@ -136,10 +148,6 @@ function Suite(options) {
 
     this.getText = function(selector) {
         return cobj.fetchText(selector);
-    };
-
-    this.evaluate = function(func) {
-        return cobj.evaluate(func);
     };
 
 }

--- a/smokealarm/tests/scroll.js
+++ b/smokealarm/tests/scroll.js
@@ -1,0 +1,65 @@
+var suite = require('./kasperle').suite();
+var scrollPos;
+var firstItemSel = '#gallery .listing li:first-child a';
+
+suite.run('/category/foo', function(test, waitFor) {
+
+    waitFor(function() {
+        return suite.exists('#gallery .listing');
+    });
+
+    test('General scroll tests', function(assert) {
+        assert.that(window.scrollY === 0, 'ScrollY starts at 0');
+        scrollPos = suite.evaluate(function(Y) {
+            window.scrollTo(0, Y);
+            return window.scrollY;
+        }, suite.getElementBounds(firstItemSel).top);
+        suite.press(firstItemSel);
+    });
+
+    waitFor(function() {
+        return suite.exists('#page');
+    });
+
+    test('Check scroll position test', function(assert) {
+        var scrollY = suite.evaluate(function() {
+            return window.scrollY;
+        });
+        assert.equal(scrollY, 0, 'Check scroll is 0');
+        suite.back();
+    });
+
+    waitFor(function() {
+        return suite.exists('#gallery');
+    });
+
+    test('Scroll post back button test', function(assert) {
+        var scrollY = suite.evaluate(function() {
+            return window.scrollY;
+        });
+        assert.that(scrollY > 0, 'Check scroll is greater than 0');
+        assert.equal(scrollY, scrollPos, "Check scroll hasn't changed");
+        suite.press(firstItemSel);
+    });
+
+    waitFor(function() {
+        return suite.exists('#nav-back');
+    });
+
+    test('Click back link', function(assert) {
+        suite.press('#nav-back');
+    });
+
+    waitFor(function() {
+        return suite.exists('#page');
+    });
+
+    test('Scroll back link test', function(assert) {
+        var scrollY = suite.evaluate(function() {
+            return window.scrollY;
+        });
+        assert.that(scrollY > 0, 'Check scroll is greater than 0');
+        assert.equal(scrollY, scrollPos, "Check scroll hasn't changed");
+    });
+
+});

--- a/smokealarm/tests/tabs.js
+++ b/smokealarm/tests/tabs.js
@@ -1,0 +1,44 @@
+var suite = require('./kasperle').suite();
+var scrollPos;
+
+suite.run('/', function(test, waitFor) {
+
+    waitFor(function() {
+        return suite.exists('.tabs .active');
+    });
+
+    test('Tab scroll tests', function(assert) {
+        assert.that(window.scrollY === 0, 'ScrollY starts at 0');
+        scrollPos = suite.evaluate(function(tabsTop) {
+            window.scrollTo(0, tabsTop);
+            return window.scrollY;
+        }, suite.getElementBounds('.tabs').top);
+        suite.press('.tabs .active + a');
+    });
+
+    waitFor(function() {
+        return suite.exists('.tabs .active');
+    });
+
+    test('Tab scroll click test', function(assert) {
+        var scrollY = suite.evaluate(function() {
+            return window.scrollY;
+        });
+        assert.that(scrollY > 0, 'Check scroll is greater than 0');
+        assert.equal(scrollY, scrollPos, "Check scroll hasn't changed");
+        suite.back();
+    });
+
+    waitFor(function() {
+        return suite.exists('.tabs .active');
+    });
+
+    test('Tab scroll post back button test', function(assert) {
+        var scrollY = suite.evaluate(function() {
+            return window.scrollY;
+        });
+        assert.that(scrollY > 0, 'Check scroll is greater than 0');
+        assert.equal(scrollY, scrollPos, "Check scroll hasn't changed");
+    });
+
+});


### PR DESCRIPTION
This is an attempt to maintain the scroll position for the tabs.

There's a noticeable effect the first time the second tab is clicked as the loaded event now happens fairly late when requests.pool is closed.

An alternative approach involves fixing the min-height at the same time as preserving the scroll but I've left this out for now as it seemed a lot less ideal compared to happening via an event.

I've also fixed the back button scroll positioning 870008.

Note: going forwards still needs to be accounted for and that will involve more re-working of navigation to understand when back is back and forwards is forwards when popstate fires.

Tests cover the tabs + basic scroll history case. They won't pass until the updated flue changes land which make the tabs visible by default.
