### PR TITLE
Improve scroll restoration perf (bug 986625)

### DIFF
--- a/hearth/media/js/navigation.js
+++ b/hearth/media/js/navigation.js
@@ -10,7 +10,6 @@ define('navigation',
         {path: '/', type: 'root'}
     ];
     var initialized = false;
-    var scrollTimer;
 
     function extract_nav_url(url) {
         // This function returns the URL that we should use for navigation.
@@ -60,26 +59,18 @@ define('navigation',
 
         var top = 0;
         if ((state.preserveScroll || popped) && state.scrollTop) {
-            if (state.docHeight) {
-                // Preserve document min-height for scroll restoration.
-                z.body.css('min-height', state.docHeight);
-                z.page.one('loaded', function() {
-                    // Remove specified min-height.
-                    z.body.css('min-height', '');
-                });
-            }
+            // Preserve document min-height for scroll preservation
+            // (e.g. when scroll pos should not change).
+            z.body.css('min-height', state.docHeight);
+            z.page.one('loaded', function() {
+                // Remove specified min-height.
+                z.body.css('min-height', '');
+            });
             top = state.scrollTop;
         }
 
-        // Introduce small delay to ensure content
-        // is ready to scroll. (Bug 976466)
-        if (scrollTimer) {
-            window.clearTimeout(scrollTimer);
-        }
-        scrollTimer = window.setTimeout(function() {
-            console.log('Setting scroll to', top);
-            window.scrollTo(0, top);
-        }, 250);
+        console.log('Setting scroll immediately to ', top);
+        window.scrollTo(0, top);
 
         // Clean the path's parameters.
         // /foo/bar?foo=bar&q=blah -> /foo/bar?q=blah


### PR DESCRIPTION
I've experimented with removing ~~the min-height changes as well as~~ the setTimeout and this looks to work both on Inari (B2G 1.2) and FF Android 28.0.1.  

I suspect the situation has been greatly improved by some of the perf work going on. (seems to still be working post removal of the deferred-image loading from a quick test).

This will need some really detailed QA to make sure across all devices we don't have any issues.

If you're reviewing this please spin this up and run on as many device you can lay your hands on :)
