### PR TITLE
Use fireplace-specific endpoint for collections (bug 989331)

### DIFF
--- a/hearth/media/js/routes_api.js
+++ b/hearth/media/js/routes_api.js
@@ -3,7 +3,7 @@ define('routes_api', [], function() {
         'app': '/api/v1/fireplace/app/{0}/?cache=1&vary=0',
         'app/privacy': '/api/v1/apps/app/{0}/privacy/?cache=1&vary=0',
         'category': '/api/v1/fireplace/search/featured/?cat={0}&cache=1&vary=0',
-        'collection': '/api/v1/rocketfuel/collections/{0}/?cache=1&vary=0',
+        'collection': '/api/v1/fireplace/collection/{0}/?cache=1&vary=0',
         'reviews': '/api/v1/apps/rating/',
         'review': '/api/v1/apps/rating/{0}/',
         'settings': '/api/v1/account/settings/mine/',


### PR DESCRIPTION
This endpoint was added in mozilla/zamboni@f780902

https://bugzilla.mozilla.org/show_bug.cgi?id=989331
