### PR TITLE
correctly reverse urls with multiple params

### DIFF
--- a/hearth/media/js/urls.js
+++ b/hearth/media/js/urls.js
@@ -2,7 +2,7 @@ define('urls',
     ['format', 'routes_api', 'routes_api_args', 'settings', 'user', 'utils'],
     function(format, api_endpoints, api_args, settings, user) {
 
-    var group_pattern = /\(.+\)/;
+    var group_pattern = /\([^\)]+\)/;
     var optional_pattern = /(\(.*\)|\[.*\]|.)\?/g;
     var reverse = function(view_name, args) {
         args = args || [];

--- a/hearth/tests/urls.js
+++ b/hearth/tests/urls.js
@@ -61,6 +61,16 @@ test('reverse too many args', function(done, fail) {
     }, fail);
 });
 
+test('reverse multiple args', function(done, fail) {
+    mock_routes([
+        {pattern: '^/apps/([0-9]+)/reviews/([0-9]+)$', view_name: 'two_args'},
+    ], function() {
+        var reversed = urls.reverse('two_args', [10, 20]);
+        eq_('/apps/10/reviews/20', reversed);
+        done();
+    }, fail);
+});
+
 test('api url', function(done, fail) {
     mock(
         'urls',


### PR DESCRIPTION
You used to get an error when reversing a route with multiple params since `group_pattern` was greedy and treated it as a much shorter url with one group.
