### PR TITLE
Shorter default min-height for short pages.

### DIFF
--- a/hearth/media/css/site.styl
+++ b/hearth/media/css/site.styl
@@ -39,8 +39,8 @@ a {
 body {
     background: $salt-flat-white;
     color: $castle-skull-gray;
-    // Needed so ff b2g/android can scroll to 0.
-    min-height: 480px;
+    // min-height needed so ff b2g/android can scroll to 0 (bug 872622).
+    min-height: 300px;
     overflow-x: hidden;
     transform-origin: 50% 400px;
     transition: transform 1s;


### PR DESCRIPTION
Reduce the default scroll height to allow b2g and android to be able to reset scroll, but so that short pages don't have scrollbars.
