### PR TITLE
Wrap scrollTo in setTimeout for android (bug 986625)

### DIFF
--- a/hearth/media/js/navigation.js
+++ b/hearth/media/js/navigation.js
@@ -10,6 +10,7 @@ define('navigation',
         {path: '/', type: 'root'}
     ];
     var initialized = false;
+    var scrollTimer;
 
     function extract_nav_url(url) {
         // This function returns the URL that we should use for navigation.
@@ -71,8 +72,20 @@ define('navigation',
             top = state.scrollTop;
         }
 
-        console.log('Setting scroll immediately to ', top);
-        window.scrollTo(0, top);
+        // For android a small delay is required.
+        if (capabilities.firefoxAndroid) {
+            if (scrollTimer) {
+                window.clearTimeout(scrollTimer);
+            }
+            scrollTimer = window.setTimeout(function() {
+                console.log('Setting scroll to', top);
+                window.scrollTo(0, top);
+            }, 250);
+        // For everything else we scroll immediately.
+        } else {
+            console.log('Setting scroll immediately to ', top);
+            window.scrollTo(0, top);
+        }
 
         // Clean the path's parameters.
         // /foo/bar?foo=bar&q=blah -> /foo/bar?q=blah


### PR DESCRIPTION
Testing bug 986625 which removed the setTimeout around scrollTo(0, x) I'm seeing intermittent issues on Android removing the setTimeout on data connections. This adds it back but this time just for android.

~~Once image loading is deferred again we can look at removing this again.~~ That's back this still fails.
