### PR TITLE
Add extra slash to the search URL to be compatible with zamboni URLs (bug 872954)

### DIFF
--- a/hearth/media/js/routes.js
+++ b/hearth/media/js/routes.js
@@ -13,6 +13,7 @@ var routes = [
     {pattern: '^/app/([^/<>"\']+)$', view_name: 'app'},
     {pattern: '^/app/([^/<>"\']+)/$', view_name: 'app'},  // For the trailing slash
     {pattern: '^/search$', view_name: 'search'},
+    {pattern: '^/search/$', view_name: 'search'},  // For the trailing slash
     {pattern: '^/category/([^/<>"\']+)$', view_name: 'category'},
     {pattern: '^/category/([^/<>"\']+)/featured$', view_name: 'featured'},
     {pattern: '^/settings$', view_name: 'settings'},


### PR DESCRIPTION
This is needed to fix https://bugzilla.mozilla.org/show_bug.cgi?id=872954#c6

Note that we also need to change the nginx config on -dev and production to let that URL be handled by fireplace instead of zamboni. It already works with the newest recommended config from README.rst.
