### PR TITLE
add webactivities support to packaged app and handlers for e.me (bug 883402)

### DIFF
--- a/hearth/media/js/capabilities.js
+++ b/hearth/media/js/capabilities.js
@@ -19,7 +19,7 @@ define('capabilities', [], function() {
         'touch': !!(('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch),
         'performance': !!(window.performance || window.msPerformance || window.webkitPerformance || window.mozPerformance),
         'navPay': !!navigator.mozPay,
-        'webactivities': !!(window.setMessageHandler || window.mozSetMessageHandler),
+        'webactivities': !!(navigator.setMessageHandler || navigator.mozSetMessageHandler),
         'firefoxOS': navigator.mozApps && navigator.mozApps.installPackage &&
                      navigator.userAgent.indexOf('Android') === -1 &&
                      navigator.userAgent.indexOf('Mobile') !== -1,

--- a/hearth/media/js/settings.js
+++ b/hearth/media/js/settings.js
@@ -21,7 +21,7 @@ define('settings', ['l10n', 'settings_local', 'underscore'], function(l10n, sett
 
         // The list of query string parameters that are not stripped when
         // removing navigation loops.
-        param_whitelist: ['q', 'sort', 'cat'],
+        param_whitelist: ['q', 'sort', 'cat', 'src'],
 
         // The list of models and their primary key mapping. Used by caching.
         model_prototypes: {

--- a/hearth/media/js/views/search.js
+++ b/hearth/media/js/views/search.js
@@ -175,6 +175,9 @@ define('views/search',
             {params: _.extend({}, params)}
         ).done(function() {
             var results = builder.results['searchresults'];
+            if (params.manifest_url && results.objects.length === 1) {
+                z.page.trigger('divert', [urls.reverse('app', [results.objects[0].slug]) + '?src=' + params.src]);
+            }
             // When there are no results, tell GA (bug 890314)
             if (!results.objects.length) {
                 tracking.trackEvent(

--- a/hearth/media/js/webactivities.js
+++ b/hearth/media/js/webactivities.js
@@ -1,32 +1,66 @@
-define('webactivities',
-    ['capabilities', 'urls', 'z'],
-    function(capabilities, urls, z) {
+define('webactivities', ['capabilities', 'log', 'urls', 'z'], function(capabilities, log, urls, z) {
 
     if (!capabilities.webactivities) {
         return;
     }
 
-    // Load up an app
-    navigator.mozSetMessageHandler('marketplace-app', function(req) {
-        var slug = req.source.data.slug;
-        z.page.trigger('navigate', [urls.reverse('app', [slug])]);
+    var console = log('webactivities');
+
+    function handleActivity(name, data) {
+        // Usage:
+        //
+        // new MozActivity({name: 'marketplace-app', data: {manifest_url: 'http://littlealchemy.com/manifest.webapp'}});
+        // new MozActivity({name: 'marketplace-app', data: {slug: 'littlealchemy'}});
+
+        console.log('Handled "' + name + '" activity: ' + JSON.stringify(e.data));
+
+        switch (name) {
+            case 'marketplace-app':
+                // Load up an app detail page.
+                var slug = data.slug;
+                var manifest_url = data.manifest_url || data.manifest;
+                if (slug) {
+                    z.page.trigger('navigate', [urls.reverse('app', [slug]) + '?src=webactivities']);
+                } else if (manifest_url) {
+                    z.page.trigger('search', {q: ':manifest=' + manifest_url, src: 'webactivities'});
+                }
+                break;
+            case 'marketplace-app-rating':
+                // Load up the page to leave a rating for the app.
+                z.page.trigger('navigate', [urls.reverse('app/ratings/add', [data.slug])]);
+                break;
+            case 'marketplace-category':
+                // Load up a category page.
+                z.page.trigger('navigate', [urls.reverse('category', [data.slug])]);
+                break;
+            case 'marketplace-search':
+                // Load up a search.
+                z.page.trigger('search', {q: data.query});
+                break;
+        }
+    }
+
+    navigator.mozSetMessageHandler('activity', function(req) {
+        handleActivity(req.source.name, req.source.data);
     });
 
-    // Load up the page to leave a rating for the app.
-    navigator.mozSetMessageHandler('marketplace-app-rating', function(req) {
-        var slug = req.source.data.slug;
-        z.page.trigger('navigate', [urls.reverse('app/ratings/add', [slug])]);
-    });
+    window.addEventListener('message', function(e) {
+        console.log('Received post message from ' + e.origin + ': ' + e.data);
+        // Receive postMessage from the packaged app and do something with it.
+        if (e.data && e.data.name && e.data.data) {
+            handleActivity(e.data.name, e.data.data);
+        }
+    }, false);
 
-    // Load up a category page
-    navigator.mozSetMessageHandler('marketplace-category', function(req) {
-        var slug = req.source.data.slug;
-        z.page.trigger('navigate', [urls.reverse('category', [slug])]);
-    });
+    if (window.self !== window.top) {
+        // If the Marketplace is being iframed, tell the parent window
+        // (the packaged app) we've been successfully loaded.
+        //
+        // Let the target origin be '*' because only in Firefox OS v.1.1+ do
+        // we know for certain that the origin of the Marketplace packaged app
+        // will be 'app://marketplace.firefox.com'.
+        console.log('postMessaging to *: loaded');
+        window.top.postMessage('loaded', '*');
+    }
 
-    // Load up a search
-    navigator.mozSetMessageHandler('marketplace-search', function(req) {
-        var query = req.source.data.query;
-        z.page.trigger('search', {q: query});
-    });
 });

--- a/yulelog/manifest.webapp
+++ b/yulelog/manifest.webapp
@@ -32,6 +32,7 @@
     },
     "name": "Marketplace",
     "orientation": ["portrait-primary"],
+    "origin": "app://marketplace.firefox.com",
     "permissions": {
         "mobilenetwork": {"description": "To detect mobile carrier and regional information."}
     },


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=883402
# Usage:

``` javascript
// Look up app by its manifest URL.
new MozActivity({
    name: 'marketplace-app',
    data: {manifest_url: 'http://littlealchemy.com/manifest.webapp'}
});

// Look up app by its slug.
new MozActivity({
    name: 'marketplace-app',
    data: {slug: 'littlealchemy'}
});
```
