### PR TITLE
Do review post login 873620

### DIFF
--- a/hearth/media/js/login.js
+++ b/hearth/media/js/login.js
@@ -58,6 +58,7 @@ define('login',
             privacyPolicy: '/privacy-policy',
             oncancel: function() {
                 console.log('Persona login cancelled');
+                z.page.trigger('login_cancel');
                 _.invoke(pending_logins, 'reject');
                 pending_logins = [];
             }
@@ -120,6 +121,7 @@ define('login',
             $('.loading-submit').removeClass('loading-submit');
             notification.notification({message: err});
 
+            z.page.trigger('login_fail');
             _.invoke(pending_logins, 'reject');
             pending_logins = [];
         });

--- a/hearth/media/js/views/app.js
+++ b/hearth/media/js/views/app.js
@@ -1,7 +1,9 @@
 define('views/app',
-    ['capabilities', 'l10n', 'login', 'utils', 'requests', 'underscore', 'urls', 'z', 'templates', 'overflow'],
-    function(caps, l10n, login, utils, requests, _, urls, z, nunjucks, overflow) {
+    ['capabilities', 'helpers', 'l10n', 'utils', 'underscore', 'z', 'templates', 'overflow'],
+    function(caps, helpers, l10n, utils, _, z, nunjucks, overflow) {
     'use strict';
+
+    var gettext = l10n.gettext;
 
     z.page.on('click', '#product-rating-status .toggle', utils._pd(function() {
         // Show/hide scary content-rating disclaimers to developers.
@@ -53,27 +55,19 @@ define('views/app',
             if (caps.widescreen() && !$('.report-abuse').length) {
                 z.page.append(
                     nunjucks.env.getTemplate('detail/abuse.html').render(
-                        _.extend({slug: slug}, require('helpers'))
+                        _.extend({slug: slug}, helpers)
                     )
                 );
             }
         }).onload('ratings', function() {
             var reviews = $('.detail .reviews li');
-            if (!require('user').logged_in()) {
-                $('#add-review').text(gettext('Sign in to Review')).on('click', function(e) {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    login.login();
-                });
-            }
-
-            if (reviews.length < 3) return;
-
-            for (var i = 0; i < reviews.length - 2; i += 2) {
-                var hgt = Math.max(reviews.eq(i).find('.review-inner').height(),
-                                   reviews.eq(i + 1).find('.review-inner').height());
-                reviews.eq(i).find('.review-inner').height(hgt);
-                reviews.eq(i + 1).find('.review-inner').height(hgt);
+            if (reviews.length >= 3) {
+                for (var i = 0; i < reviews.length - 2; i += 2) {
+                    var hgt = Math.max(reviews.eq(i).find('.review-inner').height(),
+                                       reviews.eq(i + 1).find('.review-inner').height());
+                    reviews.eq(i).find('.review-inner').height(hgt);
+                    reviews.eq(i + 1).find('.review-inner').height(hgt);
+                }
             }
         });
     };

--- a/hearth/media/js/views/app/ratings.js
+++ b/hearth/media/js/views/app/ratings.js
@@ -1,38 +1,13 @@
-define('views/app/ratings', ['capabilities', 'helpers', 'l10n', 'login', 'templates', 'urls', 'user', 'utils', 'underscore', 'z'],
-       function(capabilities, helpers, l10n, login, nunjucks, urls, user, utils, _, z) {
+define('views/app/ratings', ['l10n', 'urls'],
+       function(l10n, urls) {
 
     var gettext = l10n.gettext;
-
-    z.page.on('click', '#write-review', function() {
-        if (capabilities.widescreen()) {
-            var ctx = _.extend({slug: $(this).data('slug')}, helpers);
-            e.preventDefault();
-            e.stopPropagation();
-
-            z.page.append(
-                nunjucks.env.getTemplate('ratings/write.html').render(ctx)
-            );
-
-            z.body.trigger('decloak');
-            $('.compose-review.modal').addClass('show');
-            $('.compose-review').find('select[name="rating"]').ratingwidget('large');
-            utils.initCharCount();
-        }
-    });
 
     return function(builder, args) {
         var slug = args[0];
 
         builder.start('ratings/main.html', {
             'slug': slug
-        }).done(function() {
-            if (!user.logged_in()) {
-                $('#write-review').text(gettext('Sign in to Review')).on('click', function(e) {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    login.login();
-                });
-            }
         });
 
         builder.z('type', 'leaf');

--- a/hearth/media/js/views/app/ratings/add.js
+++ b/hearth/media/js/views/app/ratings/add.js
@@ -7,13 +7,9 @@ define('views/app/ratings/add',
     return function(builder, args) {
         var slug = args[0];
 
-        // If the user isn't logged in, redirect them to the detail page and
-        // open a login window. If they complete the login, click the Write
-        // Review button if it exists.
+        // If the user isn't logged in, redirect them to the detail page.
         if (!user.logged_in()) {
-            login.login().done(function() {
-                $('#add-review').trigger('click');
-            });
+            z.page.trigger('navigate', urls.reverse('app', [slug]));
             return;
         }
 
@@ -32,6 +28,7 @@ define('views/app/ratings/add',
                     textarea.focus();
                 }
             });
+
             if (scrollTo && !caps.widescreen()) {
                 console.log('scrollTo');
                 $reviewBox.find('textarea').on('focus', function() {

--- a/hearth/media/js/views/app/ratings/edit.js
+++ b/hearth/media/js/views/app/ratings/edit.js
@@ -47,7 +47,6 @@ define('views/app/ratings/edit',
         // have even gotten to this page in their current state anyway.
         if (!user.logged_in()) {
             z.page.trigger('navigate', urls.reverse('app', [slug]));
-            require('views').reload();
             return;
         }
 

--- a/hearth/media/js/views/feedback.js
+++ b/hearth/media/js/views/feedback.js
@@ -32,8 +32,7 @@ define('views/feedback',
     // Init desktop feedback form modal trigger.
     function addFeedbackModal() {
         if (!caps.widescreen()) return;
-
-        if (!$('.main.feedback:not(.modal)').length) {
+        if (!$('.main.feedback:not(.modal)').length && !$('.feedback.modal').length) {
             z.page.append(
                 nunjucks.env.getTemplate('settings/feedback.html').render(helpers)
             );

--- a/hearth/media/js/z.js
+++ b/hearth/media/js/z.js
@@ -7,7 +7,8 @@ define('z', ['jquery', 'underscore'], function($, _) {
         page: $('#page'),
         canInstallApps: true,
         state: {},
-        apps: {}
+        apps: {},
+        flags: {}
     };
 
     var data_user = z.body.data('user');

--- a/hearth/templates/detail/main.html
+++ b/hearth/templates/detail/main.html
@@ -121,12 +121,13 @@
       {% if (this.user.can_rate or not user.logged_in()) or this.user.has_rated %}
         <div class="{{ 'split' if this.objects.length else ' full' }}">
           {% if user.logged_in() and this.user.has_rated %}
-            <a class="button alt" id="edit-review" href="{{ url('app/ratings/edit', [slug]) }}">
+            <a class="button write-review alt" id="edit-review" href="{{ url('app/ratings/edit', [slug]) }}"
+               data-app="{{ slug }}">
               {{ _('Edit Your Review') }}</a>
           {% else %}
-            <a class="button alt" id="add-review" href="{{ url('app/ratings/add', [slug]) }}"
-               data-action="add" data-app="{{ slug }}">
-              {{ _('Write a Review') }}</a>
+            <a class="button write-review alt" id="add-review" href="{{ url('app/ratings/add', [slug]) }}"
+               data-app="{{ slug }}">
+               {{ _('Write a Review') if user.logged_in() else _('Sign in to Review') }}</a>
           {% endif %}
         </div>
       {% endif %}

--- a/hearth/templates/ratings/main.html
+++ b/hearth/templates/ratings/main.html
@@ -9,9 +9,13 @@
   {% defer (url=apiParams('reviews', {'app': slug}), pluck='objects', id='ratings', paginate='.ratings-placeholder-inner') %}
     <p id="add-review" class="primary-button">
       {% if response.user.has_rated %}
-        <a class="button" id="write-review" href="{{ url('app/ratings/edit', [slug]) }}" data-slug="{{ slug }}">{{ _('Edit Review') }}</a>
+        <a class="button write-review" id="edit-review" href="{{ url('app/ratings/edit', [slug]) }}"
+           data-app="{{ slug }}">
+           {{ _('Edit Review') }}</a>
       {% else %}
-        <a class="button" id="write-review" href="{{ url('app/ratings/add', [slug]) }}" data-slug="{{ slug }}">{{ _('Write a Review') }}</a>
+        <a class="button write-review" id="write-review" href="{{ url('app/ratings/add', [slug]) }}"
+           data-app="{{ slug }}">
+           {{ _('Write a Review') if user.logged_in() else  _('Sign in to Review') }}</a>
       {% endif %}
     </p>
     <div class="reviews reviews-listing">

--- a/smokealarm/tests/app/ratings.js
+++ b/smokealarm/tests/app/ratings.js
@@ -1,6 +1,6 @@
 var suite = require('./kasperle').suite();
 
-suite.run('/app/foo', function(test, waitFor) {
+suite.run('/app/can_rate', function(test, waitFor) {
 
     waitFor(function() {
         // Wait for reviews to load in.
@@ -21,7 +21,7 @@ suite.run('/app/foo', function(test, waitFor) {
     });
 
     test('Ratings page baseline tests', function(assert) {
-        assert.URL(/\/app\/foo\/ratings/);
+        assert.URL(/\/app\/can_rate\/ratings/);
 
         assert.hasText('#write-review');
 

--- a/smokealarm/tests/ratings/add.js
+++ b/smokealarm/tests/ratings/add.js
@@ -1,0 +1,24 @@
+var suite = require('./kasperle').suite();
+var lib = require('./lib');
+
+suite.run('/app/can_rate', function(test, waitFor) {
+
+    waitFor(function() {
+        return suite.exists('#splash-overlay.hide');
+    });
+
+    test('Assert sign-in to review button present', function(assert) {
+        assert.hasText('#add-review', 'Sign in to Review');
+        suite.press('.write-review');
+        lib.fake_login(suite);
+    });
+
+    waitFor(function() {
+        return suite.exists('.compose-review');
+    });
+
+    test('Assert we are on rating add page', function(assert) {
+        assert.URL(/\/app\/can_rate\/ratings\/add/);
+    });
+
+});

--- a/smokealarm/tests/ratings/add_deeplinked.js
+++ b/smokealarm/tests/ratings/add_deeplinked.js
@@ -1,0 +1,12 @@
+var suite = require('./kasperle').suite();
+
+suite.run('/app/foo/ratings/add', function(test, waitFor) {
+
+    waitFor(function() {
+        return suite.exists('#splash-overlay.hide');
+    });
+
+    test('Check redirected to app page', function(assert) {
+        assert.URL(/\/app\/foo/);
+    });
+});

--- a/smokealarm/tests/ratings/add_desktop.js
+++ b/smokealarm/tests/ratings/add_desktop.js
@@ -1,0 +1,35 @@
+var suite = require('./kasperle').suite();
+var lib = require('./lib');
+
+// Desktop only tests.
+suite.marionetteSkip = true;
+
+suite.setUp = function(){
+    suite.viewport(1024, 768);
+};
+
+suite.tearDown = function(){
+    suite.viewport(400, 300);
+};
+
+suite.run('/app/can_rate', function(test, waitFor) {
+
+    waitFor(function() {
+        return suite.exists('#splash-overlay.hide');
+    });
+
+    test('Assert sign-in to review button present', function(assert) {
+        assert.hasText('#add-review', 'Sign in to Review');
+        suite.press('.write-review');
+        lib.fake_login(suite);
+    });
+
+    waitFor(function() {
+        return suite.exists('#add-review');
+    });
+
+    test('Assert modal is visible', function(assert) {
+        assert.visible('.compose-review.modal');
+    });
+
+});

--- a/smokealarm/tests/ratings/edit.js
+++ b/smokealarm/tests/ratings/edit.js
@@ -1,0 +1,24 @@
+var suite = require('./kasperle').suite();
+var lib = require('./lib');
+
+suite.run('/app/has_rated', function(test, waitFor) {
+
+    waitFor(function() {
+        return suite.exists('#splash-overlay.hide');
+    });
+
+    test('Assert sign-in to review button present', function(assert) {
+        assert.hasText('#add-review', 'Sign in to Review');
+        suite.press('.write-review');
+        lib.fake_login(suite);
+    });
+
+    waitFor(function() {
+        return suite.exists('.compose-review');
+    });
+
+    test('Assert we are on rating edit page', function(assert) {
+        assert.URL(/\/app\/has_rated\/ratings\/edit/);
+    });
+
+});

--- a/smokealarm/tests/ratings/edit_deeplinked.js
+++ b/smokealarm/tests/ratings/edit_deeplinked.js
@@ -1,0 +1,12 @@
+var suite = require('./kasperle').suite();
+
+suite.run('/app/foo/ratings/edit', function(test, waitFor) {
+
+    waitFor(function() {
+        return suite.exists('#splash-overlay.hide');
+    });
+
+    test('Check redirected to app page', function(assert) {
+        assert.URL(/\/app\/foo/);
+    });
+});

--- a/smokealarm/tests/ratings/edit_desktop.js
+++ b/smokealarm/tests/ratings/edit_desktop.js
@@ -1,0 +1,35 @@
+var suite = require('./kasperle').suite();
+var lib = require('./lib');
+
+// Desktop only tests.
+suite.marionetteSkip = true;
+
+suite.setUp = function(){
+    suite.viewport(1024, 768);
+};
+
+suite.tearDown = function(){
+    suite.viewport(400, 300);
+};
+
+suite.run('/app/has_rated', function(test, waitFor) {
+
+    waitFor(function() {
+        return suite.exists('#splash-overlay.hide');
+    });
+
+    test('Assert sign-in to review button present', function(assert) {
+        assert.hasText('#add-review', 'Sign in to Review');
+        suite.press('.write-review');
+        lib.fake_login(suite);
+    });
+
+    waitFor(function() {
+        return suite.exists('.compose-review');
+    });
+
+    test('Assert we are on rating edit page', function(assert) {
+        assert.URL(/\/app\/has_rated\/ratings\/edit/);
+    });
+
+});

--- a/smokealarm/tests/ratings/ratings.js
+++ b/smokealarm/tests/ratings/ratings.js
@@ -1,6 +1,6 @@
 var suite = require('./kasperle').suite();
 
-suite.run('/app/foo', function(test, waitFor) {
+suite.run('/app/can_rate', function(test, waitFor) {
 
     waitFor(function() {
         // Wait for reviews to load in.
@@ -21,7 +21,7 @@ suite.run('/app/foo', function(test, waitFor) {
     });
 
     test('Ratings page baseline tests', function(assert) {
-        assert.URL(/\/app\/foo\/ratings/);
+        assert.URL(/\/app\/can_rate\/ratings/);
 
         assert.hasText('#write-review');
 


### PR DESCRIPTION
This takes @cvan's original branch and adds:
- Add/Edit reviews load as modal or page after login via loaded event in both mobile and desktop
- Cleaned up the distributed reviews logic and put it in ratings.js.
- Deeplinked add/edit are sent to app details instead.
- Basic tests to cover the whole thing.

Note: Edit is still linked to the page rather than being modal which is as it is today.
