### PR TITLE
Fix redraw zooming issue (bug 972532)

### DIFF
--- a/hearth/media/js/marketplace.js
+++ b/hearth/media/js/marketplace.js
@@ -183,6 +183,19 @@ function(_) {
         false
     );
 
+    function setVpHeightAndroid() {
+        // Workaround to prevent zooming on short pages when keyboard
+        // is lowered (972532, 976531)
+        var scrollableBodyHeight = z.win.height() + 200;
+        console.log('[Android] Setting min-height to: ' + scrollableBodyHeight);
+        z.body.css('min-height', scrollableBodyHeight);
+    }
+
+    if (capabilities.firefoxAndroid) {
+        z.doc.on('saferesize', setVpHeightAndroid);
+        setVpHeightAndroid();
+    }
+
     require('consumer_info').promise.done(function() {
         console.log('Triggering initial navigation');
         if (!z.spaceheater) {


### PR DESCRIPTION
This is definitely a hacky solution but seems to be the only thing that prevents the zooming that happens when the page is scrolled up when the keyboard is up. The keyboard lowering makes it zoom see https://bugzilla.mozilla.org/show_bug.cgi?id=976531 for details and videos that show the problem.

Adding min-height  equal to 200px larger than the viewport prevents the redraw causing the page to be zoomed in or be rendered with the bottom part missing. Which subsequently caused the notification position to be mis-calculated.

Alternative thoughts and suggestions welcomed.
