### PR TITLE
don't rebuild page on visibility change from 917592 (bug 960235)

### DIFF
--- a/hearth/media/js/buttons.js
+++ b/hearth/media/js/buttons.js
@@ -296,8 +296,36 @@ define('buttons',
         setButton($button, gettext('Launch'), 'launch install');
     }
 
+    function revertUninstalled() {
+        /* If an app was uninstalled, revert state of install buttons from
+           "Launch" to "Install". */
+
+        // Get installed apps to know which apps may have been uninstalled.
+        var r = navigator.mozApps.getInstalled();
+        r.onsuccess = function() {
+            // Build an array of manifests that match the button's data-manifest.
+            var installed = [];
+            _.each(r.result, function(val) {
+                installed.push(require('utils').baseurl(val.manifestURL));
+            });
+
+            $('.button.product').each(function(i, button) {
+                var $button = $(button);
+                // For each install button, check if its respective app is installed.
+                if (installed.indexOf($button.data('manifest_url')) === -1) {
+                    // If it is no longer installed, revert button.
+                    if ($button.hasClass('launch')) {
+                        revertButton($button, gettext('Install'));
+                    }
+                    $button.removeClass('launch');
+                }
+            });
+        };
+    }
+
     return {
         buttonInstalled: buttonInstalled,
-        install: install
+        install: install,
+        revertUninstalled: revertUninstalled,
     };
 });


### PR DESCRIPTION
- Changes the solution of https://bugzilla.mozilla.org/show_bug.cgi?id=917592 to be more focused.
- The issue was trying to revert "Launch" buttons back to "Install" if the user uninstalled the app.
- The previous solution was to fetch the installed apps list and then manually _rebuild_ (not reload) the whole page with builder.js.
- This was a buggy way since many views had code outside of the builder that was not re-run and many defers/GET requests were failing, causing disappearing content.
- The new solution is to fetch the installed apps list, and revert only applicable install buttons
