### PR TITLE
Display OSC detail like existing category collections (bug 927471)

### DIFF
--- a/hearth/media/js/views/collection.js
+++ b/hearth/media/js/views/collection.js
@@ -1,4 +1,4 @@
-define('views/collection', ['l10n', 'models', 'utils'], function(l10n, models, utils) {
+define('views/collection', ['l10n', 'models', 'utils', 'z'], function(l10n, models, utils, z) {
     'use strict';
 
     var gettext = l10n.gettext;
@@ -17,9 +17,15 @@ define('views/collection', ['l10n', 'models', 'utils'], function(l10n, models, u
             if (!data.apps) {
                 return;
             }
+            if (data['collection_type'] === 2) {
+                builder.z('show_cats', true);
+                builder.z('cat', data['slug']);
+                z.page.trigger('build_start');
+            }
             data.apps.map(app_model.cast);
         });
 
+        builder.z('show_cats', false);
         builder.z('type', 'leaf');
         builder.z('title', gettext('Loading...'));
         builder.z('pagetitle', gettext('Collection Details'));

--- a/hearth/templates/collection.html
+++ b/hearth/templates/collection.html
@@ -3,28 +3,44 @@
 
 {% set endpoint=api('collection', [slug]) %}
 
-<section class="main">
-  {% defer (url=endpoint, id='collection', as='collection', key=slug) %}
-    {{ collection_tile(this) }}
-  {% placeholder %}
-    <p class="spinner alt spaced"></p>
-  {% except %}
-    <div class="detailed-error">
-      <h2>{{ _('Oh no!') }}</h2>
-      <p>{{ _('We could not load that collection. Please try again later.') }}</p>
-    </div>
-  {% end %}
-  {% defer (url=endpoint, id='apps', pluck='apps', as='app') %}
-    <ol class="container listing only-logged-in c">
-      {% for result in this %}
-        <li class="item result app c">
-          {{ market_tile(result, link=true, src='collection') }}
-        </li>
-      {% endfor %}
-    </ol>
-  {% empty %}
-    {# L10n: Please do your best to capture the essence of Scooby Doo. #}
-    {{ _("Ruh roh! No apps here, Shaggy!") }}
-  {% except %}
-  {% end %}
-</section>
+{% defer (url=endpoint, id='collection', as='collection', key=slug) %}
+
+  {# One display for OSCs... #}
+  {% if this.collection_type == 2 %}
+    <section id="gallery" class="main category gallery full c">
+      <ol class="container listing grid-if-desktop search-listing c">
+        {% for result in this.apps %}
+          <li class="item result app c">
+            {{ market_tile(result, link=true, src='osc', tray=False) }}
+          </li>
+        {% endfor %}
+      </ol>
+    </section>
+
+  {# ...and one for all other collections. #}
+  {% else %}
+    <section class="main">
+      {{ collection_tile(this) }}
+      {% if this.apps %}
+        <ol class="container listing only-logged-in c">
+          {% for result in this.apps %}
+            <li class="item result app c">
+              {{ market_tile(result, link=true, src='collection') }}
+            </li>
+          {% endfor %}
+        </ol>
+      {% else %}
+        {# L10n: Please do your best to capture the essence of Scooby Doo. #}
+        {{ _("Ruh roh! No apps here, Shaggy!") }}
+      {% endif %}
+    </section>
+  {% endif %}
+
+{% placeholder %}
+  <p class="spinner alt spaced"></p>
+{% except %}
+  <div class="detailed-error">
+    <h2>{{ _('Oh no!') }}</h2>
+    <p>{{ _('We could not load that collection. Please try again later.') }}</p>
+  </div>
+{% end %}


### PR DESCRIPTION
Previous discussion: https://github.com/mozilla/fireplace/commit/ee884218e96e1c67deaf3756163c2c6b4a79c9bb

r? @mattbasta @cvan @spasovski
# Screenshots
## OSC

![osc-small](https://f.cloud.github.com/assets/23885/1346062/8690001a-369a-11e3-8ad4-bf27148bae88.png)
![osc-large](https://f.cloud.github.com/assets/23885/1346064/88d5290e-369a-11e3-875a-959d902a0029.png)
## Other collection

![reg-small](https://f.cloud.github.com/assets/23885/1346066/8ccbcca2-369a-11e3-8cca-7bc816e7ddf8.png)
![reg-large](https://f.cloud.github.com/assets/23885/1346068/8ed6544a-369a-11e3-8705-05f030af6cfb.png)
