### PR TITLE
Fix scroll restoration in Android (bug 976466)

### DIFF
--- a/hearth/media/js/navigation.js
+++ b/hearth/media/js/navigation.js
@@ -10,6 +10,7 @@ define('navigation',
         {path: '/', type: 'root'}
     ];
     var initialized = false;
+    var scrollTimer;
 
     function extract_nav_url(url) {
         // This function returns the URL that we should use for navigation.
@@ -68,8 +69,16 @@ define('navigation',
             }
             top = state.scrollTop;
         }
-        console.log('Setting scroll to', top);
-        window.scrollTo(0, top);
+
+        // Introduce small delay to ensure content
+        // is ready to scroll. (Bug 976466)
+        if (scrollTimer) {
+            window.clearTimeout(scrollTimer);
+        }
+        scrollTimer = window.setTimeout(function() {
+            console.log('Setting scroll to', top);
+            window.scrollTo(0, top);
+        }, 250);
 
         // Clean the path's parameters.
         // /foo/bar?foo=bar&q=blah -> /foo/bar?q=blah


### PR DESCRIPTION
See the bug for details: https://bugzilla.mozilla.org/show_bug.cgi?id=976466

This solution uses a `setTimeout` to workaround the page not being ready (in Android) to handle scroll events.

Perhaps longer term we should consider having a loading page and do this based on events as redraws in android are noticeably not smooth.

I've looked at putting this on the loaded event but the problem with that is the `z.page` `loaded` event fires after the page has been visibly loaded at the previous scroll position. Once loaded fires then in moves up which feels clunky. So that would only really work if the page load was covered with a loading screen during the transition to the new page.

`loaded` on `z.page` feels like it should be the right event as this is connected to when the pool of requests is completed.
