### PR TITLE
refactor lightbox navigation to preserve scroll (bug 979506)

### DIFF
--- a/hearth/media/js/lightbox.js
+++ b/hearth/media/js/lightbox.js
@@ -1,6 +1,6 @@
 define('lightbox',
-    ['keys', 'models', 'utils', 'shothandles', 'tracking', 'underscore', 'z'],
-    function(keys, models, utils, handles, tracking, _, z) {
+    ['keys', 'models', 'navigation', 'utils', 'shothandles', 'tracking', 'underscore', 'z'],
+    function(keys, models, navigation, utils, handles, tracking, _, z) {
 
     var $lightbox = $(document.getElementById('lightbox'));
     var $section = $lightbox.find('section');
@@ -41,9 +41,7 @@ define('lightbox',
             renderPreviews();
         }
 
-        // Set an anchor so the back button closes the lightbox instead of
-        // navigating.
-        window.location.hash = 'lightbox';
+        navigation.modal('lightbox');
 
         // Fade that bad boy in.
         z.body.addClass('overlayed');
@@ -163,10 +161,7 @@ define('lightbox',
             slider = null;
         }
 
-        // Remove the hash addition from the history.
-        if (location.hash == '#lightbox') {
-            history.back();
-        }
+        navigation.closeModal('lightbox');
     }
 
     // We need to adjust the scroll distances on resize.

--- a/hearth/media/js/navigation.js
+++ b/hearth/media/js/navigation.js
@@ -230,8 +230,29 @@ define('navigation',
         return false;
     });
 
+    function modal(name) {
+        console.log('Opening modal', name);
+        stack[0].scrollTop = window.pageYOffset;
+        stack[0].docHeight = z.doc.height();
+        history.replaceState(stack[0], false, stack[0].path);
+        history.pushState(null, name, '#' + name);
+        var path = window.location.href + '#' + name;
+        stack.unshift({path: path, type: 'modal', name: name});
+    }
+
+    function closeModal(name) {
+        if (stack[0].type === 'modal' && stack[0].name === name) {
+            console.log('Closing modal', name);
+            back();
+        } else {
+            console.log('Attempted to close modal', name, 'that was not open');
+        }
+    }
+
     return {
         'back': back,
+        'modal': modal,
+        'closeModal': closeModal,
         'stack': function() {return stack;},
         'navigationFilter': navigationFilter
     };


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=979506

Fixes a bug that caused the page to scroll to top after closing the lightbox.
