### PR TITLE
Remove setTimeout workaround

### DIFF
--- a/hearth/media/css/site.styl
+++ b/hearth/media/css/site.styl
@@ -39,6 +39,8 @@ a {
 body {
     background: $salt-flat-white;
     color: $castle-skull-gray;
+    // Needed so ff b2g/android can scroll to 0.
+    min-height: 480px;
     overflow-x: hidden;
     transform-origin: 50% 400px;
     transition: transform 1s;

--- a/hearth/media/js/navigation.js
+++ b/hearth/media/js/navigation.js
@@ -70,17 +70,19 @@ define('navigation',
         state.title = z.context.title;
 
         if ((state.preserveScroll || popped) && state.scrollTop) {
-            z.page.one('loaded', function() {
-                console.log('[nav] Setting scroll: ', state.scrollTop);
-                z.doc.scrollTop(state.scrollTop);
-            });
+            console.log('[nav] Setting scroll: ', state.scrollTop);
+            if (state.docHeight) {
+                // Preserve document min-height for scroll restoration.
+                z.body.css('min-height', state.docHeight);
+                z.page.one('loaded', function() {
+                    // Remove specified min-height.
+                    z.body.css('min-height', '');
+                });
+            }
+            window.scrollTo(0, state.scrollTop);
         } else {
             console.log('[nav] Resetting scroll');
-            // Asynchronously reset scroll position.
-            // This works around a bug in B2G/Android where rendering blocks interaction.
-            setTimeout(function() {
-                z.doc.scrollTop(0);
-            }, 0);
+            window.scrollTo(0, 0);
         }
 
         // Clean the path's parameters.
@@ -171,6 +173,7 @@ define('navigation',
         if (preserveScroll) {
             newState.preserveScroll = preserveScroll;
             newState.scrollTop = scrollTop;
+            newState.docHeight = z.doc.height();
         }
 
         if (!canNavigate()) {
@@ -186,7 +189,7 @@ define('navigation',
         // Update scrollTop for current history state.
         if (stack.length && scrollTop !== stack[0].scrollTop) {
             stack[0].scrollTop = scrollTop;
-            console.log('[nav] Updating scrollTop for path: "' + stack[0].path + '" as: ' + scrollTop);
+            console.log('[nav] Updating scrollTop');
             history.replaceState(stack[0], false, stack[0].path);
         }
 

--- a/hearth/media/js/requests.js
+++ b/hearth/media/js/requests.js
@@ -54,7 +54,7 @@ define('requests',
       Functionally similar to the root `del()` method with pool support.
 
     - finish()
-      Closes the pool (prevents new requests). If no requests have been made
+      Closes the pool. If no requests have been made
       at this point, the pool's promise will resolve.
 
     - abort()
@@ -168,7 +168,7 @@ define('requests',
                     setTimeout(def.resolve, 0);
                 }
             }
-        };
+        }
 
         this.finish = function() {
             marked_to_finish = true;
@@ -181,9 +181,7 @@ define('requests',
             requests.push(req);
             req.always(function() {
                 initiated--;
-                // Prevent race condition causing early
-                // closing of pool.
-                setTimeout(finish, 0);
+                finish();
             });
             return req;
         }


### PR DESCRIPTION
Thanks to @mattbasta's refactor of the pool setTimeout hack is no longer needed.
- Removed unecessary semi-colon 
- Updated docs re: preventing new requests.
- Fixes reset scroll issues on FF Android/B2g
- Makes tab change have no noticeable screen movement.
