### PR TITLE
fix desktop listing font-sizes (bug 931946)

### DIFF
--- a/hearth/media/css/listing.styl
+++ b/hearth/media/css/listing.styl
@@ -665,11 +665,11 @@ ratings-sidebar() {
                     background-image: none;
                 }
                 h3 {
-                    font-size: 22px;
-                    line-height: 22px;
+                    font-size: 26px;
+                    line-height: 26px;
                 }
                 .subdetail {
-                    font-size: 13px;
+                    font-size: 15px;
                     line-height: 20px;
                 }
             }


### PR DESCRIPTION
heading to 26px/26px
author/ratings to 15px/20px

![screen shot 2013-11-22 at 4 33 52 pm](https://f.cloud.github.com/assets/674727/1605387/9f0057f2-53d8-11e3-89f4-c1b6640657ba.png)
