### PR TITLE
hide redundant reviewer tools button (bug 962562)

### DIFF
--- a/hearth/media/css/account.styl
+++ b/hearth/media/css/account.styl
@@ -60,4 +60,7 @@
     article.extras .notice {
         padding: 0 0 15px;
     }
+    footer .extras .button.reviewer-tools {
+        display: none;
+    }
 }


### PR DESCRIPTION
We can hide the button (this affects roughly tablet sizes) since a reviewer tools link is available in the footer anyway. Before this commit this extra button would break the layout.
