### PR TITLE
Prevent rendering when closing lightbox (bug 979506)

### DIFF
--- a/hearth/media/js/lightbox.js
+++ b/hearth/media/js/lightbox.js
@@ -147,6 +147,11 @@ define('lightbox',
     }
 
     function hideLightbox() {
+        navigation.closeModal('lightbox');
+        closeLightbox();
+    }
+
+    function closeLightbox() {
         z.body.removeClass('overlayed');
         pauseVideos();
         $lightbox.removeClass('show');
@@ -160,8 +165,6 @@ define('lightbox',
             slider.destroy();
             slider = null;
         }
-
-        navigation.closeModal('lightbox');
     }
 
     // We need to adjust the scroll distances on resize.
@@ -183,5 +186,10 @@ define('lightbox',
 
     // Hide screenshot overlay on back button hit.
     z.win.on('navigating', hideLightbox);
+    z.win.on('closeModal', function (e, modalName) {
+        if (modalName === 'lightbox') {
+            closeLightbox();
+        }
+    });
 
 });

--- a/hearth/media/js/navigation.js
+++ b/hearth/media/js/navigation.js
@@ -222,8 +222,13 @@ define('navigation',
         }
         var state = e.originalEvent.state;
         if (state) {
-            console.log('popstate navigate');
-            navigate(state.path, true, state);
+            if (state.closeModalName) {
+                console.log('popstate closing modal');
+                cleanupModal(state.closeModalName);
+            } else {
+                console.log('popstate navigate');
+                navigate(state.path, true, state);
+            }
         }
     }).on('submit', 'form', function() {
         console.error("Form submissions are not allowed.");
@@ -232,18 +237,23 @@ define('navigation',
 
     function modal(name) {
         console.log('Opening modal', name);
-        stack[0].scrollTop = window.pageYOffset;
-        stack[0].docHeight = z.doc.height();
+        stack[0].closeModalName = name;
         history.replaceState(stack[0], false, stack[0].path);
         history.pushState(null, name, '#' + name);
         var path = window.location.href + '#' + name;
         stack.unshift({path: path, type: 'modal', name: name});
     }
 
+    function cleanupModal(name) {
+        stack.shift();
+        delete stack[0].closeModalName;
+        z.win.trigger('closeModal', name);
+    }
+
     function closeModal(name) {
         if (stack[0].type === 'modal' && stack[0].name === name) {
             console.log('Closing modal', name);
-            back();
+            history.back();
         } else {
             console.log('Attempted to close modal', name, 'that was not open');
         }


### PR DESCRIPTION
Continued from #396. https://bugzilla.mozilla.org/show_bug.cgi?id=979506

@cvan found a bug that caused the history to not be removed. This fixes that bug and also prevents the scroll-to-top by preventing the render instead of resetting the scroll position.
