### PR TITLE
Let devs install a hosted app locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,17 @@ the subset of keys found in
 make test
 ```
 
-## Local Development With Nginx
+## Local Development
+
+The packaging section above will explain how to build a package from your local
+source. If you want to install a hosted version of your local Fireplace you
+can do so. It won't have all the same privileges as the packaged app but it
+can let you test device-specific things like payments.
+
+To install as a hosted app, start the damper server (see Usage), and
+use this manifest:
+[http://0.0.0.0:8675/hosted-manifest.webapp](http://0.0.0.0:8675/hosted-manifest.webapp).
+
+### Setting up a virtual host with Nginx
 
 See [Using Fireplace with Zamboni](https://github.com/mozilla/fireplace/wiki/Using-Fireplace-with-Zamboni)

--- a/hearth/hosted-manifest.webapp
+++ b/hearth/hosted-manifest.webapp
@@ -1,0 +1,43 @@
+{
+  "activities": {
+    "marketplace-search": {"href": "/index.html"},
+    "marketplace-category": {"href": "/index.html"},
+    "marketplace-app": {"href": "/index.html"},
+    "marketplace-app-rating": {"href": "/index.html"}
+  },
+  "default_locale": "en-US",
+  "description": "Firefox Marketplace",
+  "developer": {
+    "name": "Mozilla",
+    "url": "http://mozilla.org"
+  },
+  "icons": {
+    "60": "/app-icons/60.png",
+    "90": "/app-icons/90.png",
+    "120": "/app-icons/120.png",
+    "128": "/app-icons/128.png"
+  },
+  "launch_path": "/index.html",
+  "locales": {
+    "bg": {},
+    "ca": {},
+    "cs": {},
+    "de": {},
+    "el": {},
+    "en-US": {},
+    "es": {},
+    "eu": {},
+    "fr": {},
+    "ga-IE": {},
+    "hr": {},
+    "hu": {},
+    "it": {},
+    "pl": {},
+    "tr": {},
+    "zh-TW": {}
+  },
+  "name": "Marketplace",
+  "orientation": ["portrait-primary"],
+  "type": "web",
+  "version": "hosted-version"
+}

--- a/hearth/media/js/marketplace.js
+++ b/hearth/media/js/marketplace.js
@@ -65,7 +65,7 @@ function(_) {
     // Use Native Persona, if it's available.
     if (capabilities.firefoxOS && 'mozId' in navigator && navigator.mozId !== null) {
         console.log('Native Persona is available');
-        navigator.id = navigator.mozId;
+        window.navigator.id = navigator.id = navigator.mozId;
     }
 
     if (!capabilities.performance) {


### PR DESCRIPTION
This allows developers to install Marketplace
as a hosted app within desktop B2G for local
development. I know not everything will work
but this is essential for payments since we
need navigator.mozPay().
