### PR TITLE
fix typography for listing headers (w/ content ratings)

### DIFF
--- a/hearth/media/css/detail.styl
+++ b/hearth/media/css/detail.styl
@@ -15,6 +15,7 @@
     border-radius: 10px;
     box-shadow: 0 1px 1px $cement-gray;
     margin: 10px;
+
     h3 {
         font-size: 15px;
         font-weight: 500;
@@ -26,6 +27,7 @@
     clear: both;
     color: $dark-gray;
     line-height: 22px;
+
     > div {
         padding: 24px 10px;
     }

--- a/hearth/media/css/listing.styl
+++ b/hearth/media/css/listing.styl
@@ -33,9 +33,11 @@ $triangle-size = 20px;
 // also used as standalone "card" on detail pages.
 
 .mkt-tile .rating {
+    clear: left;
     color: $sailor-blue;
     display: block;
     font-size: 12px;
+    padding: 8px 0;
     position: relative;
 
     a {
@@ -73,7 +75,7 @@ $triangle-size = 20px;
     .subdetail {
         color: $earl-gray;
         font-size: 12px;
-        line-height: 15px;
+        line-height: 18px;
         max-height: 28px;
 
         &.content-rating {
@@ -107,6 +109,7 @@ $triangle-size = 20px;
     overflow: hidden;
     padding: 21px 0 0;
     position: relative;
+
     &.single {
         // No dots so make it smaller. Leave 15px from bottom of screenshot to bottom of tray.
         height: 201px;
@@ -530,8 +533,11 @@ grid-style() {
 ratings-sidebar() {
     // These rules get applied on mobile detail page and desktop category listing pages.
     .rating {
+        bottom: 2px;
         clear: left;
-        padding: 8px 0 10px;
+        padding: 10px 0 10px;
+        position: relative;
+
         .cnt {
             display: inline-block;
             // To line up with app name.
@@ -543,13 +549,13 @@ ratings-sidebar() {
         }
     }
     h3 {
-        font-size: 30px;
+        font-size: 20px;
         font-weight: 300;
-        line-height: 30px;
+        line-height: 18px;
         max-width: 100%;
     }
     .subdetail {
-        font-size: 15px;
+        font-size: 12px;
         line-height: 18px;
     }
 }
@@ -659,10 +665,11 @@ ratings-sidebar() {
                     background-image: none;
                 }
                 h3 {
-                    font-size: 34px;
-                    line-height: 34px;
+                    font-size: 22px;
+                    line-height: 22px;
                 }
                 .subdetail {
+                    font-size: 13px;
                     line-height: 20px;
                 }
             }


### PR DESCRIPTION
- Squishing in the line for content ratings
- Line-height and font-size change for [detail page (mock)](https://bug929805.bugzilla.mozilla.org/attachment.cgi?id=822464) and [listing page (mock)](https://bug929805.bugzilla.mozilla.org/attachment.cgi?id=822461).
- basta-breaks

**Detail page mobile**
![screen shot 2013-11-14 at 3 36 55 pm](https://f.cloud.github.com/assets/674727/1546441/b58767f8-4d85-11e3-95de-f23cf3a47252.png)

**Detail page desktop**
![screen shot 2013-11-14 at 3 36 51 pm](https://f.cloud.github.com/assets/674727/1546442/b7818b10-4d85-11e3-9943-9c612d170d33.png)

**Listing page mobile**
![screen shot 2013-11-14 at 3 36 33 pm](https://f.cloud.github.com/assets/674727/1546439/aef4afea-4d85-11e3-9a69-78c06e174b63.png)

**Listing page desktop**
![screen shot 2013-11-14 at 3 36 42 pm](https://f.cloud.github.com/assets/674727/1546440/b35e4294-4d85-11e3-9f12-a9ad4afbebe1.png)
