### PR TITLE
Remove jQuery from requests.js (bug 879504)

### DIFF
--- a/hearth/media/js/assert.js
+++ b/hearth/media/js/assert.js
@@ -82,7 +82,7 @@ define('assert', ['underscore'], function(_) {
         }
     );
     */
-    function mock(test_module, mock_objs, runner) {
+    function mock(test_module, mock_objs, runner, failfunc) {
         var stub_map = {};
         var stubbed = _.object(_.pairs(mock_objs).map(function(x) {
             var orig = x[0];
@@ -102,7 +102,6 @@ define('assert', ['underscore'], function(_) {
             return x;
         }));
 
-        console.log(stub_map);
         var context = require.config({
             context: _.uniqueId(),
             map: {'*': stub_map},
@@ -116,7 +115,13 @@ define('assert', ['underscore'], function(_) {
         });
 
         context([test_module], function(module) {
-            runner.apply(this, [module, mock_objs]);
+            try {
+                runner.apply(this, [module, mock_objs]);
+            } catch (e) {
+                if (failfunc) {
+                    failfunc(e);
+                }
+            }
         });
     }
 

--- a/hearth/media/js/defer.js
+++ b/hearth/media/js/defer.js
@@ -1,0 +1,3 @@
+define('defer', ['jquery'], function($) {
+	return {Deferred: $.Deferred};
+});

--- a/hearth/media/js/views/tests.js
+++ b/hearth/media/js/views/tests.js
@@ -44,7 +44,7 @@ define('views/tests', ['assert'], function() {
         };
         builder.start('tests.html');
 
-        builder.z('type', 'leaf');
+        builder.z('type', 'debug');
         builder.z('title', 'Unit Tests');
     };
 });


### PR DESCRIPTION
This removes jQuery from requests.js by externalizing Deferreds to the
new 'defer' module and converting use of `$.ajax` to a function which
uses XmlHttpRequest directly.

The long-term benefits of this include the ability to release libraries
which are independent of jQuery and jQuery-compatibility-related issues
as well as to allow us to migrate to jQuery 2.0.1 and eventually
(potentially) Zepto.
