### PR TITLE
Fix ratings to not show 'for previous version xxx' when not needed (bug 901486)

### DIFF
--- a/hearth/templates/_macros/rating.html
+++ b/hearth/templates/_macros/rating.html
@@ -1,6 +1,6 @@
 {% include "_macros/stars.html" %}
 
-{% macro rating(this, detailpage=false) %}
+{% macro rating(this, detailpage=false, current_version=None) %}
 <li data-report-uri="{{ this.report_spam }}" data-rating="{{ this.rating }}"
     class="review{{ ' flagged' if this.is_flagged }} c"
     itemprop="review" itemscope itemtype="http://schema.org/Review">
@@ -9,8 +9,8 @@
     <span class="byline">
       {{ _('by {author}',
            author='<strong itemprop="author">' + escape(this.user.display_name) + '</strong>') }}
-      {% if this.version and not this.version.latest %}
-        {{ _('for previous version {version}', version=this.version.name) }}
+      {% if this.version and current_version and current_version != this.version.version %}
+        {{ _('for previous version {version}', version=this.version.version) }}
       {% endif %}
     </span>
     <div class="body" itemprop="reviewBody">

--- a/hearth/templates/detail/main.html
+++ b/hearth/templates/detail/main.html
@@ -103,7 +103,7 @@
       {% if this.meta.total_count %}
         <ul class="ratings-placeholder-inner">
           {% for rat in this.objects.slice(0, 2) %}
-            {{ rating(rat, detailpage=true) }}
+            {{ rating(rat, detailpage=true, current_version=this.info.current_version) }}
           {% endfor %}
         </ul>
         <div class="{{ 'split' if has_second_button else 'full' }}">

--- a/hearth/templates/ratings/main.html
+++ b/hearth/templates/ratings/main.html
@@ -23,7 +23,7 @@
     <div class="reviews reviews-listing">
       <ul class="ratings-placeholder-inner">
         {% for rat in this %}
-          {{ rating(rat) }}
+          {{ rating(rat, current_version=this.info.current_version) }}
         {% endfor %}
 
         {# Render the more button if there's another page of results #}


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=901486

This needs mozilla/zamboni#1048 to work 
