### PR TITLE
fix for bug 985737, relies on PR 82 on legal-docs

### DIFF
--- a/hearth/media/js/builder.js
+++ b/hearth/media/js/builder.js
@@ -248,6 +248,11 @@ define('builder',
                     });
                 } else {
                     var done = function(data) {
+                        if (signature.filters){
+                            signature.filters.forEach(function(filterName){
+                                data = env.filters[filterName](data);
+                            });
+                        }
                         document.getElementById(uid).innerHTML = data;
                     };
                     request.done(done).fail(function() {

--- a/hearth/media/js/helpers_local.js
+++ b/hearth/media/js/helpers_local.js
@@ -1,0 +1,40 @@
+define('helpers_local', ['nunjucks', 'z'], function(nunjucks, z) {
+    var filters = nunjucks.require('filters');
+    var globals = nunjucks.require('globals');
+
+   var rewriteCdnUrlMappings = [
+        {
+            name: 'Privacy Policy',
+            pattern: /\/media\/docs\/privacy\/.+\.html/g,
+            replacement: '/privacy-policy'
+        },
+        {
+            name: 'Terms of Use',
+            pattern: /\/media\/docs\/terms\/.+\.html/g,
+            replacement: '/terms-of-use'
+        }
+    ];
+
+    // When we get a page back from legal docs stored on the CDN, we
+    // need to rewrite them to work locally within a packaged version
+    // of Marketplace.
+    filters.rewriteCdnUrls = function(text){
+        rewriteCdnUrlMappings.forEach(function(mapping){
+            text = text.replace(mapping.pattern, mapping.replacement);
+        });
+        return text;
+    };
+
+    // Functions provided in the default context.
+    var helpers = {
+    };
+
+    // Put the helpers into the nunjucks global.
+    for (var i in helpers) {
+        if (helpers.hasOwnProperty(i)) {
+            globals[i] = helpers[i];
+        }
+    }
+
+    return helpers;
+});

--- a/hearth/media/js/marketplace.js
+++ b/hearth/media/js/marketplace.js
@@ -25,6 +25,7 @@ define(
         'underscore',
         'jquery',
         'helpers',  // Must come before mostly everything else.
+        'helpers_local',
         'buttons',
         'cache',
         'capabilities',

--- a/hearth/templates/privacy.html
+++ b/hearth/templates/privacy.html
@@ -5,7 +5,7 @@
   <article class="island prose">
     {% set url = '/docs/privacy/' + language + '.html?20140425' %}
     {% set fallback = '/docs/privacy/' + settings.default_locale + '.html?20140425' %}
-    {% fetch (url=media(url), fallback=media(fallback)) %}
+    {% fetch (url=media(url), fallback=media(fallback), filters=['rewriteCdnUrls']) %}
       <p class="spinner spaced alt"></p>
     {% endfetch %}
   </article>

--- a/hearth/templates/terms.html
+++ b/hearth/templates/terms.html
@@ -5,7 +5,7 @@
   <article class="island prose">
     {% set url = '/docs/terms/' + language + '.html?20140425' %}
     {% set fallback = '/docs/terms/' + settings.default_locale + '.html?20140425' %}
-    {% fetch (url=media(url), fallback=media(fallback)) %}
+    {% fetch (url=media(url), fallback=media(fallback), filters=['rewriteCdnUrls']) %}
       <p class="spinner spaced alt"></p>
     {% endfetch %}
   </article>


### PR DESCRIPTION
This is a bit of a hack, rewriting URLs for all uses of {% fetch %}, but for the time being the only places we use {% fetch %} is for legal docs that need their URLs rewritten. Happy to field suggestions for cleaner ways of doing this.

Note that I have tested the URL remapping manually on the legal docs in github, but need those to be [deployed](https://github.com/mozilla/legal-docs/pull/82) to the CDN before it can actually be tested in fireplace properly.
