### PR TITLE
Fix pluralisation of locales (bug 874802)

### DIFF
--- a/hearth/media/js/l10n.js
+++ b/hearth/media/js/l10n.js
@@ -63,7 +63,8 @@ if (!window.define) {
             var fallback = n === 1 ? str : plural;
             if (context.l10n && str in (strings = context.l10n.strings)) {
                 if (strings[str].plurals) {
-                    var plid = context.l10n.pluralize(n);
+                    // +true is 1 / +false is 0
+                    var plid = +context.l10n.pluralize(n);
                     out = strings[str].plurals[plid] || fallback;
                 } else {
                     // Support for languages like zh-TW where there is no plural form.

--- a/hearth/tests/l10n.js
+++ b/hearth/tests/l10n.js
@@ -17,7 +17,7 @@ var basic_context = new MockNavigator(
      formatted: {body: 'zip {zap}'},
      sing: {plurals: ['zero {n}', 'one {n}']},
      sing2: {plurals: ['zero {n} {asdf}', 'one {n} {asdf}']}},
-    function(n) {return +!!(n - 1);}
+    function(n) {return !!(n - 1);}
 );
 
 test('l10n.gettext', function(done) {

--- a/locale/it/LC_MESSAGES/messages.po
+++ b/locale/it/LC_MESSAGES/messages.po
@@ -118,7 +118,7 @@ msgstr "Installata"
 
 #: hearth/templates/detail/main.html:36
 msgid "Launch this app from your <b>Applications</b> directory."
-msgstr "Avvia quest'app dalla cartella <b>Applicazioni/b>."
+msgstr "Avvia quest'app dalla cartella <b>Applicazioni</b>."
 
 #: hearth/templates/detail/main.html:39
 msgid "Launch this app from your <b>Windows desktop</b> or <b>Start &#9658; All Programs</b>."

--- a/scripts/generate_langpacks.js
+++ b/scripts/generate_langpacks.js
@@ -93,7 +93,7 @@ function parse(po_content) {
         }
 
         var line_val = JSON.parse(line);
-        if (id === null && last !== 'plurals') {
+        if (!id && last !== 'plurals') {
             var plex_match = RE_PLURALIZER.exec(line_val);
             if (!plex_match) {
                 continue;


### PR DESCRIPTION
This branch fixes the building of langpacks so the pluraliser function is correctly represented and booleans are converted to 0 and 1 respectively.

I also fixed an unclosed tag in the italian translation too.
