### PR TITLE
fix extract_nav_url so nav scroll is correctly preserved (bug 986718)

### DIFF
--- a/hearth/media/js/navigation.js
+++ b/hearth/media/js/navigation.js
@@ -22,9 +22,10 @@ define('navigation',
             return url;
         }
 
-        var used_params = _.pick(utils.querystring(url), settings.param_whitelist);
         // We can't use urlparams() because that only extends, not replaces.
-        return utils.baseurl(url) + '?' + utils.urlencode(used_params);
+        var used_params = _.pick(utils.querystring(url), settings.param_whitelist);
+        var queryParams = utils.urlencode(used_params);
+        return utils.baseurl(url) + (queryParams.length ? '?' + queryParams : '');
     }
 
     function canNavigate() {
@@ -254,7 +255,8 @@ define('navigation',
         'modal': modal,
         'closeModal': closeModal,
         'stack': function() {return stack;},
-        'navigationFilter': navigationFilter
+        'navigationFilter': navigationFilter,
+        'extract_nav_url': extract_nav_url
     };
 
 });

--- a/hearth/templates/tests.html
+++ b/hearth/templates/tests.html
@@ -22,6 +22,7 @@
 <script type="text/javascript" src="/tests/cache.js"></script>
 <script type="text/javascript" src="/tests/l10n.js"></script>
 <script type="text/javascript" src="/tests/mobilenetwork.js"></script>
+<script type="text/javascript" src="/tests/navigation.js"></script>
 <script type="text/javascript" src="/tests/models.js"></script>
 <script type="text/javascript" src="/tests/requests.js"></script>
 <script type="text/javascript" src="/tests/rewriters.js"></script>

--- a/hearth/tests/navigation.js
+++ b/hearth/tests/navigation.js
@@ -1,0 +1,12 @@
+(function() {
+  var a = require('assert');
+  var assert = a.assert;
+  var eq_ = a.eq_;
+
+  var navigation = require('navigation');
+  test('navigation url extraction', function(done) {
+      eq_(navigation.extract_nav_url('/foo/bar?src=all-popular'), '/foo/bar');
+      eq_(navigation.extract_nav_url('/foo/bar?src=all-popular&q=bar'), '/foo/bar?q=bar');
+      done();
+  });
+})();


### PR DESCRIPTION
I noticed looking at the scroll perf - that scroll restoration isn't working pressing back after going to reviews from a details page.

Further investigation showed that the `extract_nav_url` function erroneously returns urls like `/foo/bar?` when no whitelisted url params are present. This results in an extra nav stack entry which then has no scrollTop property hence pressing back cannot restore the scroll.
