### PR TITLE
Do not display report link if already flagged (bug 874980)

### DIFF
--- a/hearth/templates/_macros/rating.html
+++ b/hearth/templates/_macros/rating.html
@@ -28,7 +28,7 @@
                  data-href="{{ this.resource_uri }}"
                  data-app="{{ slug }}">{{ _('Delete') }}</a></li>
         {% endif %}
-        {% if not this.is_author %}
+        {% if not this.is_author and not this.has_flagged %}
           <li><a class="flag post" data-action="report" href="#">{{ _('Report') }}</a></li>
         {% endif %}
       </ul>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=874980

`has_flagged` was added in zamboni in https://github.com/mozilla/zamboni/commit/1f16275292f55520f83ec5fcf2e786d2ce3fcf93
