### PR TITLE
fall back to generic content rating body (bug 932074)

### DIFF
--- a/hearth/templates/detail/main.html
+++ b/hearth/templates/detail/main.html
@@ -197,7 +197,12 @@
 {% end %}
 
 {% defer (url=endpoint, as='app', key=slug) %}
-  {% set ratings = this.content_ratings[user.get_setting('region')].values() %}
+  {% if this.content_ratings[user.get_setting('region')] %}
+    {% set ratings = this.content_ratings[user.get_setting('region')].values() %}
+  {% else %}
+    {# Try to fall back to generic ratings body if region has no rating. #}
+    {% set ratings = this.content_ratings['generic'].values() %}
+  {% endif %}
   {% if ratings.length %}
     <div class="content-ratings-wrapper main infobox c">
       <div>


### PR DESCRIPTION
Depends on https://github.com/mozilla/zamboni/pull/1308

Mocked at https://github.com/mozilla/flue/pull/6

Screenshot of falling back to generic region (I mocked the region to be 'lol'):

![screen shot 2013-10-28 at 6 13 03 pm](https://f.cloud.github.com/assets/674727/1425359/7a3db144-4037-11e3-9fea-06ae09239950.png)
