### PR TITLE
Show app release notes if they are available (bug 945852)

### DIFF
--- a/hearth/media/css/detail.styl
+++ b/hearth/media/css/detail.styl
@@ -31,17 +31,6 @@
     > div {
         padding: 24px 10px;
     }
-    .description:only-child {
-        padding-bottom: 0;
-    }
-    .description + div > {
-        h3:first-child {
-            padding-top: 0;
-        }
-        :last-child {
-            padding-bottom: 0;
-        }
-    }
     blockquote {
         background: $faint-gray;
         border-left: 2px solid $light-gray;
@@ -49,7 +38,7 @@
         margin: 0;
         padding: 5px 10px;
     }
-    .description-wrapper {
+    .truncated-wrapper {
         padding: 0;
 
         &.truncated {
@@ -72,11 +61,19 @@
     }
 }
 
+section.releasenotes {
+    border-bottom: 1px solid $cloud-gray;
+
+    .truncated-wrapper.truncated {
+        max-height: 7.5em;
+    }
+}
+
 .show-toggle {
     display: block;
-    float: right;
     font-weight: bold;
     padding: 10px;
+    text-align: right;
     text-transform: lowercase;
     &:before {
         content: "(";
@@ -402,13 +399,13 @@
         p.description {
             padding-top: 0;
         }
-        &.truncated {
-            max-height: none;
-            overflow: visible;
+    }
+    section.blurbs .truncated-wrapper.truncated {
+        max-height: none;
+        overflow: visible;
 
-            &:after {
-                content: none;
-            }
+        &:after {
+            content: none;
         }
     }
     .show-toggle {

--- a/hearth/media/js/views/app.js
+++ b/hearth/media/js/views/app.js
@@ -16,7 +16,7 @@ define('views/app',
         $this.attr('data-toggle-text', $this.text());
         $this.text(newTxt);
         // Toggle description.
-        $this.closest('.blurbs').find('.description-wrapper').toggleClass('truncated');
+        $this.prev('.truncated-wrapper').toggleClass('truncated');
 
         tracking.trackEvent('App view interactions', 'click', 'Toggle description');
 
@@ -73,11 +73,12 @@ define('views/app',
 
             // 'truncated' class is applied by default, remove it if it's not
             // needed.
-            var wrapper = $('.description-wrapper');
-            if (wrapper.prop('scrollHeight') <= wrapper.prop('offsetHeight')) {
-                wrapper.removeClass('truncated');
-                wrapper.next('.show-toggle').hide();
-            }
+            $('.truncated-wrapper').each(function() {
+                var $this = $(this);
+                if ($this.prop('scrollHeight') <= $this.prop('offsetHeight')) {
+                    $this.removeClass('truncated').next('.show-toggle').hide();
+                }
+            });
             if (caps.widescreen() && !$('.report-abuse').length) {
                 z.page.append(
                     require('templates').env.render('detail/abuse.html', {slug: slug})

--- a/hearth/templates/detail/main.html
+++ b/hearth/templates/detail/main.html
@@ -55,10 +55,29 @@
 </section>
 <div id="purchased-message"></div>
 
+{% defer (url=endpoint, as='app', key=slug) %}
+  {% if this.release_notes %}
+    <section class="main blurbs prose infobox releasenotes">
+      <div>
+        <h3>{{ _('Updates') }}</h3>
+        <div class="truncated-wrapper truncated">
+          <p class="releasenotes">
+            {{ this.release_notes|translate(this)|nl2br }}
+          </p>
+        </div>
+        <a href="#" class="show-toggle" data-toggle-text="{{ _('Less&hellip;') }}">{{ _('More&hellip;') }}</a>
+      </div>
+    </section>
+  {% endif %}
+{# No placeholder, the block below already supplies one #}
+{% except %}
+{% end %}
+
 <section class="main blurbs prose infobox">
   <div>
     {% defer (url=endpoint, as='app', key=slug) %}
-      <div class="description-wrapper truncated">
+      <h3>{{ _('Description') }}</h3>
+      <div class="truncated-wrapper description-wrapper truncated">
         <p class="description" itemprop="description">
           {{ this.description|translate(this)|nl2br }}
         </p>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=945852

See also https://bugzilla.mozilla.org/show_bug.cgi?id=945858 for the zamboni side of things, where we let developers add release notes for hosted apps as well.

**Screenshots:**
Mobile view, no updates to show
![screen shot 2013-12-04 at 18 57 16](https://f.cloud.github.com/assets/187006/1675663/c213716e-5d0d-11e3-9fb0-6ee6bd22f361.png)

Mobile view, both description and updates truncated
![screen shot 2013-12-04 at 18 54 22](https://f.cloud.github.com/assets/187006/1675662/c212fb30-5d0d-11e3-9ba2-cf561294b411.png)

Mobile view, description truncated, updates fully shown
![screen shot 2013-12-04 at 18 54 33](https://f.cloud.github.com/assets/187006/1675659/c20ee9a0-5d0d-11e3-8aa0-0e08cadc8eb8.png)

Desktop view, both description and updates shown
![screen shot 2013-12-04 at 18 55 27](https://f.cloud.github.com/assets/187006/1675660/c210e232-5d0d-11e3-8bf9-b0734eeb85c9.png)

Desktop view, no updates to show
![screen shot 2013-12-04 at 18 57 06](https://f.cloud.github.com/assets/187006/1675661/c211dc96-5d0d-11e3-8fc0-b39cb1359f7c.png)
