### PR TITLE
remove description line from content ratings portion of detail page for CLASSIND (bug 945926)

### DIFF
--- a/hearth/templates/detail/main.html
+++ b/hearth/templates/detail/main.html
@@ -216,7 +216,10 @@
                 {{ content_rating.rating_label }}&plus;
               </span>
             </div>
-            <p class="description">{{ content_rating.rating }}</p>
+            {% if content_rating.body_label != 'classind' %}
+              {# CLASSIND doesn't want to show rating name. #}
+              <p class="description">{{ content_rating.rating }}</p>
+            {% endif %}
           </div>
         </div>
         {% if content_rating.body_label == 'pegi' and this.descriptors %}


### PR DESCRIPTION
Requested by CLASSIND/DEJUS through IARC.

_"If possible, CLASSIND/DEJUS would like to eliminate the rating title (as in “General Audience”)and just have the symbol and the descriptors displayed."_
### After

![screen shot 2013-12-03 at 2 03 32 pm](https://f.cloud.github.com/assets/674727/1668521/3a4af758-5c67-11e3-901b-7b725fc75ad3.png)
### Before

![screen shot 2013-12-03 at 2 03 45 pm](https://f.cloud.github.com/assets/674727/1668522/3cf41e12-5c67-11e3-85a2-5b82fab17b59.png)
