### PR TITLE
Refresh and store lists of installed/purchased/developed apps by the user (bug 969433)

### DIFF
--- a/hearth/media/js/buttons.js
+++ b/hearth/media/js/buttons.js
@@ -88,7 +88,7 @@ define('buttons',
 
         // If the user has already purchased the app, we do need to generate
         // another receipt but we don't need to go through the purchase flow again.
-        if (product.user.purchased) {
+        if (user.has_purchased(product.id)) {
             product.payment_required = false;
         }
 
@@ -106,7 +106,7 @@ define('buttons',
                 $this.data('old-text', $this.html());  // Save the old text of the button.
 
                 // Update the cache to show that the app was purchased.
-                product.user.purchased = true;
+                user.update_purchased(product.id);
 
                 // Bust the cache for the My Apps page.
                 cache.bust(urls.api.url('installed'));
@@ -168,7 +168,7 @@ define('buttons',
 
             // If the app has already been installed by the user and we don't
             // need a receipt, just start the app install.
-            if (product.user.installed && !product.receipt_required) {
+            if (user.has_installed(product.id) && !product.receipt_required) {
                 console.log('Receipt not required (skipping record step) for', product_name);
                 return do_install();
             }
@@ -215,7 +215,7 @@ define('buttons',
         function do_install(data) {
             return apps.install(product, data || {}).done(function(installer) {
                 // Update the cache to show that the user installed the app.
-                product.user.installed = true;
+                user.update_install(product.id);
                 // Bust the cache for the My Apps page.
                 cache.bust(urls.api.url('installed'));
 

--- a/hearth/media/js/cat-dropdown.js
+++ b/hearth/media/js/cat-dropdown.js
@@ -22,7 +22,7 @@ define('cat-dropdown',
     // TODO: Detect when the user is offline and raise an error.
 
     // Do the request out here so it happens immediately when the app loads.
-    var categoryReq = consumer_info.then(function() {
+    var categoryReq = consumer_info.promise.then(function() {
         return requests.get(urls.api.url('categories'));
     });
     // Store the categories in models.

--- a/hearth/media/js/consumer_info.js
+++ b/hearth/media/js/consumer_info.js
@@ -1,24 +1,45 @@
 define('consumer_info',
-       ['user_helpers', 'mobilenetwork', 'urls', 'requests', 'defer', 'log'],
-       function(user_helpers, mobilenetwork, urls, requests, defer, log) {
+    ['user', 'user_helpers', 'mobilenetwork', 'urls', 'requests', 'defer', 'log'],
+    function(user, user_helpers, mobilenetwork, urls, requests, defer, log) {
+
     var logger = log('consumer_info');
-    mobilenetwork.detectMobileNetwork();
-    if (!user_helpers.region(undefined, true)) {
-        logger.log('Retrieving consumer info.');
-        var deferred = defer.Deferred();
-        var consumerInfoRequest = requests.get(urls.api.url('consumer_info'));
-        consumerInfoRequest.then(function(consumerInfo) {
-            logger.log('Consumer info retrieved.');
-            user_helpers.set_region_geoip(consumerInfo.region);
-        }, function() {
-            logger.error('Failed to retrieve consumer info.');
-            user_helpers.set_region_geoip('restofworld');
-        }).always(function() {
-            deferred.resolve();
-        });
-        return deferred.promise();
-    } else {
-        logger.log('Consumer info already loaded.');
-        return defer.Deferred().resolve().promise();
+
+    function fetch(force) {
+        var already_have_region = false;
+
+        if (!force) {
+            // If we aren't forcing, check whether we actually need consumer
+            // info. If we already have a region, we don't. Because we depend
+            // on mobilenetwork, region should already have been detected
+            // from the SIM at this point.
+            already_have_region = user_helpers.region(undefined, true);
+        }
+
+        if (force || !already_have_region) {
+            logger.log('Retrieving consumer info.' + (force ? ' (forced)' : ''));
+            var deferred = defer.Deferred();
+            var consumerInfoRequest = requests.get(urls.api.url('consumer_info'));
+            consumerInfoRequest.then(function(consumerInfo) {
+                logger.log('Consumer info retrieved.' + (force ? ' (forced)' : ''));
+                user_helpers.set_region_geoip(consumerInfo.region);
+                if (user.logged_in() && consumerInfo.apps !== undefined) {
+                    user.update_apps(consumerInfo.apps);
+                }
+            }, function() {
+                logger.error('Failed to retrieve consumer info.');
+                user_helpers.set_region_geoip('restofworld');
+            }).always(function() {
+                deferred.resolve();
+            });
+            return deferred.promise();
+        } else {
+            logger.log('Consumer info already loaded and not forced.');
+            return defer.Deferred().resolve().promise();
+        }
     }
+
+    return {
+        'fetch': fetch,
+        'promise': fetch(),  // Call immediately and return the promise for consumption.
+    };
 });

--- a/hearth/media/js/helpers.js
+++ b/hearth/media/js/helpers.js
@@ -108,6 +108,9 @@ define('helpers',
             return _.clone(user.get_settings());
         },
         get_permission: user.get_permission,
+        has_developed: user.has_developed,
+        has_installed: user.has_installed,
+        has_purchased: user.has_purchased,
         logged_in: user.logged_in
     };
 

--- a/hearth/media/js/login.js
+++ b/hearth/media/js/login.js
@@ -99,6 +99,7 @@ define('login',
 
             user.set_token(data.token, data.settings);
             user.update_permissions(data.permissions);
+            user.update_apps(data.apps);
             console.log('Login succeeded, preparing the app');
 
             z.body.addClass('logged-in');

--- a/hearth/media/js/marketplace.js
+++ b/hearth/media/js/marketplace.js
@@ -122,10 +122,16 @@ function(_) {
         z.page.on('fragment_loaded loaded_more',
                   _.debounce(get_installed, 2000, true));  // No delay.
         document.addEventListener('visibilitychange', function() {
-            // Check if apps were uninstalled since switching from Marketplace,
-            // and refresh Install buttons if any were.
             if (document.hidden) {
                 return;
+            }
+            // We switched away from Marketplace, and now we are back and
+            // visible. The user might have installed/uninstalled apps during
+            // that time, so refresh the list of installed/purchased/developed
+            // apps, and check if apps were uninstalled since switching away,
+            // refreshing Install buttons if any were.
+            if (require('user').logged_in()) {
+                require('consumer_info').fetch(true);
             }
             require('buttons').revertUninstalled();
         }, false);
@@ -177,7 +183,7 @@ function(_) {
         false
     );
 
-    require('consumer_info').done(function() {
+    require('consumer_info').promise.done(function() {
         console.log('Triggering initial navigation');
         if (!z.spaceheater) {
             z.page.trigger('navigate', [window.location.pathname + window.location.search]);

--- a/hearth/media/js/user.js
+++ b/hearth/media/js/user.js
@@ -7,6 +7,11 @@ define('user',
     var token;
     var settings = {};
     var permissions = {};
+    var apps = {
+        'installed': [],
+        'purchased': [],
+        'developed': []
+    };
 
     var save_to_ls = !capabilities.phantom;
 
@@ -15,6 +20,10 @@ define('user',
         log.unmention(token);
         settings = JSON.parse(storage.getItem('settings') || '{}');
         permissions = JSON.parse(storage.getItem('permissions') || '{}');
+        var _stored = storage.getItem('user_apps');
+        if (_stored) {
+            apps = JSON.parse(_stored);
+        }
     }
 
     if (save_to_ls) {
@@ -48,6 +57,22 @@ define('user',
 
     function get_settings() {
         return settings;
+    }
+
+    function get_apps() {
+        return apps;
+    }
+
+    function has_developed(app_id) {
+        return apps.developed.indexOf(app_id) !== -1;
+    }
+
+    function has_installed(app_id) {
+        return apps.installed.indexOf(app_id) !== -1;
+    }
+
+    function has_purchased(app_id) {
+        return apps.purchased.indexOf(app_id) !== -1;
     }
 
     function set_token(new_token, new_settings) {
@@ -105,16 +130,53 @@ define('user',
         save_permissions();
     }
 
+    function update_apps(data) {
+        if (!data) {
+            return;
+        }
+        console.log('Updating user apps', data);
+        apps = data;
+        save_apps();
+    }
+
+    function update_install(app_id) {
+        console.log('Adding to user apps.installed', app_id);
+        apps.installed.push(app_id);
+        save_apps();
+    }
+
+    function update_purchased(app_id) {
+        console.log('Adding to user apps.purchased', app_id);
+        apps.purchased.push(app_id);
+        save_apps();
+    }
+
+    function save_apps() {
+        if (save_to_ls) {
+            console.log('Saving user apps to localStorage');
+            storage.setItem('user_apps', JSON.stringify(apps));
+        } else {
+            console.log('User apps not saved to localStorage');
+        }
+    }
+
     return {
         clear_settings: clear_settings,
         clear_token: clear_token,
-        get_setting: get_setting,
+        get_apps: get_apps,
         get_permission: get_permission,
+        get_setting: get_setting,
         get_settings: get_settings,
         get_token: function() {return token;},
+        has_developed: has_developed,
+        has_installed: has_installed,
+        has_purchased: has_purchased,
         logged_in: function() {return !!token;},
         set_token: set_token,
+        update_apps: update_apps,
+        update_install: update_install,
+        update_permissions: update_permissions,
+        update_purchased: update_purchased,
         update_settings: update_settings,
-        update_permissions: update_permissions
     };
 });

--- a/hearth/templates/_macros/market_button.html
+++ b/hearth/templates/_macros/market_button.html
@@ -12,6 +12,6 @@
   <button class="button product install {{ classes|join(' ') }} {{ 'incompatible' if app_incompat(app) }}"
           {{ data_attrs|make_data_attrs }}
           {{ 'disabled' if app_incompat(app) }}>
-    {{ _('Install') if app.user.installed or app.user.purchased else price }}
+    {{ _('Install') if user.has_installed(app.id) or user.has_purchased(app.id) else price }}
   </button>
 {% endmacro %}

--- a/hearth/templates/detail/main.html
+++ b/hearth/templates/detail/main.html
@@ -104,7 +104,7 @@
 </section>
 
 {% defer (url=endpoint, as='app', key=slug) %}
-  {% if this.user.developed or user.get_permission('reviewer') %}
+  {% if user.has_developed(this.id) or user.get_permission('reviewer') %}
     <section class="main actions infobox">
       <div>
         <p class="split"><a href="/developers/app/{{ slug }}/edit" class="button manage" rel="external">
@@ -190,7 +190,7 @@
           {{ _('Privacy Policy') }}</a>
         </li>
       {% endif %}
-      {% if this.public_stats or this.user.developed %}
+      {% if this.public_stats or user.has_developed(this.id) %}
         <li class="statistics" data-tracking="Statistics">
           <a class="button alt view-stats" rel="external" href="/statistics/app/{{ slug }}">
           {{ _('Statistics') }}</a>

--- a/smokealarm/lib.js
+++ b/smokealarm/lib.js
@@ -3,6 +3,11 @@ function fake_login(suite) {
     suite.evaluate(function() {
         console.log('[*][phantom] Performing fake login action');
         window.require('user').set_token("it's fine, it's fine");
+        window.require('user').update_apps({
+            'installed': [],
+            'developed': [424242],  // Hardcoded in flue as the id for the 'developer' app.
+            'purchased': []
+        });
         var z = window.require('z');
         z.body.addClass('logged-in');
         z.page.trigger('reload_chrome');

--- a/smokealarm/tests/app/detail_developer.js
+++ b/smokealarm/tests/app/detail_developer.js
@@ -1,13 +1,16 @@
 var suite = require('./kasperle').suite();
+var lib = require('./lib');
 
-suite.run('/app/developer', function(test, waitFor) {
+suite.run('/app/developed', function(test, waitFor) {
 
     waitFor(function() {
         return suite.exists('#splash-overlay.hide');
     });
 
     test('Detail page tests for apps as a developer', function(assert) {
-        assert.URL(/\/app\/developer/);
+        lib.fake_login(suite);
+
+        assert.URL(/\/app\/developed/);
         suite.capture('detail_developer.png');
 
         assert.invisible('.expand-toggle');

--- a/smokealarm/tests/app/detail_reviewer.js
+++ b/smokealarm/tests/app/detail_reviewer.js
@@ -1,7 +1,7 @@
 var suite = require('./kasperle').suite();
 var lib = require('./lib');
 
-suite.run('/app/developer', function(test, waitFor) {
+suite.run('/app/developed', function(test, waitFor) {
 
     waitFor(function() {
         return suite.exists('#splash-overlay.hide');
@@ -15,7 +15,7 @@ suite.run('/app/developer', function(test, waitFor) {
             require('views').reload();
         });
 
-        assert.URL(/\/app\/developer/);
+        assert.URL(/\/app\/developed/);
         suite.capture('detail_owner.png');
 
         assert.invisible('.expand-toggle');


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=969433
- [x] Store the lists on login
- [x] Create methods to use the list data
- [x] Use the newly created methods instead of app.user in the views / templates
- [x] Refresh the list via a consumer-info call if I'm already logged in.
- [x] Refresh the list when the app visibility changes
- [x] Tests

Note: Changing fireplace and/or the API to not use any user-dependent params/information in the search/featured API endpoint is a separate issue, https://bugzilla.mozilla.org/show_bug.cgi?id=975413
