### PR TITLE
show interactive as text for non-ESRB, no show interactive for CLASSIND (bug 949261)

### DIFF
--- a/hearth/media/css/detail.styl
+++ b/hearth/media/css/detail.styl
@@ -146,11 +146,18 @@ section.releasenotes {
     }
 }
 
-.content-descriptors-text {
+.content-descriptors.text {
     float: left;
 }
+.interactive-elements.text {
+    float: left;
+    left: 10px;
+    padding-left: 10px;
+}
 
-.content-descriptors-text li, span.description {
+.content-descriptors.text li,
+span.description,
+.interactive-elements.text p {
     clear: left;
     color: $earl-gray;
     display: inline-block;
@@ -159,14 +166,14 @@ section.releasenotes {
     font-weight: 400;
     margin: 0;
 }
-.content-descriptors-icons {
+.content-descriptors.icons {
     max-width: 65%;
 }
 .interactive-elements {
     max-width: 45%;
 }
 
-.content-descriptors-icons, .interactive-elements {
+.content-descriptors.icons, .interactive-elements {
     border-left: 1px solid $faint-gray;
     float: right;
     left: 12px;
@@ -324,13 +331,17 @@ section.releasenotes {
         .content-rating .icon {
             margin-right: 15px;
         }
-        .interactive-elements, .content-descriptors {
+        .interactive-elements.text {
+            left: 15px;
+            padding-left: 15px;
+        }
+        .interactive-elements.icons, .content-descriptors {
             left: 5px;
         }
-        .content-descriptors-icons {
+        .content-descriptors.icons {
             left: 27px;
         }
-        .interactive-elements, .content-descriptors-icons {
+        .interactive-elements, .content-descriptors.icons {
             padding-left: 20px;
 
             .icon {
@@ -340,7 +351,9 @@ section.releasenotes {
         .description {
             clear: none;
         }
-        ul.content-descriptors-text li, .description {
+        ul.content-descriptors.text li,
+        span.description,
+        .interactive-elements.text p {
             font-size: 15px;
         }
     }

--- a/hearth/media/js/settings.js
+++ b/hearth/media/js/settings.js
@@ -165,9 +165,14 @@ define('settings', ['l10n', 'settings_local', 'underscore'], function(l10n, sett
                 }
             },
             interactive_elements: {
-                'shares-info': '/media/img/icons/ratings/interactives/ESRB_shares-info.png',
-                'shares-location': '/media/img/icons/ratings/interactives/ESRB_shares-location.png',
-                'users-interact': '/media/img/icons/ratings/interactives/ESRB_users-interact.png',
+                // Only show the ESRB-branded interactive Elements icons for ESRB.
+                'esrb': {
+                    'shares-info': '/media/img/icons/ratings/interactives/ESRB_shares-info.png',
+                    'shares-location': '/media/img/icons/ratings/interactives/ESRB_shares-location.png',
+                    'users-interact': '/media/img/icons/ratings/interactives/ESRB_users-interact.png',
+                },
+                // CLASSIND doesn't want to show Interactive Elements as part of their rating.
+                'classind': {},
             }
         },
 

--- a/hearth/templates/detail/main.html
+++ b/hearth/templates/detail/main.html
@@ -239,7 +239,7 @@
             {# Content descriptors as a list of text.
                Only shown if there are not any descriptor icons (i.e. non-PEGI bodies). #}
             {% if not settings.iarc_icons.descriptors[rating_body] %}
-              <ul class="content-descriptors-text">
+              <ul class="content-descriptors text">
                 {% for descriptor in this.descriptors[rating_body] %}
                   {# Don't show "No Descriptors". #}
                   {% if descriptor.label != 'no-descs' %}
@@ -258,7 +258,7 @@
         {% if desc_icons %}
           {# Content descriptors as a grid of icons.
              Only shown if there are descriptor icons (i.e. PEGI-only). #}
-          <div class="content-descriptors-icons">
+          <div class="content-descriptors icons">
             {% for descriptor in this.descriptors[rating_body] %}
               {% set icon_src = desc_icons[descriptor.label] %}
               {% if icon_src %}
@@ -268,14 +268,18 @@
           </div>
 
         {% elif this.interactive_elements %}
-         {# Interactive elements as a row of icons.
-            Only shown if there are no descriptor icons (i.e. non-PEGI bodies). #}
-         {% set interactive_icons = settings.iarc_icons.interactive_elements %}
-          <div class="interactive-elements">
+         {% set interactive_icons = settings.iarc_icons.interactive_elements[rating_body] %}
+          <div class="interactive-elements {{ 'icons' if interactive_icons else 'text' }}">
             {% for interactive in this.interactive_elements %}
-              {% set icon_src = interactive_icons[interactive.label] %}
-              {% if icon_src %}
-                <img src="{{ icon_src }}" class="icon" title="{{ interactive.name }}">
+              {% if interactive_icons %}
+                {# Interactive elements as a row of icons (ESRB only). #}
+                {% set icon_src = interactive_icons[interactive.label] %}
+                {% if icon_src %}
+                  <img src="{{ icon_src }}" class="icon" title="{{ interactive.name }}">
+                {% endif %}
+              {% else %}
+                {# Interactive elements as a column of text (non-PEGI/ESRB bodies). #}
+                <p>{{ interactive.name }}</p>
               {% endif %}
             {% endfor %}
           </div>


### PR DESCRIPTION
When showing text, floating it left so there's not a giant space in the middle:

![screen shot 2013-12-12 at 12 10 16 pm](https://f.cloud.github.com/assets/674727/1736862/878ae72c-6369-11e3-9be3-66130f1bcfbe.png)

![screen shot 2013-12-12 at 12 10 21 pm](https://f.cloud.github.com/assets/674727/1736860/8379fc54-6369-11e3-879c-73993cb61782.png)

Don't show anything for CLASSIND:

![screen shot 2013-12-12 at 11 59 18 am](https://f.cloud.github.com/assets/674727/1736808/b88eaf30-6368-11e3-9dd7-bf88f710f468.png)

ESRB stays the same:

![screen shot 2013-12-12 at 12 05 34 pm](https://f.cloud.github.com/assets/674727/1736813/c82561c8-6368-11e3-94c7-4bfec96474a1.png)
