### PR TITLE
Payment cancelled should use a period (bug 899817)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,7 @@ $(COMPILED_TEMPLATES): $(TEMPLATES)
 	node damper.js --compile stylus --path $<
 
 l10n: clean fastcompile
-	cd locale ; \
-	./omg_new_l10n.sh
+	./locale/omg_new_l10n.sh
 
 langpacks:
 	mkdir -p hearth/locales

--- a/hearth/media/js/payments/payments.js
+++ b/hearth/media/js/payments/payments.js
@@ -88,7 +88,7 @@ define('payments/payments',
                         case 'cancelled':
                         // Sent from the trusted-ui on cancellation.
                         case 'DIALOG_CLOSED_BY_USER':
-                            msg = gettext('Payment cancelled');
+                            msg = gettext('Payment cancelled.');
                             break;
                         default:
                             msg = gettext('Payment failed. Try again later.');

--- a/locale/bg/LC_MESSAGES/messages.po
+++ b/locale/bg/LC_MESSAGES/messages.po
@@ -522,8 +522,8 @@ msgid "Category"
 msgstr "Категория"
 
 #: hearth/media/js/install.js:34 hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
-msgstr "Плащането отказано"
+msgid "Payment cancelled."
+msgstr "Плащането отказано."
 
 #: hearth/media/js/install.js:141
 msgid "Install failed. Please try again later."

--- a/locale/ca/LC_MESSAGES/messages.po
+++ b/locale/ca/LC_MESSAGES/messages.po
@@ -527,8 +527,8 @@ msgid "Category"
 msgstr "Categoria"
 
 #: hearth/media/js/install.js:34 hearth/media/js/payments/payments.js:86
-msgid "Payment cancelled"
-msgstr "S'ha cancel·lat el pagament"
+msgid "Payment cancelled."
+msgstr "S'ha cancel·lat el pagament."
 
 #. The app's installation has failed.
 #: hearth/media/js/install.js:142

--- a/locale/cs/LC_MESSAGES/messages.po
+++ b/locale/cs/LC_MESSAGES/messages.po
@@ -525,8 +525,8 @@ msgid "Category"
 msgstr "Kategorie"
 
 #: hearth/media/js/install.js:34 hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
-msgstr "Platba byla zrušena"
+msgid "Payment cancelled."
+msgstr "Platba byla zrušena."
 
 #: hearth/media/js/install.js:141
 msgid "Install failed. Please try again later."

--- a/locale/dbg/LC_MESSAGES/messages.po
+++ b/locale/dbg/LC_MESSAGES/messages.po
@@ -543,8 +543,8 @@ msgstr "Ƈȧŧḗɠǿřẏ"
 
 #: hearth/media/js/install.js:34
 #: hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
-msgstr "Ƥȧẏḿḗƞŧ ƈȧƞƈḗŀŀḗḓ"
+msgid "Payment cancelled."
+msgstr "Ƥȧẏḿḗƞŧ ƈȧƞƈḗŀŀḗḓ."
 
 #: hearth/media/js/install.js:141
 msgid "Install failed. Please try again later."

--- a/locale/de/LC_MESSAGES/messages.po
+++ b/locale/de/LC_MESSAGES/messages.po
@@ -535,8 +535,8 @@ msgstr "Kategorie"
 
 #: hearth/media/js/install.js:34
 #: hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
-msgstr "Zahlung abgebrochen"
+msgid "Payment cancelled."
+msgstr "Zahlung abgebrochen."
 
 #: hearth/media/js/install.js:141
 msgid "Install failed. Please try again later."

--- a/locale/el/LC_MESSAGES/messages.po
+++ b/locale/el/LC_MESSAGES/messages.po
@@ -481,8 +481,8 @@ msgid "Category"
 msgstr "Κατηγορία"
 
 #: hearth/media/js/install.js:34 hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
-msgstr "Ακυρώθηκε η πληρωμή"
+msgid "Payment cancelled."
+msgstr "Ακυρώθηκε η πληρωμή."
 
 #: hearth/media/js/install.js:141
 msgid "Install failed. Please try again later."

--- a/locale/en_US/LC_MESSAGES/messages.po
+++ b/locale/en_US/LC_MESSAGES/messages.po
@@ -483,8 +483,8 @@ msgid "Category"
 msgstr "Category"
 
 #: hearth/media/js/install.js:34 hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
-msgstr "Payment cancelled"
+msgid "Payment cancelled."
+msgstr "Payment cancelled."
 
 #: hearth/media/js/install.js:141
 msgid "Install failed. Please try again later."

--- a/locale/es/LC_MESSAGES/messages.po
+++ b/locale/es/LC_MESSAGES/messages.po
@@ -481,8 +481,8 @@ msgid "Category"
 msgstr "Categoría"
 
 #: hearth/media/js/install.js:34 hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
-msgstr "Pago cancelado"
+msgid "Payment cancelled."
+msgstr "Pago cancelado."
 
 #: hearth/media/js/install.js:141
 msgid "Install failed. Please try again later."

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -527,8 +527,8 @@ msgid "Category"
 msgstr "Catégorie"
 
 #: hearth/media/js/install.js:34 hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
-msgstr "Paiement annulé"
+msgid "Payment cancelled."
+msgstr "Paiement annulé."
 
 #: hearth/media/js/install.js:141
 msgid "Install failed. Please try again later."

--- a/locale/ga_IE/LC_MESSAGES/messages.po
+++ b/locale/ga_IE/LC_MESSAGES/messages.po
@@ -529,8 +529,8 @@ msgid "Category"
 msgstr "Catagóir"
 
 #: hearth/media/js/install.js:34 hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
-msgstr "Cealaíodh an íocaíocht"
+msgid "Payment cancelled."
+msgstr "Cealaíodh an íocaíocht."
 
 #: hearth/media/js/install.js:141
 msgid "Install failed. Please try again later."

--- a/locale/hr/LC_MESSAGES/messages.po
+++ b/locale/hr/LC_MESSAGES/messages.po
@@ -536,8 +536,8 @@ msgstr "Kategorija"
 
 #: hearth/media/js/install.js:34
 #: hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
-msgstr "Plaćanje otkazano"
+msgid "Payment cancelled."
+msgstr "Plaćanje otkazano."
 
 #: hearth/media/js/install.js:141
 msgid "Install failed. Please try again later."

--- a/locale/hu/LC_MESSAGES/messages.po
+++ b/locale/hu/LC_MESSAGES/messages.po
@@ -497,8 +497,8 @@ msgid "Category"
 msgstr "Kategória"
 
 #: hearth/media/js/install.js:34 hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
-msgstr "Fizetés törölve"
+msgid "Payment cancelled."
+msgstr "Fizetés törölve."
 
 #: hearth/media/js/install.js:141
 msgid "Install failed. Please try again later."

--- a/locale/it/LC_MESSAGES/messages.po
+++ b/locale/it/LC_MESSAGES/messages.po
@@ -524,8 +524,8 @@ msgid "Category"
 msgstr "Categoria"
 
 #: hearth/media/js/install.js:34 hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
-msgstr "Pagamento annullato"
+msgid "Payment cancelled."
+msgstr "Pagamento annullato."
 
 #: hearth/media/js/install.js:141
 msgid "Install failed. Please try again later."

--- a/locale/ja/LC_MESSAGES/messages.po
+++ b/locale/ja/LC_MESSAGES/messages.po
@@ -483,7 +483,7 @@ msgid "Category"
 msgstr "カテゴリ"
 
 #: hearth/media/js/install.js:34 hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
+msgid "Payment cancelled."
 msgstr "支払いがキャンセルされました"
 
 #: hearth/media/js/install.js:141

--- a/locale/mk/LC_MESSAGES/messages.po
+++ b/locale/mk/LC_MESSAGES/messages.po
@@ -481,7 +481,7 @@ msgid "Category"
 msgstr ""
 
 #: hearth/media/js/install.js:34 hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
+msgid "Payment cancelled."
 msgstr ""
 
 #: hearth/media/js/install.js:141

--- a/locale/my/LC_MESSAGES/messages.po
+++ b/locale/my/LC_MESSAGES/messages.po
@@ -481,7 +481,7 @@ msgid "Category"
 msgstr ""
 
 #: hearth/media/js/install.js:34 hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
+msgid "Payment cancelled."
 msgstr ""
 
 #: hearth/media/js/install.js:141

--- a/locale/nl/LC_MESSAGES/messages.po
+++ b/locale/nl/LC_MESSAGES/messages.po
@@ -482,8 +482,8 @@ msgid "Category"
 msgstr "Categorie"
 
 #: hearth/media/js/install.js:34 hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
-msgstr "Betaling geannuleerd"
+msgid "Payment cancelled."
+msgstr "Betaling geannuleerd."
 
 #: hearth/media/js/install.js:141
 msgid "Install failed. Please try again later."

--- a/locale/pl/LC_MESSAGES/messages.po
+++ b/locale/pl/LC_MESSAGES/messages.po
@@ -499,8 +499,8 @@ msgid "Category"
 msgstr "Kategoria"
 
 #: hearth/media/js/install.js:34 hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
-msgstr "Anulowano płatność"
+msgid "Payment cancelled."
+msgstr "Anulowano płatność."
 
 #: hearth/media/js/install.js:141
 msgid "Install failed. Please try again later."

--- a/locale/pt_BR/LC_MESSAGES/messages.po
+++ b/locale/pt_BR/LC_MESSAGES/messages.po
@@ -525,8 +525,8 @@ msgid "Category"
 msgstr "Categoria"
 
 #: hearth/media/js/install.js:34 hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
-msgstr "Pagamento cancelado"
+msgid "Payment cancelled."
+msgstr "Pagamento cancelado."
 
 #: hearth/media/js/install.js:141
 msgid "Install failed. Please try again later."

--- a/locale/ro/LC_MESSAGES/messages.po
+++ b/locale/ro/LC_MESSAGES/messages.po
@@ -525,8 +525,8 @@ msgid "Category"
 msgstr "Categorie"
 
 #: hearth/media/js/install.js:34 hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
-msgstr "Plată anulată"
+msgid "Payment cancelled."
+msgstr "Plată anulată."
 
 #: hearth/media/js/install.js:141
 msgid "Install failed. Please try again later."

--- a/locale/ru/LC_MESSAGES/messages.po
+++ b/locale/ru/LC_MESSAGES/messages.po
@@ -537,8 +537,8 @@ msgstr "Категория"
 
 #: hearth/media/js/install.js:34
 #: hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
-msgstr "Платёж отменён"
+msgid "Payment cancelled."
+msgstr "Платёж отменён."
 
 #: hearth/media/js/install.js:141
 msgid "Install failed. Please try again later."

--- a/locale/sk/LC_MESSAGES/messages.po
+++ b/locale/sk/LC_MESSAGES/messages.po
@@ -525,8 +525,8 @@ msgid "Category"
 msgstr "Kategória"
 
 #: hearth/media/js/install.js:34 hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
-msgstr "Platba zrušená"
+msgid "Payment cancelled."
+msgstr "Platba zrušená."
 
 #: hearth/media/js/install.js:141
 msgid "Install failed. Please try again later."

--- a/locale/sq/LC_MESSAGES/messages.po
+++ b/locale/sq/LC_MESSAGES/messages.po
@@ -538,7 +538,7 @@ msgstr ""
 
 #: hearth/media/js/install.js:34
 #: hearth/media/js/payments/payments.js:86
-msgid "Payment cancelled"
+msgid "Payment cancelled."
 msgstr ""
 
 #. The app's installation has failed.

--- a/locale/sr/LC_MESSAGES/messages.po
+++ b/locale/sr/LC_MESSAGES/messages.po
@@ -481,7 +481,7 @@ msgid "Category"
 msgstr ""
 
 #: hearth/media/js/install.js:34 hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
+msgid "Payment cancelled."
 msgstr ""
 
 #: hearth/media/js/install.js:141

--- a/locale/sr_Latn/LC_MESSAGES/messages.po
+++ b/locale/sr_Latn/LC_MESSAGES/messages.po
@@ -481,7 +481,7 @@ msgid "Category"
 msgstr ""
 
 #: hearth/media/js/install.js:34 hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
+msgid "Payment cancelled."
 msgstr ""
 
 #: hearth/media/js/install.js:141

--- a/locale/th/LC_MESSAGES/messages.po
+++ b/locale/th/LC_MESSAGES/messages.po
@@ -481,7 +481,7 @@ msgid "Category"
 msgstr ""
 
 #: hearth/media/js/install.js:34 hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
+msgid "Payment cancelled."
 msgstr ""
 
 #: hearth/media/js/install.js:141

--- a/locale/tr/LC_MESSAGES/messages.po
+++ b/locale/tr/LC_MESSAGES/messages.po
@@ -523,8 +523,8 @@ msgid "Category"
 msgstr "Kategori"
 
 #: hearth/media/js/install.js:34 hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
-msgstr "Ödeme iptal edildi"
+msgid "Payment cancelled."
+msgstr "Ödeme iptal edildi."
 
 #: hearth/media/js/install.js:141
 msgid "Install failed. Please try again later."

--- a/locale/ur/LC_MESSAGES/messages.po
+++ b/locale/ur/LC_MESSAGES/messages.po
@@ -481,7 +481,7 @@ msgid "Category"
 msgstr ""
 
 #: hearth/media/js/install.js:34 hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
+msgid "Payment cancelled."
 msgstr ""
 
 #: hearth/media/js/install.js:141

--- a/locale/zh_CN/LC_MESSAGES/messages.po
+++ b/locale/zh_CN/LC_MESSAGES/messages.po
@@ -538,7 +538,7 @@ msgstr ""
 
 #: hearth/media/js/install.js:34
 #: hearth/media/js/payments/payments.js:86
-msgid "Payment cancelled"
+msgid "Payment cancelled."
 msgstr ""
 
 #. The app's installation has failed.

--- a/locale/zh_TW/LC_MESSAGES/messages.po
+++ b/locale/zh_TW/LC_MESSAGES/messages.po
@@ -481,7 +481,7 @@ msgid "Category"
 msgstr "分類"
 
 #: hearth/media/js/install.js:34 hearth/media/js/payments/payments.js:81
-msgid "Payment cancelled"
+msgid "Payment cancelled."
 msgstr ""
 
 #: hearth/media/js/install.js:141


### PR DESCRIPTION
@clouserw this fixes up the keys for the Payment cancelled message to be just on 'Payment cancelled.' rather than having both that and 'Payment cancelled' (Without the period) 

This will separately require running 'make l10n' separately (I fixed the Makefile it so it runs from the tree root)
