### PR TITLE
shift down install btn on mobile listing

### DIFF
--- a/hearth/media/css/detail.styl
+++ b/hearth/media/css/detail.styl
@@ -21,6 +21,9 @@
         font-weight: 500;
         line-height: 18px;
     }
+    .install {
+        bottom: 15px;
+    }
 }
 
 .blurbs {

--- a/hearth/media/css/listing.styl
+++ b/hearth/media/css/listing.styl
@@ -594,7 +594,7 @@ ratings-sidebar() {
         }
     }
     .install {
-        bottom: 15px;
+        bottom: 10px;
         position: absolute;
         right: 10px;
     }


### PR DESCRIPTION
Install button a bit too close when the content ratings line is at its longest on mobile.
### After

![screen shot 2013-12-06 at 4 25 27 pm](https://f.cloud.github.com/assets/674727/1697223/96f76a9c-5ed6-11e3-812a-f1427e9b5e5c.png)
### Before

![screen shot 2013-12-06 at 4 26 18 pm](https://f.cloud.github.com/assets/674727/1697224/99204d2a-5ed6-11e3-8c73-9cb99e1b83a8.png)
