### PR TITLE
defer loading of persona include.js (bug 983556)

### DIFF
--- a/hearth/index.html
+++ b/hearth/index.html
@@ -71,7 +71,7 @@
       </section>
     </div>
 
-    <script src="https://login.persona.org/include.js"></script>
+    <script async src="https://login.persona.org/include.js"></script>
     <script src="/media/js/l10n.js"></script>
     <script data-main="/media/js/marketplace" src="/media/js/lib/require.js"></script>
 

--- a/hearth/media/css/header.styl
+++ b/hearth/media/css/header.styl
@@ -235,6 +235,7 @@
     }
     // 'Sign In'
     &.persona {
+        cursor: wait;
         display: none;
         margin-left: 15px;
         word-break: keep-all;
@@ -250,6 +251,10 @@
             }
         }
     }
+}
+
+.persona-loaded .header-button.persona {
+    cursor: pointer;
 }
 
 // On hover the settings gear icon should turn blue.

--- a/hearth/media/js/capabilities.js
+++ b/hearth/media/js/capabilities.js
@@ -23,15 +23,15 @@ define('capabilities', [], function() {
         'firefoxOS': navigator.mozApps && navigator.mozApps.installPackage &&
                      navigator.userAgent.indexOf('Android') === -1 &&
                      navigator.userAgent.indexOf('Mobile') !== -1,
-        'persona': !!navigator.id,
+        'persona': function() { return !!navigator.id; },
         'phantom': navigator.userAgent.match(/Phantom/)  // Don't use this if you can help it.
     };
 
-    static_caps.persona = !!navigator.id && !static_caps.phantom;
+    static_caps.persona = function() { return !!navigator.id && !static_caps.phantom; };
 
     // True if the login should inherit mobile behaviors such as allowUnverified.
     // The _shimmed check is for B2G where identity is native (not shimmed).
-    static_caps.mobileLogin = static_caps.persona && (!navigator.id._shimmed || static_caps.firefoxAndroid);
+    static_caps.mobileLogin = function() { return static_caps.persona() && (!navigator.id._shimmed || static_caps.firefoxAndroid) };
 
     static_caps.device_type = function() {
         if (static_caps.firefoxOS) {

--- a/hearth/media/js/settings.js
+++ b/hearth/media/js/settings.js
@@ -105,6 +105,9 @@ define('settings', ['l10n', 'settings_local', 'underscore'], function(l10n, sett
         // The Persona unverified issuer origin. Used by login.js.
         persona_unverified_issuer: 'login.persona.org',
 
+        // How long to wait before giving up on loading Persona's include.js.
+        persona_timeout: 30000,  // 30 seconds
+
         // The string to suffix page titles with. Used by builder.js.
         title_suffix: 'Firefox Marketplace',
 


### PR DESCRIPTION
1. When the page first loads, and if the user was not already signed in, we set `cursor: wait` for the "Sign in" link so it's clear that the user is in some holding pattern. (I haven't been able to see this, even on my crappy Comcast connection, unless I'm proxying Persona through a delayer.)
2. We check if Persona has been loaded every 25 milliseconds (simple `'id' in navigator` check).
   
   a. If Persona loads within the 30 seconds, we resolve the deferred and let the user sign in (i.e., we call `navigator.id.watch`).
   b. If Persona times out after 30 seconds, we reject the deferred and pop up a notification telling the user that Persona is responsive.

Feel free to test this locally with [http://deelay.me/5000/http://login.persona.org/include.js](http://deelay.me/5000/http://login.persona.org/include.js) to simulate a slow Persona load.
