### PR TITLE
Updated requests, pool improvements

### DIFF
--- a/hearth/media/js/builder.js
+++ b/hearth/media/js/builder.js
@@ -74,6 +74,10 @@ define(
             }
 
             els.on('click', function() {
+                // Call the injector to load the next page's URL into the
+                // more button's parent. `target` is the selector to extract
+                // from the newly built HTML to inject into the currently
+                // visible page.
                 injector(els.data('url'), els.parent(), target).done(function() {
                     z.page.trigger('loaded_more');
                 }).fail(function() {

--- a/hearth/media/js/requests.js
+++ b/hearth/media/js/requests.js
@@ -150,8 +150,6 @@ define('requests',
         var marked_to_finish = false;
         var closed = false;
 
-        var _this = this;
-
         function finish() {
             if (closed) {
                 return;
@@ -159,10 +157,6 @@ define('requests',
             if (!initiated && marked_to_finish) {
                 console.log('[req] Closing pool');
                 closed = true;
-                // Don't allow new requests.
-                _this.get = null;
-                _this.post = null;
-                _this.del = null;
 
                 // Resolve the deferred whenevs.
                 if (window.setImmediate) {


### PR DESCRIPTION
- Updated docs to reflect latest requests code
- Alphabetized methods
- Changed pool to only allow close after `.finish()` has been called

cc @muffinresearch 

This should fix your race condition issues. The `this` context bug was previously preventing the pool from actually closing, which was enabling the code to continue working. Once you fix that, the bug is apparent. The pool should only close after `pool.finish()` is explicitly called, not when individual requests complete.

This may also allow us to remove some janky `setTimeout`s in other parts of the code.
