### PR TITLE
use localStorage to cache homepage/category API responses (bug 980081)

### DIFF
--- a/hearth/media/js/cache.js
+++ b/hearth/media/js/cache.js
@@ -1,8 +1,99 @@
-define('cache', ['log', 'rewriters', 'storage'], function(log, rewriters, storage) {
+define('cache',
+    ['log', 'rewriters', 'settings', 'storage', 'user', 'z'],
+    function(log, rewriters, settings, storage, user, z) {
 
     var console = log('cache');
 
     var cache = {};
+    var cache_key = 'request_cache';
+
+    if (settings.offline_cache_enabled()) {
+        cache = JSON.parse(storage.getItem(cache_key) || '{}');
+        flush_expired();
+    }
+
+    // Persist the cache for whitelisted URLs.
+    window.addEventListener('beforeunload', save, false);
+
+    function get_ttl(url) {
+        // Returns TTL for an API URL in microseconds.
+        var path = new URL(url).pathname;
+        if (path in settings.offline_cache_whitelist) {
+            // Convert from seconds to microseconds.
+            return settings.offline_cache_whitelist[path] * 1000;
+        }
+        return null;
+    }
+
+    function save() {
+        if (!settings.offline_cache_enabled()) {
+            return;
+        }
+
+        var cache_to_save = {};
+        Object.keys(cache).forEach(function (url) {
+            // If there is a TTL assigned to this URL, then we can cache it.
+            if (get_ttl(url) !== null) {
+                cache_to_save[url] = cache[url];
+            }
+        });
+
+        // Trigger an event to save the cache. (We do size checks to see if
+        // the combined request+model cache is too large to persist.)
+        z.doc.trigger('save_cache', cache_key);
+
+        // Persist only if the data has changed.
+        var cache_to_save_str = JSON.stringify(cache_to_save);
+        if (storage.getItem(cache_key) !== cache_to_save_str) {
+            storage.setItem(cache_key, cache_to_save_str);
+            console.log('Persisting request cache');
+        }
+    }
+
+    function flush() {
+        cache = {};
+    }
+
+    function flush_signed() {
+        // This gets called when a user logs out, so we remove any requests
+        // with user data in them.
+
+        // First, we remove every signed URL from the request cache.
+        Object.keys(cache).forEach(function (url) {
+            if (url.indexOf('_user=' + user.get_token()) !== -1) {
+                console.log('Removing signed URL', url);
+                delete cache[url];
+            }
+        });
+
+        // Then, we persist the cache.
+        save();
+    }
+
+    function flush_expired() {
+        // This gets called once when the page loads to purge any expired
+        // persisted responses.
+
+        var now = +new Date();
+        var time;
+        var ttl = null;
+
+        Object.keys(cache).forEach(function (url) {
+            // Get the timestamp.
+            time = cache[url].__time;
+
+            // Get the TTL if this URL is allowed to be cached.
+            ttl = get_ttl(url);
+
+            // If the item is expired, remove it from the cache.
+            if (!time || time + ttl <= now) {
+                console.log('Removing expired URL', url);
+                return delete cache[url];
+            }
+        });
+
+        save();
+    }
 
     function has(key) {
         return key in cache;
@@ -48,7 +139,7 @@ define('cache', ['log', 'rewriters', 'storage'], function(log, rewriters, storag
         get: function(key) {
             if (has(key)) {
                 return get(key);
-            } else if (key in storageKeys) {
+            } else {
                 var val = storage.getItem(persistentCachePrefix + key);
                 set(key, val);
                 return val;
@@ -59,9 +150,7 @@ define('cache', ['log', 'rewriters', 'storage'], function(log, rewriters, storag
             set(key, val);
         },
         bust: function(key) {
-            if (key in storageKeys) {
-                storage.removeItem(persistentCachePrefix + key);
-            }
+            storage.removeItem(persistentCachePrefix + key);
             bust(key);
         },
         has: function(key) {
@@ -100,15 +189,18 @@ define('cache', ['log', 'rewriters', 'storage'], function(log, rewriters, storag
     }
 
     return {
-        has: has,
-        get: get,
-        set: set,
-        bust: bust,
-        purge: purge,
-
         attemptRewrite: rewrite,
+        bust: bust,
+        cache: cache,
+        flush: flush,
+        flush_expired: flush_expired,
+        flush_signed: flush_signed,
+        get: get,
+        get_ttl: get_ttl,
+        has: has,
+        persist: persistent,
+        purge: purge,
         raw: cache,
-
-        persist: persistent
+        set: set
     };
 });

--- a/hearth/media/js/login.js
+++ b/hearth/media/js/login.js
@@ -1,6 +1,6 @@
 define('login',
-    ['capabilities', 'defer', 'jquery', 'log', 'notification', 'settings', 'underscore', 'urls', 'user', 'utils', 'requests', 'z'],
-    function(capabilities, defer, $, log, notification, settings, _, urls, user, utils, requests, z) {
+    ['cache', 'capabilities', 'defer', 'jquery', 'log', 'notification', 'settings', 'underscore', 'urls', 'user', 'utils', 'requests', 'z'],
+    function(cache, capabilities, defer, $, log, notification, settings, _, urls, user, utils, requests, z) {
 
     var console = log('login');
 
@@ -23,6 +23,7 @@ define('login',
 
     }).on('click', '.logout', function(e) {
         e.preventDefault();
+        cache.flush_signed();
         user.clear_token();
         z.body.removeClass('logged-in');
         z.page.trigger('reload_chrome').trigger('before_logout');

--- a/hearth/media/js/marketplace.js
+++ b/hearth/media/js/marketplace.js
@@ -58,11 +58,22 @@ define(
         'z'
     ],
 function(_) {
+    var capabilities = require('capabilities');
+    if (!capabilities.performance) {
+        // Polyfill `performance.now` for PhantomJS.
+        // (And don't even bother with `Date.now` because IE.)
+        window.performance = {
+            now: function() {
+                return +new Date();
+            }
+        };
+    }
+    var start_time = performance.now();
+
     var console = require('log')('mkt');
     console.log('Dependencies resolved, starting init');
 
     var $ = require('jquery');
-    var capabilities = require('capabilities');
     var format = require('format');
     var nunjucks = require('templates');
     var settings = require('settings');
@@ -85,7 +96,7 @@ function(_) {
     z.body.addClass('html-' + require('l10n').getDirection());
 
     z.page.one('loaded', function() {
-        console.log('Hiding splash screen');
+        console.log('Hiding splash screen (' + ((performance.now() - start_time) / 1000).toFixed(6) + 's)');
         // Remove the splash screen once it's hidden.
         var splash = $('#splash-overlay').addClass('hide');
         z.body.removeClass('overlayed');

--- a/hearth/media/js/models.js
+++ b/hearth/media/js/models.js
@@ -1,9 +1,67 @@
-define('models', ['defer', 'log', 'requests', 'settings', 'underscore'], function(defer, log, requests, settings, _) {
+define('models',
+    ['cache', 'defer', 'log', 'requests', 'settings', 'storage', 'underscore', 'z'],
+    function(cache, defer, log, requests, settings, storage, _, z) {
 
     var console = log('model');
 
     // {'type': {'<id>': object}}
+    var cache_key = 'model_cache';
     var data_store = {};
+
+    if (settings.offline_cache_enabled()) {
+        data_store = JSON.parse(storage.getItem(cache_key) || '{}');
+    }
+
+    // Persist the model cache.
+    window.addEventListener('beforeunload', save, false);
+
+    z.doc.on('saving_offline_cache', function (e, cache_key) {
+        // Really, this should be an LRU cache but the builder has an
+        // expectation that a hit to the request cache means that the models
+        // have been casted and exist already in the model cache too.
+        //
+        // It gets too complicated having one LRU cache for the request cache
+        // and then independent LRU caches for app, category, and collection
+        // model caches. It's fine. It's fine.
+
+        var data = {
+            'request_cache': JSON.stringify(cache.cache),
+            'model_cache': JSON.stringify(data_store)
+        };
+
+        var size = (JSON.stringify(data.request_cache).length +
+                    JSON.stringify(data.model_cache).length);
+        if (size >= settings.offline_cache_limit) {
+            console.warn('Quota exceeded for request/model offline cache; ' +
+                         'flushing cache');
+            cache.flush();
+            flush();
+            storage.setItem(cache_key, data_store_str);
+        } else {
+            // Persist only if the data has changed.
+            var data_store_str = data[cache_key];
+            if (storage.getItem(cache_key) !== data_store_str) {
+                storage.setItem(cache_key, data_store_str);
+                console.log('Persisting model cache');
+            }
+        }
+    });
+
+    function flush() {
+        // Purge cache for every type of model.
+        data_store = {};
+    }
+
+    function save() {
+        z.doc.trigger('save_cache', cache_key);
+
+        // Persist only if the data has changed.
+        var data_store_str = JSON.stringify(data_store);
+        if (storage.getItem(cache_key) !== data_store_str) {
+            storage.setItem(cache_key, data_store_str);
+            console.log('Persisting model cache');
+        }
+    }
 
     var prototypes = settings.model_prototypes;
 
@@ -96,11 +154,13 @@ define('models', ['defer', 'log', 'requests', 'settings', 'underscore'], functio
 
         return {
             cast: cast,
-            uncast: uncast,
+            data_store: data_store,
+            del: del,
+            flush: flush,
             get: get,
             lookup: lookup,
             purge: purge,
-            del: del
+            uncast: uncast
         };
     };
 

--- a/hearth/media/js/requests.js
+++ b/hearth/media/js/requests.js
@@ -1,6 +1,6 @@
 define('requests',
-    ['cache', 'defer', 'log', 'utils'],
-    function(cache, defer, log, utils) {
+    ['cache', 'defer', 'log', 'settings', 'utils'],
+    function(cache, defer, log, settings, utils) {
 
     var console = log('req');
 
@@ -96,32 +96,58 @@ define('requests',
         return def;
     }
 
-    function get(url, nocache, persistent) {
+    // During a single session, we never want to fetch the same URL more than
+    // once. Because our persistent offline cache does XHRs in the background
+    // to keep the cache fresh, we want to do that only once per session. In
+    // order to do all this magic, we have to keep an array of all of the URLs
+    // we hit per session.
+    var urls_fetched = {};
+
+    function get(url, nocache) {
+        var cache_offline = settings.offline_cache_enabled();
+
         var cached;
         if (cache.has(url) && !nocache) {
             console.log('GETing from cache', url);
             cached = cache.get(url);
-        } else if (cache.persist.has(url) && persistent && !nocache) {
-            console.log('GETing from persistent cache', url);
-            cached = cache.persist.get(url);
         }
-        if (cached) {
-            return defer.Deferred()
-                        .resolve(cached)
-                        .promise({__cached: true});
-        }
-        return _get.apply(this, arguments, persistent);
-    }
 
-    function _get(url, nocache, persistent) {
+        var def_cached;
+        if (cached) {
+            def_cached = defer.Deferred()
+                              .resolve(cached)
+                              .promise({__cached: true});
+            if (!cache_offline || url in urls_fetched) {
+                // If we don't need to make an XHR in the background to update
+                // the cache, then let's bail now.
+                return def_cached;
+            }
+        }
+
         console.log('GETing', url);
-        return ajax('GET', url).done(function(data, xhr) {
+        urls_fetched[url] = null;
+
+        var def_ajax = ajax('GET', url).done(function(data) {
             console.log('GOT', url);
             if (!nocache) {
+                data.__time = +(new Date());
                 cache.set(url, data);
-                if (persistent) cache.persist.set(url, data);
+            }
+            if (cached && cache_offline) {
+                console.log('Updating request cache', url);
             }
         });
+
+        if (cached && cache_offline) {
+            // If the response was cached, we still want to fire off the
+            // AJAX request so the cache can get updated in the background,
+            // but let's resolve this deferred with the cached response
+            // so the request pool can get closed and the builder can render
+            // the template for the `defer` block.
+            return def_cached;
+        }
+
+        return def_ajax;
     }
 
     function handle_errors(xhr, type, status) {

--- a/hearth/media/js/settings.js
+++ b/hearth/media/js/settings.js
@@ -19,6 +19,14 @@ define('settings', ['l10n', 'settings_local', 'underscore'], function(l10n, sett
         base_settings.cdn_url = media_url.protocol + '//' + media_url.hostname;
     }
 
+    function offline_cache_enabled() {
+        var storage = require('storage');
+        if (storage.getItem('offline_cache_disabled') || require('capabilities').phantom) {
+            return false;
+        }
+        return window.location.search.indexOf('cache=false') === -1;
+    }
+
     return _.defaults(base_settings, {
         app_name: 'fireplace',
         init_module: 'marketplace',
@@ -58,6 +66,18 @@ define('settings', ['l10n', 'settings_local', 'underscore'], function(l10n, sett
             'dummy': 'id',
             'dummy2': 'id'
         },
+
+        // These are the only URLs that should be cached
+        // (key: URL; value: TTL [time to live] in seconds).
+        // Keep in mind that the cache is always refreshed asynchronously;
+        // these TTLs apply to only when the app is first launched.
+        offline_cache_whitelist: {
+            '/api/v1/fireplace/consumer-info/': 60 * 60 * 6,  // 6 hours
+            '/api/v1/fireplace/search/featured/': 60 * 60 * 24,  // 1 day
+            '/api/v1/apps/category/': 60 * 60 * 24 * 7  // 1 week
+        },
+        offline_cache_enabled: offline_cache_enabled,
+        offline_cache_limit: 1024 * 1024 * 4,  // 4 MB
 
         // Error template paths. Used by builder.js.
         fragment_error_template: 'errors/fragment.html',

--- a/hearth/media/js/settings_local_hosted.js
+++ b/hearth/media/js/settings_local_hosted.js
@@ -1,11 +1,7 @@
-define('settings_local', [], function() {
-    var origin = window.location.origin || (
-        window.location.protocol + '//' + window.location.host);
+define('settings_local', [], function(settings_base, _) {
+    // Override settings here!
     return {
-        api_url: origin,
-        media_url: document.body.getAttribute('data-media'),
-        tracking_enabled: true,
-
-        potatolytics_enabled: false
+        api_url: 'https://marketplace-dev.allizom.org',
+        media_url: ' https://marketplace-dev-cdn.allizom.org/media',
     };
 });

--- a/hearth/templates/debug.html
+++ b/hearth/templates/debug.html
@@ -24,6 +24,20 @@
       <button class="button" id="clear-localstorage">Clear <code>localStorage</code></button>
     </p>
 
+    {% if settings.offline_cache_enabled() %}
+      <p>
+        <button class="button" id="disable-offline-cache">Disable offline cache</button>
+      </p>
+    {% else %}
+      <p>
+        <button class="button" id="enable-offline-cache">Enable offline cache</button>
+      </p>
+    {% endif %}
+
+    <p>
+      <button class="button" id="clear-offline-cache">Clear offline cache</button>
+    </p>
+
     <p>
       <button class="button" id="clear-cookies">Clear cookies</button>
     </p>
@@ -118,5 +132,15 @@
         {% endfor %}
       </ol>
     {% endfor %}
+
+    <h3>Offline Cache</h3>
+    <ol>
+      {% for url, response in request_cache.items() %}
+        <li>{{ url }}</li>
+      {% endfor %}
+    </ol>
+    <pre>
+      {{ request_cache|stringify(null, 2) }}
+    </pre>
   </div>
 </section>

--- a/hearth/tests/cache.js
+++ b/hearth/tests/cache.js
@@ -4,6 +4,7 @@ var _ = require('underscore');
 var assert = a.assert;
 var eq_ = a.eq_;
 var eeq_ = a.eeq_;
+var feq_ = a.feq_;
 var mock = a.mock;
 
 var cache = require('cache');
@@ -67,7 +68,11 @@ test('cache purge', function(done) {
 test('cache purge filter', function(done) {
     mock(
         'cache',
-        {},
+        {
+            settings: {
+                offline_cache_enabled: function () { return false; }
+            }
+        },
         function(cache) {
             var key = 'test2:';
             var str = 'poop';
@@ -238,6 +243,107 @@ test('cache deep rewrite on set', function(done) {
 
             eq_(cache.get('foo:deep'), 'asdfbar');
             eq_(cache.get('fart:deep'), 'asdfzap');
+            done();
+        }
+    );
+});
+
+test('cache get_ttl', function(done) {
+    mock(
+        'cache',
+        {
+            settings: {
+                offline_cache_enabled: function () { return true; },
+                offline_cache_whitelist: {
+                    '/api/v1/fireplace/consumer-info/': 60 * 60,  // 1 hour in seconds
+                    '/api/v1/fireplace/search/featured/': 60 * 60 * 6,  // 6 hours
+                    '/api/v1/apps/category/': 60 * 60 * 24  // 1 day
+                }
+            }
+        },
+        function (cache) {
+            eq_(cache.get_ttl('https://omg.org/api/v1/fireplace/consumer-info/'),
+                60 * 60 * 1000);  // 1 hour in microseconds
+            eq_(cache.get_ttl('https://omg.org/api/v1/apps/category/'),
+                60 * 60 * 24 * 1000);  // 1 hour in microseconds
+            eq_(cache.get_ttl('https://omg.org/api/v1/swag/yolo/foreva/'), null);
+            done();
+        }
+    );
+});
+
+test('cache flush_signed', function(done) {
+    mock(
+        'user',
+        {},
+        function (user) {
+            user.set_token('SwaggasaurusRex');
+
+            var data = 'ratchet data';
+
+            var signed_url = 'https://omg.org/api/v1/app/yolo/?_user=SwaggasaurusRex';
+            cache.set(signed_url, data);
+            eq_(cache.get(signed_url), data);
+
+            var unsigned_url = 'https://omg.org/api/v1/app/swag/';
+            cache.set(unsigned_url, data);
+            eq_(cache.get(unsigned_url), data);
+
+            feq_(Object.keys(cache.cache).sort(), [unsigned_url, signed_url]);
+
+            // Calling this should clear all cache keys whose URLs contain
+            // `_user=<token>`.
+            cache.flush_signed();
+
+            feq_(Object.keys(cache.cache), [unsigned_url]);
+
+            done();
+        }
+    );
+});
+
+test('cache flush_expired', function(done) {
+    mock(
+        'cache',
+        {
+            settings: {
+                offline_cache_enabled: function () { return true; },
+                offline_cache_whitelist: {
+                    '/api/v1/fireplace/consumer-info/': 60 * 60,  // 1 hour in seconds
+                    '/api/v1/fireplace/search/featured/': 60 * 60 * 6,  // 6 hours
+                    '/api/v1/apps/category/': 60 * 60 * 24  // 1 day
+                }
+            }
+        },
+        function (cache) {
+            // Both were just added and unexpired ...
+            cache.set('https://omg.org/api/v1/fireplace/consumer-info/', {
+                '__time': +new Date()
+            });
+            cache.set('https://omg.org/api/v1/fireplace/search/featured/', {
+                '__time': +new Date()
+            });
+            cache.flush_expired();
+            assert(cache.has('https://omg.org/api/v1/fireplace/consumer-info/'));
+            assert(cache.has('https://omg.org/api/v1/fireplace/search/featured/'));
+
+            // Neither has expired ...
+            cache.set('https://omg.org/api/v1/fireplace/consumer-info/', {
+                '__time': +new Date() - (60 * 59 * 1000)  // 59 min ago in microseconds
+            });
+            cache.flush_expired();
+            assert(cache.has('https://omg.org/api/v1/fireplace/consumer-info/'));
+            assert(cache.has('https://omg.org/api/v1/fireplace/search/featured/'));
+
+            // One expired!
+            cache.set('https://omg.org/api/v1/fireplace/consumer-info/', {
+                '__time': +new Date() - (60 * 65 * 1000)  // 1 hr 5 min ago in microseconds
+            });
+            cache.flush_expired();
+            assert(!cache.has('https://omg.org/api/v1/fireplace/consumer-info/'));
+            assert(cache.has('https://omg.org/api/v1/fireplace/search/featured/'));
+
+
             done();
         }
     );

--- a/hearth/tests/models.js
+++ b/hearth/tests/models.js
@@ -20,7 +20,12 @@ test('model invalid type', function(done, fail) {
 test('model cast/lookup/purge', function(done, fail) {
     mock(
         'models',
-        {settings: {model_prototypes: {'dummy': 'id', 'dummy2': 'id'}}},
+        {
+            settings: {
+                offline_cache_enabled: function () { return false; },
+                model_prototypes: {'dummy': 'id', 'dummy2': 'id'}
+            }
+        },
         function(models) {
             var d1 = models('dummy');
             var d2 = models('dummy2');
@@ -57,7 +62,12 @@ test('model cast/lookup/purge', function(done, fail) {
 test('model cast/lookup/delete', function(done, fail) {
     mock(
         'models',
-        {settings: {model_prototypes: {'dummy': 'id'}}},
+        {
+            settings: {
+                offline_cache_enabled: function () { return false; },
+                model_prototypes: {'dummy': 'id'}
+            }
+        },
         function(models) {
             var d1 = models('dummy');
             d1.cast({
@@ -79,7 +89,12 @@ test('model cast/lookup/delete', function(done, fail) {
 test('model cast/lookup/delete val', function(done, fail) {
     mock(
         'models',
-        {settings: {model_prototypes: {'dummy': 'id'}}},
+        {
+            settings: {
+                offline_cache_enabled: function () { return false; },
+                model_prototypes: {'dummy': 'id'}
+            }
+        },
         function(models) {
             var d1 = models('dummy');
             d1.cast({
@@ -101,7 +116,12 @@ test('model cast/lookup/delete val', function(done, fail) {
 test('model cast/uncast', function(done, fail) {
     mock(
         'models',
-        {settings: {model_prototypes: {'dummy': 'id'}}},
+        {
+            settings: {
+                offline_cache_enabled: function () { return false; },
+                model_prototypes: {'dummy': 'id'}
+            }
+        },
         function(models) {
             var d1 = models('dummy');
 
@@ -125,7 +145,12 @@ test('model cast/uncast', function(done, fail) {
 test('model cast/uncast lists', function(done, fail) {
     mock(
         'models',
-        {settings: {model_prototypes: {'dummy': 'id'}}},
+        {
+            settings: {
+                offline_cache_enabled: function () { return false; },
+                model_prototypes: {'dummy': 'id'}
+            }
+        },
         function(models) {
             var d1 = models('dummy');
 
@@ -165,7 +190,10 @@ test('model get hit', function(done, fail) {
         'models',
         {
             requests: {get: function(x) {return 'surprise! ' + x;}},
-            settings: {model_prototypes: {'dummy': 'id'}}
+            settings: {
+                offline_cache_enabled: function () { return false; },
+                model_prototypes: {'dummy': 'id'}
+            }
         },
         function(models) {
             var d1 = models('dummy');
@@ -190,7 +218,10 @@ test('model get miss', function(done, fail) {
         'models',
         {
             requests: {get: function(x) {return 'surprise! ' + x;}},
-            settings: {model_prototypes: {'dummy': 'id'}}
+            settings: {
+                offline_cache_enabled: function () { return false; },
+                model_prototypes: {'dummy': 'id'}
+            }
         },
         function(models) {
             var d1 = models('dummy');
@@ -207,7 +238,10 @@ test('model get getter', function(done, fail) {
         'models',
         {
             requests: {get: function(x) {return "not the droids you're looking for";}},
-            settings: {model_prototypes: {'dummy': 'id'}}
+            settings: {
+                offline_cache_enabled: function () { return false; },
+                model_prototypes: {'dummy': 'id'}
+            }
         },
         function(models) {
             var d1 = models('dummy');
@@ -224,7 +258,12 @@ test('model get getter', function(done, fail) {
 test('model lookup by', function(done, fail) {
     mock(
         'models',
-        {settings: {model_prototypes: {'dummy': 'id'}}},
+        {
+            settings: {
+                offline_cache_enabled: function () { return false; },
+                model_prototypes: {'dummy': 'id'}
+            }
+        },
         function(models) {
             var d1 = models('dummy');
 
@@ -250,7 +289,12 @@ test('model lookup by', function(done, fail) {
 test('model lookup miss', function(done, fail) {
     mock(
         'models',
-        {settings: {model_prototypes: {'dummy': 'id'}}},
+        {
+            settings: {
+                offline_cache_enabled: function () { return false; },
+                model_prototypes: {'dummy': 'id'}
+            }
+        },
         function(models) {
             var d1 = models('dummy');
 
@@ -270,7 +314,12 @@ test('model lookup miss', function(done, fail) {
 test('model cast list', function(done, fail) {
     mock(
         'models',
-        {settings: {model_prototypes: {'dummy': 'id'}}},
+        {
+            settings: {
+                offline_cache_enabled: function () { return false; },
+                model_prototypes: {'dummy': 'id'}
+            }
+        },
         function(models) {
             var d1 = models('dummy');
 


### PR DESCRIPTION
This is a working implementation of [bug 980081](https://bugzilla.mozilla.org/show_bug.cgi?id=980081) but using `localStorage` as a proof of concept instead of `IndexedDB` ([localForage](https://github.com/mozilla/localForage)). The goal is to improve the second-run experience (launching the app for any subsequent time after the first time the app is launched). I'd encourage people to read my [exhaustive proposal](https://bugzilla.mozilla.org/show_bug.cgi?id=980081#c1) in the bug if they're curious.

I'd love to have lots of eyes on this and get people's feedback. @dethe and I will be working on this, and if anyone else is interested in helping out here, holler at us.
- [x] persist request cache
- [x] persist model cache
- [x] do asynchronous cache refreshing (such that even on cache hits, we update the cache in the background by letting each XHR still go through after the template has been rendered from the cached data from the _persistent_ cache [never from the local, in-memory cache] and updating the local, in-memory cache when the request)
- [x] upon log out, remove all cached responses (persisted and local, in-memory ones) containing for signed URLs (those containing `?_user=` tokens that may or may not contain user data)
- [x] allow local setting (`offline_cache_enabled`) and query-string parameter (`?cache=false`) to disable caching
- [x] allow cache to be disabled, reenabled, and cleared from the debug page
- [x] use a whitelist for only relevant API endpoints (i.e., not search results, ratings, etc.)
- [x] use an LRU cache (allowing each whitelisted API URL to have a different TTL)
- [x] figure out a way to expire model cache (consider whitelisting + LRU cache like we're doing for request cache; because the model cache gets rewritten whenever the request cache gets updated, this is not a huge concern but if there are models in the persisted model cache that we never end up using [e.g., a featured app gets removed from the homepage], then we're wasting space [albeit not a huge ton])
- [ ] use localForage instead of localStorage
- [x] add tests
- [ ] enhancement for later: move background XHRs to a web worker
