### PR TITLE
ignore vim droppings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.po.js
 *.pyc
 *.styl.css
-*.swp
+*.sw*
 *~
 .#*
 .DS_Store


### PR DESCRIPTION
Ignore `*.sw*` to avoid collecting vim droppings.
