### PR TITLE
implement 'view all' link on a new line (bug 929722)

### DIFF
--- a/hearth/media/css/listing.styl
+++ b/hearth/media/css/listing.styl
@@ -222,16 +222,30 @@ $dot-size = 13px;
     font-size: 15px;
     line-height: 16px;
     .view-all {
-        display: block;
-        float: right;
+        display: none;
+    }
+    .view-all-mbl {
+        border-bottom: 1px solid $link;
+        display: inline-block;
+        font-size: 14px;
         font-weight: 300;
-        // Bigger click area.
-        margin: -10px -6px -3px;
-        padding: 10px 6px 6px;
-        position: relative;
-        z-index: 1;
+        margin: 0 auto 10px 50%;
+        padding: 2px 25px;
+        text-align: center;
+        transform: translate(-50%, 0);
+        &:before, &:after {
+            border-left: 1px solid $link;
+            bottom: 0;
+            content: "";
+            height: 5px;
+            position: absolute;
+            width: 0;
+        }
+        &:before {
+            left: 0;
+        }
         &:after {
-            content: " \00BB";
+            right: 0;
         }
     }
 }
@@ -384,6 +398,22 @@ grid-style() {
 
     .category {
         border-radius: 10px;
+        .view-all-mbl {
+            display: none;
+        }
+        .view-all {
+            display: block;
+            float: right;
+            font-weight: 300;
+            // Bigger click area.
+            margin: -10px -6px -3px;
+            padding: 10px 6px 6px;
+            position: relative;
+            z-index: 1;
+            &:after {
+                content: " \00BB";
+            }
+        }
     }
 
     .featured {

--- a/hearth/templates/category/main.html
+++ b/hearth/templates/category/main.html
@@ -43,6 +43,7 @@
           <li>{{ market_tile(app_cast(result), link=true, src='featured', tray=False) }}</li>
         {% endfor %}
       </ol>
+      <a href="{{ featured_url }}" class="view-all-mbl">{{ _('View All') }}</a>
     </section>
   {% endif %}
 {% placeholder %}


### PR DESCRIPTION
Same as before on desktop. The pic below on mobile.

![screen shot 2013-12-09 at 3 45 23 pm](https://f.cloud.github.com/assets/391260/1708727/88e09e80-6113-11e3-8572-340d6260d6fe.png)
