### PR TITLE
banner_message is a PurifiedField, it's already safe (bug 951027)

### DIFF
--- a/hearth/media/js/utils.js
+++ b/hearth/media/js/utils.js
@@ -135,6 +135,9 @@ define('utils', ['jquery', 'l10n', 'underscore'], function($, l10n, _) {
     }
 
     function translate(data, default_language, lang) {
+        if (!data) {
+            return '';
+        }
         if (typeof data === 'string') {
             return data;
         }

--- a/hearth/templates/detail/main.html
+++ b/hearth/templates/detail/main.html
@@ -58,7 +58,7 @@
 {% defer (url=endpoint, as='app', key=slug) %}
   {% if this.banner_regions and this.banner_message and this.banner_regions.indexOf(user_helpers.region()) != -1 %}
     <section class="main infobox regionbanner">
-      <div> {{ this.banner_message|translate(this) }} </div>
+      <div> {{ this.banner_message|translate(this)|safe }} </div>
     </section>
   {% endif %}
   {% if this.release_notes %}


### PR DESCRIPTION
Also, drive-by fix for edge case: don't fail when translating if somehow the data is null, just return an empty string.

https://bugzilla.mozilla.org/show_bug.cgi?id=951027
