### PR TITLE
Fix bug 992342 by updating cached value

### DIFF
--- a/hearth/media/js/cache.js
+++ b/hearth/media/js/cache.js
@@ -118,7 +118,7 @@ define('cache',
         for (var i = 0, rw; rw = rewriters[i++];) {
             var output = rw(key, value, cache);
             if (output === null) {
-                return;
+                break;
             } else if (output) {
                 value = output;
             }


### PR DESCRIPTION
This took a long time to find one word to change. By returning early, we weren't updating the cached value, and we were always returning early if it wasn't the subsequent page of multi-page search results. By using break instead of return we get to the cache update each time.

I'd like to rewrite the iteration through the rewriters to be clearer, and the rewriters themselves to return the original string instead of null when there is nothing to rewrite, but that is a separate issue.
