### PR TITLE
Reset cache for the direct endpoint to the review when editing one (bug 987557)

### DIFF
--- a/hearth/media/js/views/app/ratings/edit.js
+++ b/hearth/media/js/views/app/ratings/edit.js
@@ -1,6 +1,6 @@
 define('views/app/ratings/edit',
-    ['l10n', 'notification', 'ratings', 'requests', 'settings', 'urls', 'user', 'utils', 'z'],
-    function(l10n, notification, ratings, requests, settings, urls, user, utils, z) {
+    ['cache', 'l10n', 'notification', 'ratings', 'requests', 'settings', 'urls', 'user', 'utils', 'z'],
+    function(cache, l10n, notification, ratings, requests, settings, urls, user, utils, z) {
 
     var gettext = l10n.gettext;
     var notify = notification.notification;
@@ -9,21 +9,19 @@ define('views/app/ratings/edit',
     z.page.on('submit', '.edit-review-form', function(e) {
         e.preventDefault();
         var $this = $(this);
-        var uri = $this.data('uri');
+        var resource_uri = $this.data('uri');
+        var uri = settings.api_url + urls.api.sign(resource_uri);
         var slug = $this.data('slug');
         var _data = utils.getVars($this.serialize());
 
         forms.toggleSubmitFormState($this);
 
-        requests.put(
-            settings.api_url + urls.api.sign(uri),
-            _data
-        ).done(function() {
+        requests.put(uri, _data).done(function(_data) {
             notify({message: gettext('Review updated successfully')});
-
+            cache.set(uri, _data);
             ratings._rewriter(slug, function(data) {
                 for (var i = 0; i < data.objects.length; i++) {
-                    if (data.objects[i].resource_uri === uri) {
+                    if (data.objects[i].resource_uri === resource_uri) {
                         data.objects[i].body = _data.body;
                         data.objects[i].rating = _data.rating;
                     }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=987557

This is needed because the ratings._rewriter below only works for the `app=slug, user=mine` endpoint, and reviewers use the direct URI to the review instead.
