### PR TITLE
Fix outline footer logo (bug 869390)

### DIFF
--- a/hearth/media/css/site.styl
+++ b/hearth/media/css/site.styl
@@ -338,19 +338,15 @@ body {
     }
 
     #footzilla {
-        background: url(../img/logos/footzilla.png) 0 5px no-repeat;
+        background: url(../img/logos/footzilla.png) 0 3px no-repeat;
         float: left;
-        hidetext();
         width: 100px;
         a {
             display: block;
+            height: 26px;
+            hidetext();
+            width: 80px;
         }
-    }
-
-    #footzilla,
-    #footzilla a {
-        height: 26px;
-        width: 100px;
     }
 
     #footer {


### PR DESCRIPTION
Move the indent to the link and tweak the sizing so the outline is around the logo and the logo is more vertically center.
