### PR TITLE
Make explicit event handlers delegated

### DIFF
--- a/hearth/media/js/buttons.js
+++ b/hearth/media/js/buttons.js
@@ -51,13 +51,18 @@ define('buttons',
         );
 
         // Reset button if it's been 30 seconds without user action.
-        setTimeout(function() {
+        $button[0].timeout = setTimeout(function() {
             if ($button.hasClass('installing')) {
                 revertButton($button);
             }
         }, 30000);
     }).on('app_install_success', function(e, installer, product, installedNow) {
         var $button = getButton(product);
+
+        if ($button[0].timeout) {
+            clearTimeout($button[0].timeout);
+        }
+
         if (installedNow) {
             var $installed = $('#installed'),
                 $how = $installed.find('.' + browser);

--- a/hearth/media/js/header.js
+++ b/hearth/media/js/header.js
@@ -1,11 +1,4 @@
 define('header', ['capabilities', 'z'], function(capabilities, z) {
-    var htim;
-    z.body.on('mousedown', '.wordmark', function() {
-        htim = setTimeout(function() {z.body.toggleClass('nightly');}, 5000);
-    }).on('mouseup', '.wordmark', function() {
-        clearTimeout(htim);
-    });
-
     // We would use :hover, but we want to hide the menu on fragment load!
     function act_tray() {
         $('.act-tray').on('mouseover', function() {

--- a/hearth/media/js/lightbox.js
+++ b/hearth/media/js/lightbox.js
@@ -148,7 +148,6 @@ define('lightbox',
             $lightbox.hide();
         }, 500);
         ghettoFresh();
-        z.win.off('keydown.lightboxDismiss');
         if (slider && slider.element) {
             slider.element.removeEventListener('fsmoveend', pauseVideos);
             slider.destroy();

--- a/hearth/media/js/outgoing_links.js
+++ b/hearth/media/js/outgoing_links.js
@@ -4,38 +4,37 @@ define('outgoing_links', ['capabilities', 'z'], function(capabilities, z) {
     // e.g. http://outgoing.mozilla.org/v1/b2d58f443178ce1de2ef80bb57dcc80211232c8b/http%3A//wvtc.net/
     // ...will display as http://wvtc.net/
     //
+
+    var outbound = 'a[href^="http://outgoing.mozilla.org"]';
+
     z.win.on('loaded', function() {
 
         // Hijack external links if we're within the app.
         if (capabilities.chromeless) {
-            $('a[rel=external]').attr('target', '_blank');
+            $('a[rel=external], ' + outbound).attr('target', '_blank');
         }
 
-        $('a[href^="http://outgoing.mozilla.org"]').each(function(e) {
-            var $a = $(this),
-                outgoing = $a.attr('href'),
+        $(outbound).each(function() {
+            var outgoing = this.getAttribute('href'),
                 dest = unescape(outgoing.split('/').slice(5).join('/'));
             // Change it to the real destination:
-            $a.attr('href', dest);
-            if (capabilities.chromeless) {
-                $a.attr('target', '_blank');
-            }
-            $a.on('click', function(e) {
-                // Change it to the outgoing URL:
-                $a.attr('href', outgoing);
-                setTimeout(function() {
-                    // Put back the real destination:
-                    $a.attr('href', dest);
-                }, 100);
-                return true;
-            });
+            this.setAttribute('data-orig-href', outgoing);
+            this.setAttribute('href', dest);
         });
     });
 
     // If we're inside the Marketplace app, open external links in the Browser.
-    z.doc.on('click', 'a.external, a[rel=external]', function() {
+    z.page.on('click', 'a.external, a[rel=external]', function() {
         if (capabilities.chromeless) {
             $(this).attr('target', '_blank');
         }
+    }).on('click', 'a[data-orig-href]', function() {
+        var href = this.getAttribute('href');
+        this.setAttribute('href', this.getAttribute('data-orig-href'));
+        setTimeout(function() {
+            // Put back the real destination:
+            this.setAttribute('href', href);
+        }, 100);
+        return true;
     });
 });

--- a/hearth/media/js/previews.js
+++ b/hearth/media/js/previews.js
@@ -10,6 +10,12 @@ define('previews',
 
     var slider_pool = [];
 
+    z.page.on('click', '.dot', function() {
+        console.log('Dot clicked, repositioning trays');
+        var $this = $(this);
+        $this.closest('.tray')[0].slider.moveToPoint($this.index());
+    });
+
     function populateTray() {
         // preview trays expect to immediately follow a .mkt-tile.
         var $tray = $(this);
@@ -50,6 +56,7 @@ define('previews',
             $tray.find('.content')[0],
             {distance: THUMB_PADDED}
         );
+        this.slider = slider;
         var $pointer = $tray.find('.dots .dot');
 
         slider.element.addEventListener('fsmoveend', setActiveDot, false);
@@ -64,11 +71,6 @@ define('previews',
             $pointer.eq(slider.currentPoint).addClass('current');
         }
         setActiveDot();
-
-        $tray.on('click.tray', '.dot', function() {
-            console.log('Dot clicked, repositioning trays');
-            slider.moveToPoint($(this).index());
-        });
 
         // Tray can fit 3 desktop thumbs before paging is required.
         if (numPreviews > 3 && caps.widescreen()) {
@@ -90,7 +92,6 @@ define('previews',
 
     // We're leaving the page, so destroy Flipsnap.
     z.win.on('unloading.tray', function() {
-        $('.tray').off('click.tray');
         for (var i = 0, e; e = slider_pool[i++];) {
             e.destroy();
         }

--- a/hearth/media/js/shothandles.js
+++ b/hearth/media/js/shothandles.js
@@ -1,9 +1,9 @@
-define('shothandles', ['utils'], function(utils) {
+define('shothandles', ['z'], function(z) {
     function attachHandles(slider, $container) {
         $container.find('.prev, .next').remove();
 
-        var $prevHandle = $('<a href="#" class="prev"></a>'),
-            $nextHandle = $('<a href="#" class="next"></a>');
+        var $prevHandle = $('<a href="#" class="shandle prev"></a>'),
+            $nextHandle = $('<a href="#" class="shandle next"></a>');
 
         function setHandleState() {
             $prevHandle.hide();
@@ -17,18 +17,22 @@ define('shothandles', ['utils'], function(utils) {
             }
         }
 
-        $prevHandle.on('click', utils._pd(function() {
-            slider.toPrev();
-        }));
-        $nextHandle.on('click', utils._pd(function() {
-            slider.toNext();
-        }));
-
         slider.element.addEventListener('fsmoveend', setHandleState);
 
         setHandleState();
+        $container[0].slider = slider;
         $container.append($prevHandle, $nextHandle);
     }
+
+    z.body.on('click', '.shandle', function(e) {
+        e.preventDefault();
+        var slider = this.parentNode.slider;
+        if (this.classList.contains('prev')) {
+            slider.toPrev();
+        } else {
+            slider.toNext();
+        }
+    });
 
     return {attachHandles: attachHandles};
 });


### PR DESCRIPTION
Some optimizations to help with event listener leakage. We're still leaking one or two, but this seems to clean up the vast majority of them. Memory usage now gets almost entirely freed on GC.

![screen shot 2013-06-12 at 5 30 42 pm](https://f.cloud.github.com/assets/279498/646220/8a217dcc-d3c0-11e2-8872-1f96ec716930.png)
- The very left is during Marketplace initialization (waiting for the XHRs to complete)
- The first jump is category rendering, which is why the document count quickly drops (the document fragment is merged into the DOM)
- The three steps up in red are the individual defer blocks being built. The corresponding tiny increase in green is the placeholders getting filled.
- The jumps in purple after the red goes up is my first navigation to another page
- At the very right is a sharp decrease. That's a forced garbage collection on my part (it would have happened naturally on its own). Notice that the event listeners dip to just above where they were when the page first rendered (42 at site load up to 44 after GC).
- The remaining two event listeners were for a Flipsnap on the previous page. We keep a reference around to the previous builder object (Bob J. Sr.), so that accounts for those not being cleaned up.

Notice that the site's memory footprint never climbs above 15mb.

cc @spasovski @muffinresearch 
