### PR TITLE
Add incompatibility banner when user agent doesn't support navigator.mozApps (bug 878329)

### DIFF
--- a/hearth/index.html
+++ b/hearth/index.html
@@ -31,6 +31,7 @@
     <link rel="stylesheet" href="/media/css/feedback.styl.css">
     <link rel="stylesheet" href="/media/css/forms.styl.css">
     <link rel="stylesheet" href="/media/css/form-modal.styl.css">
+    <link rel="stylesheet" href="/media/css/incompatible.styl.css">
     <link rel="stylesheet" href="/media/css/lightbox.styl.css">
     <link rel="stylesheet" href="/media/css/menu.styl.css">
     <link rel="stylesheet" href="/media/css/modal.styl.css">
@@ -47,6 +48,7 @@
     <div id="splash-overlay"><div class="throbber"></div></div>
 
     <header id="site-header" class="header site-header"></header>
+    <aside id="incompatibility-banner"></aside>
 
     <div class="cloak"></div>
     <main>

--- a/hearth/media/css/incompatible.styl
+++ b/hearth/media/css/incompatible.styl
@@ -1,0 +1,72 @@
+@import 'lib';
+
+#incompatibility-banner {
+    background: $grey-gardens-gray;
+    color: $cement-gray;
+    display: none;
+    margin-top: 48px;
+    overflow: hidden;
+    position: relative;
+    &:before,
+    &:after {
+        content: "";
+        display: block;
+        glow(rgba(0,0,0,0.85), 3px);
+        height: 1px;
+        position: relative;
+        top: -1px;
+        width: 100%;
+    }
+    &:after {
+        bottom: -1px;
+        top: auto;
+    }
+    a {
+        display: table-cell;
+        &.close {
+            margin-top: -17px;
+            top: 50%;
+        }
+    }
+    p {
+        background: url(../img/logos/firefox-256.png) left / 102px 96px no-repeat;
+        margin: 0 auto;
+        max-width: $desktop-content;
+        min-height: 95px;
+        padding: 28px 60px 28px 110px;
+        position: relative;
+        text-align: left;
+    }
+}
+
+@media (min-width: 1024px) {
+    #incompatibility-banner {
+        margin-top: 0;
+    }
+}
+
+@media $narrower-than-desktop {
+    #incompatibility-banner {
+        p {
+            background-size: 85px 80px;
+            min-height: 80px;
+            padding: 20px 60px 20px 90px;
+        }
+    }
+}
+
+.show-incompatibility-banner {
+    #incompatibility-banner {
+        display: block;
+    }
+    main {
+        padding-top: 48px;
+    }
+}
+
+@media $narrower-than-desktop {
+    .show-incompatibility-banner main {
+        padding-top: 0;
+    }
+}
+

--- a/hearth/media/css/lib.styl
+++ b/hearth/media/css/lib.styl
@@ -356,6 +356,10 @@ fatten() {
     padding: 0 32px;
 }
 
+glow($glowColor, $glowSize) {
+    box-shadow: 0 0 $glowSize 0 $glowColor; 
+}
+
 alt-btn-hover-focus() {
     gradient-two-color(darken(#fff, 10%), darken($seavan-salt-white, 10%));
 }

--- a/hearth/media/js/marketplace.js
+++ b/hearth/media/js/marketplace.js
@@ -141,6 +141,15 @@ require.config({
             $('#site-footer').html(
                 nunjucks.env.getTemplate('footer.html').render(context));
 
+            if (!navigator.mozApps &&
+                !require('storage').getItem('hide_incompatibility_banner')) {
+                console.log('Adding incompatibility banner');
+                $('#incompatibility-banner').html(
+                    nunjucks.env.getTemplate(
+                        'incompatible.html').render(context));
+                z.body.toggleClass('show-incompatibility-banner');
+            }
+
             z.body.toggleClass('logged-in', require('user').logged_in());
             z.page.trigger('reloaded_chrome');
         }).trigger('reload_chrome');
@@ -154,6 +163,13 @@ require.config({
             e.preventDefault();
             console.log('← button pressed');
             require('navigation').back();
+        });
+
+        z.body.on('click', '#incompatibility-banner .close', function(e) {
+            e.preventDefault();
+            console.log('Hiding incompatibility banner');
+            z.body.toggleClass('show-incompatibility-banner');
+            require('storage').setItem('hide_incompatibility_banner', true);
         });
 
         window.addEventListener(

--- a/hearth/templates/incompatible.html
+++ b/hearth/templates/incompatible.html
@@ -1,0 +1,5 @@
+<p>
+  {{ _('You must use Firefox to install Firefox apps.') }}
+  <a href="http://www.mozilla.org/en-US/products/download.html?product=firefox" class="firefox-download">{{ _('Download.') }}</a>
+  <a href="#" class="close" title="{{ _('Close') }}">{{ _('Close') }}</a>
+</p>


### PR DESCRIPTION
r? @cvan @mattbasta
## Screenshots
### At 320px

![320](https://f.cloud.github.com/assets/23885/1424816/bd7e276a-4026-11e3-803a-a383f584d02d.png)
### At 709px

![709](https://f.cloud.github.com/assets/23885/1424818/bfe8c460-4026-11e3-9e8b-9a8f8c7f4447.png)
### At 1023px

![1023](https://f.cloud.github.com/assets/23885/1424819/c1c208fa-4026-11e3-9069-6e1dee96a99a.png)
### At 1280px

![1280](https://f.cloud.github.com/assets/23885/1424820/c40bb85e-4026-11e3-83f6-e16696bc09b0.png)
