### PR TITLE
Don't populate the search box with the category name (Bug 982668)

### DIFF
--- a/hearth/media/js/views/featured.js
+++ b/hearth/media/js/views/featured.js
@@ -11,7 +11,7 @@ define('views/featured', ['urls', 'z'], function(urls, z) {
         }
 
         builder.z('type', 'search');
-        builder.z('search', params.name || category);
+        builder.z('search', params.name);
         builder.z('title', params.name || category);
 
         builder.start('featured.html', {


### PR DESCRIPTION
In [Bug 982668](https://bugzilla.mozilla.org/show_bug.cgi?id=982668), it is noted that the search box gets populated with the category name after clicking the 'View All' link on a featured app collection. This should prevent that from happening.
