### PR TITLE
Make tracking query strings configurable (bug 918241)

### DIFF
--- a/hearth/media/js/settings.js
+++ b/hearth/media/js/settings.js
@@ -58,6 +58,7 @@ define('settings', ['l10n', 'settings_local', 'underscore'], function(l10n, sett
         ua_tracking_id: 'UA-36116321-11',
         tracking_section: 'Consumer',
         tracking_section_index: 3,
+        track_query_string: true,
 
         // A list of regions and their L10n mappings.
         REGION_CHOICES_SLUG: {

--- a/hearth/media/js/tracking.js
+++ b/hearth/media/js/tracking.js
@@ -2,6 +2,7 @@ define('tracking', ['log', 'settings', 'storage', 'underscore', 'z'], function(l
 
     var enabled = settings.tracking_enabled;
     var actions_enabled = settings.action_tracking_enabled;
+    var track_query_string = settings.track_query_string || true;
 
     var console = log('tracking');
 
@@ -89,7 +90,8 @@ define('tracking', ['log', 'settings', 'storage', 'underscore', 'z'], function(l
     }
 
     function get_url() {
-        return window.location.pathname + window.location.search;
+        var url = window.location.pathname;
+        return track_query_string ? url + window.location.search : url;
     }
 
     if (settings.ga_tracking_id) {


### PR DESCRIPTION
Make tracking of query strings optional which is needed for webpay.
