### PR TITLE
Don't populate the search box with the category name (Bug 982668)

### DIFF
--- a/hearth/media/js/views/featured.js
+++ b/hearth/media/js/views/featured.js
@@ -11,7 +11,7 @@ define('views/featured', ['urls', 'z'], function(urls, z) {
         }
 
         builder.z('type', 'search');
-        builder.z('search', params.name || category);
+        builder.z('search', params.name);
         builder.z('title', params.name || category);
 
         builder.start('featured.html', {


### PR DESCRIPTION
Testing if this can merge without breaking the build after rebasing.
