### PR TITLE
Use input event for firefox android (bug 976262)

### DIFF
--- a/hearth/media/js/utils.js
+++ b/hearth/media/js/utils.js
@@ -33,7 +33,8 @@ define('utils', ['jquery', 'l10n', 'underscore'], function($, l10n, _) {
             var $cc = $(this);
             $cc.closest('form')
                .find('#' + $cc.data('for'))
-               .on('keyup blur', _.throttle(function() {countChars(this, $cc);}, 250))
+               // Note 'input' event is need for FF android see (bug 976262)
+               .on('input keyup blur', _.throttle(function() {countChars(this, $cc);}, 250))
                .trigger('blur');
         });
     }


### PR DESCRIPTION
From the bug:

I noticed the key counter wasn't working. When looking for info on FF android key events I found this:

https://stackoverflow.com/questions/14194247/key-event-doesnt-trigger-in-firefox-on-android-when-word-suggestion-is-on

Adding that event fixes the char counter.
