### PR TITLE
Fix feedback link + tests (bug 870719)

### DIFF
--- a/hearth/media/js/capabilities.js
+++ b/hearth/media/js/capabilities.js
@@ -18,7 +18,7 @@ define('capabilities', [], function() {
         ),
         'fileAPI': !!window.FileReader,
         'userAgent': navigator.userAgent,
-        'widescreen': safeMatchMedia('(min-width: 1024px)'),
+        'widescreen': function(){ return safeMatchMedia('(min-width: 710px)'); },
         'firefoxAndroid': navigator.userAgent.indexOf('Firefox') !== -1 && navigator.userAgent.indexOf('Android') !== -1,
         'touch': !!(('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch),
         'nativeScroll': (function() {

--- a/smokealarm/casper.js
+++ b/smokealarm/casper.js
@@ -150,6 +150,11 @@ function Suite(options) {
         return cobj.fetchText(selector);
     };
 
+    this.viewport = function(w, h) {
+        console.log('Setting viewport to ' + w + 'x' + h);
+        return cobj.viewport(w, h);
+    };
+
 }
 
 exports.suite = function(options) {

--- a/smokealarm/tests/feedback_desktop.js
+++ b/smokealarm/tests/feedback_desktop.js
@@ -1,0 +1,50 @@
+// Desktop tests for feedback modal
+var suite = require('./kasperle').suite();
+
+suite.run('/', function(test, waitFor) {
+
+    test('Set viewport to desktop', function() {
+        suite.viewport(720, 500);
+    });
+
+    waitFor(function() {
+        return suite.exists('#site-footer .submit-feedback');
+    });
+
+    // TODO have a way to setup/teardown prior to navigating.
+    test('Navigate back to /', function(assert) {
+        suite.press('h1.site a');
+    });
+
+    waitFor(function() {
+        return suite.exists('#site-footer .submit-feedback');
+    });
+
+    test('Clicking on feedback link', function(assert) {
+        suite.press('#site-footer .submit-feedback');
+    });
+
+    waitFor(function() {
+        return suite.visible('.feedback.modal');
+    });
+
+    test('Check modal displayed', function(assert) {
+        suite.capture('feedback.png');
+        assert.visible('.feedback.modal');
+        assert.visible('.feedback-form textarea');
+        assert.selectorExists('.potato-captcha');
+        assert.invisible('.potato-captcha');
+        assert.selectorExists('.feedback-form button[disabled]');
+    });
+
+    test('Verify form is submitted', function(assert) {
+        suite.fill('.feedback-form', {'feedback': 'test'});
+        assert.selectorExists('.feedback-form button:not([disabled])');
+    });
+
+    test('Restore viewport', function() {
+        // Needed or else we are stuck on 1024x768
+        suite.viewport(400, 300);
+    });
+
+});

--- a/smokealarm/tests/feedback_mobile.js
+++ b/smokealarm/tests/feedback_mobile.js
@@ -1,21 +1,21 @@
+// Mobile tests for feedback
 var suite = require('./kasperle').suite();
 
-suite.run('/', function(test, waitFor) {
+suite.run('/settings', function(test, waitFor) {
 
     waitFor(function() {
         return suite.exists('#splash-overlay.hide');
     });
 
-    test('Clicking on feedback displays overlay', function(assert) {
-        suite.press('#site-footer .submit-feedback');
+    test('Click through to feedback form', function(assert) {
+        suite.press('#account-settings .toggles li:last-child a');
+    });
+
+    test('Check form exists', function(assert) {
         suite.capture('feedback.png');
-
-        assert.visible('.feedback.modal');
         assert.visible('.feedback-form textarea');
-
         assert.selectorExists('.potato-captcha');
         assert.invisible('.potato-captcha');
-
         assert.selectorExists('.feedback-form button[disabled]');
     });
 


### PR DESCRIPTION
This fixes up the tests for the feedback modals - investigating the tests found that clicks for the modal weren't happening if the viewport was too small.

Currently it's necessary to teardown the viewport size change. Would be really nice to have a setUp/tearDown available or maybe explicitly setting the viewport should happen each time somewhere in smokealarm/casper.js as an alternative?
