### PR TITLE
revert change

### DIFF
--- a/hearth/media/js/cache.js
+++ b/hearth/media/js/cache.js
@@ -118,7 +118,7 @@ define('cache',
         for (var i = 0, rw; rw = rewriters[i++];) {
             var output = rw(key, value, cache);
             if (output === null) {
-                break;
+                return;
             } else if (output) {
                 value = output;
             }


### PR DESCRIPTION
to unbreak build until I understand why cacheing is implemented the way it is
