### PR TITLE
Increase settings link click target (bug 873413)

### DIFF
--- a/hearth/media/css/header.styl
+++ b/hearth/media/css/header.styl
@@ -86,7 +86,7 @@
 }
 
 .act-tray {
-    height: 30px;
+    height: 47px;
     position: relative;
     width: 34px;  // 24px + 10px margin
 }
@@ -207,12 +207,14 @@
         width: 24px;
     }
     &.settings {
-        background: url(../img/pretty/settings_gear.svg) 0 50% no-repeat;
+        background: url(../img/pretty/settings_gear.svg) 50% 50% no-repeat;
         background-size: 24px auto;
         display: block;
-        height: 30px;
+        height: 40px;
         position: absolute;
-        width: 24px;
+        right: 2px;
+        top: 2px;
+        width: 40px;
     }
     &.back {
         hidetext();
@@ -393,6 +395,8 @@ main {
     .header-button.settings {
         background-position: 50% 10px;
         background-size: 30px auto;
+        right: 0;
+        top: 0;
     }
 
     .act-tray,


### PR DESCRIPTION
Increase the click target of the settings button in mobile.

Doesn't fix bug 873413, there's something else happening but makes it easier to hit the link in case of fat fingers!
