### PR TITLE
Improve notification styles and behaviour (bug 878047)

### DIFF
--- a/hearth/media/css/notification.styl
+++ b/hearth/media/css/notification.styl
@@ -2,48 +2,48 @@
 
 #notification {
     background-color: #3b3b3b;
-    border-radius: 4px 4px 0 0;
     bottom: 0;
     color: #fff;
     cursor: pointer;
     font-family: "MozTT", $open-stack;
     grain();
     height: 62px;
-    left: 50%;
-    line-height: 1.4em;
-    max-width: 600px;
-    min-height: 62px;
-    padding: 10px;
+    left: 0;
+    line-height: 42px; // height less padding.
+    margin: 0 auto;
+    padding: 10px 15px;
     position: fixed;
-    transform(unquote('translate(-50%, 110%)'));
+    right: 0;
+    transform(translateY(62px));
+    // If this duration is increased update the duration in notification.js
+    // to ensure hiding the notification only happens when transition is complete.
     transition-duration(unquote('.3s, .3s, .3s, .3s'));
     transition-property(unquote('transform, -moz-transform, -webkit-transform, -ms-transform'));
     width: 100%;
     z-index: 9999;
-
     &.show {
-        transform(unquote('translate(-50%, 0%)'));
+        transform(translateY(0));
+        transition-duration(unquote('.3s, .3s, .3s, .3s'));
+        transition-property(unquote('transform, -moz-transform, -webkit-transform, -ms-transform'));
+    }
+    &.hidden {
+        display: none;
     }
 }
 
 #notification-content {
-    display: block;
-    left: 50%;
-    position: absolute;
-    top: 50%;
-    transform(unquote('translate(-50%, -50%)'));
-    width: 75%;
-
+    display: inline-block;
+    line-height: 1.5;
+    vertical-align: middle;
     b {
       text-transform: uppercase;
       color: #0995b0;
   }
 }
 
-@media (max-width: 600px) {
+@media (min-width: 600px) {
     #notification {
-        border-radius: 0;
-        max-width: none;
-        right: 0;
+        border-radius: 4px 4px 0 0;
+        max-width: 600px;
     }
 }

--- a/hearth/media/js/login.js
+++ b/hearth/media/js/login.js
@@ -12,6 +12,14 @@ define('login',
         models('app').purge();
     }
 
+    function signOutNotification() {
+        notification.notification({message: gettext('You have been signed out')});
+    }
+
+    function signInNotification() {
+        notification.notification({message: gettext('You have been signed in')});
+    }
+
     z.body.on('click', '.persona', function(e) {
         e.preventDefault();
 
@@ -19,8 +27,6 @@ define('login',
         $this.addClass('loading-submit');
         startLogin().always(function() {
             $this.removeClass('loading-submit').trigger('blur');
-        }).done(function() {
-            notification.notification({message: gettext('You have been signed in')});
         });
 
     }).on('click', '.logout', function(e) {
@@ -38,10 +44,12 @@ define('login',
         // gets fixed.
         if (z.context.reload_on_logout) {
             console.log('Page requested reload on logout');
-            require('views').reload();
+            require('views').reload().done(function(){
+                signOutNotification();
+            });
+        } else {
+            signOutNotification();
         }
-
-        notification.notification({message: gettext('You have been signed out')});
     });
 
     var pending_logins = [];
@@ -94,9 +102,13 @@ define('login',
 
             if (z.context.reload_on_login) {
                 console.log('Page requested reload on login');
-                require('views').reload().done(resolve_pending);
+                require('views').reload().done(function() {
+                    resolve_pending();
+                    signInNotification();
+                });
             } else {
                 console.log('Resolving outstanding login requests');
+                signInNotification();
                 resolve_pending();
             }
 

--- a/hearth/media/js/notification.js
+++ b/hearth/media/js/notification.js
@@ -1,7 +1,10 @@
 define('notification', ['capabilities', 'helpers', 'jquery', 'templates', 'z'], function(caps, helpers, $, nunjucks, z) {
+
     var notificationDef;
-    var notificationEl = $('<div id="notification">');
+    var notificationEl = $('<div id="notification" class="hidden">');
     var contentEl = $('<div id="notification-content">');
+    var showTimer;
+    var hideTimer;
 
     // allow *bolding* message text
     var re = /\*([^\*]+)\*/g;
@@ -11,11 +14,26 @@ define('notification', ['capabilities', 'helpers', 'jquery', 'templates', 'z'], 
     }
 
     function notificationShow() {
-        notificationEl.addClass('show');
+        if (hideTimer) {
+            window.clearTimeout(hideTimer);
+        }
+        notificationEl.removeClass('hidden');
+        // Delay to ensure transition onto screen happens.
+        showTimer = window.setTimeout(function() {
+            notificationEl.addClass('show');
+        }, 700);
     }
 
     function notificationHide() {
+        if (showTimer) {
+            window.clearTimeout(showTimer);
+        }
         notificationEl.removeClass('show');
+        // This needs to be greater than the transition timing
+        // in notification.styl.
+        hideTimer = window.setTimeout(function() {
+            notificationEl.addClass('hidden');
+        }, 400);
     }
 
     function notification(opts) {
@@ -55,7 +73,6 @@ define('notification', ['capabilities', 'helpers', 'jquery', 'templates', 'z'], 
         notificationDef.resolve();
     });
     z.body.append(notificationEl);
-
 
     var confirmationDef = $.Deferred();
     var cloakEl = $('.cloak');


### PR DESCRIPTION
This fixes the bug with the notification widget being visible after page load on FF android.

It also simplifies the styles, and provides horiz/vertical centering of text.
Additionally this fixes the issue with the signed-out notification not being visible due to reloads.
