### PR TITLE
Update to future trusted-ui close msg (bug 879579)

### DIFF
--- a/hearth/media/js/payments/payments.js
+++ b/hearth/media/js/payments/payments.js
@@ -76,8 +76,13 @@ define('payments/payments',
                     var msg;
                     console.error('`navigator.mozPay` error:', this.error.name);
                     switch (this.error.name) {
+                        // Sent from webpay.
                         case 'cancelled':
+                        // TODO: The following only works for en locale, remove this once
+                        // DIALOG_CLOSED_BY_USER is sent by the device (Bug 879579).
                         case 'Dialog closed by the user':
+                        // Sent from the trusted-ui on cancellation.
+                        case 'DIALOG_CLOSED_BY_USER':
                             msg = gettext('Payment cancelled');
                             break;
                         default:


### PR DESCRIPTION
Add the future key sent from the trusted ui so we can display our own cancellation messages.

Currently on non-en locales this will still fall-through to the payment-failed message.

r? @kumar303
