### PR TITLE
Allow keyboard to use cat drop-down (bug 890986)

### DIFF
--- a/hearth/media/css/cat-dropdown.styl
+++ b/hearth/media/css/cat-dropdown.styl
@@ -222,6 +222,7 @@ sprite-background-position($vertical-pos) {
                 // 10px + 17px + 10px = 37
                 padding-right: 37px;
             }
+            &:active:after,
             &.current:after {
                 background: url(../img/pretty/tick.svg) no-repeat;
                 background-size: 17px auto;
@@ -232,8 +233,8 @@ sprite-background-position($vertical-pos) {
                 right: 12px;
                 top: 15px;
                 width: 17px;
-
             }
+            &:active:after,
             &.current:hover:after,
             &.current:focus:after {
                 background-image: url(../img/pretty/tick-white.svg);


### PR DESCRIPTION
This branch re-instates the ability to use the cat dropdown with the keyboard whereas previously it closed as soon as you tab off the first link in the drop-down.

There was some duplication in the dropdown toggling so that's been factored out. I've removed what seem to be unnecessary event handlers though not knowing some of the background of why they were added I'm happy to re-visit some of that if there's a need to.

I've removed the mouse-down tick as the dropdown closes so fast it's not really worth doing that afaict.

I've also narrowed the escape key toggling to just the menu and dropdown it seems a bit odd to me that globally hitting escape toggles open and closed the dropdown without this patch.
