### PR TITLE
Change 'Not yet rated' wording (bug 1003919)

### DIFF
--- a/hearth/templates/_macros/market_tile.html
+++ b/hearth/templates/_macros/market_tile.html
@@ -58,6 +58,8 @@
             {{ iarc_names.ratings[app.content_ratings.body][app.content_ratings.rating] }}
           {% endif %}
         </div>
+      {% else %}
+        <div class="content-rating lineclamp vital subdetail">{{ _('Not yet rated') }}</div>
       {% endif %}
       <div class="price vital">{{ app.price_locale if app.payment_required else _('Free') }}</div>
       {{ market_button(app, classes=(['paid'] if app.payment_required),
@@ -78,7 +80,7 @@
         {% else %}
           {# L10n: "(0)" means "0 reviews." #}
           <span class="cnt short">{{ _('(0)') }}</span>
-          <span class="cnt long">{{ _('Not yet rated') }}</span>
+          <span class="cnt long">{{ _('Not yet reviewed') }}</span>
         {% endif %}
         {% if not link %}</a>{% endif %}
       </div>

--- a/hearth/templates/detail/main.html
+++ b/hearth/templates/detail/main.html
@@ -143,7 +143,7 @@
         </div>
       {% else %}
         <p class="not-rated">
-          {{ _('App not yet rated') }}
+          {{ _('App not yet reviewed') }}
         </p>
       {% endif %}
       {% if has_second_button %}


### PR DESCRIPTION
This is to disambiguate between app reviews and content ratings.
