### PR TITLE
implement startup loading events (bug 1024014)

### DIFF
--- a/hearth/media/js/marketplace.js
+++ b/hearth/media/js/marketplace.js
@@ -44,6 +44,8 @@ define(
         'navigation',
         'outgoing_links',
         'overlay',
+        'perf_events',
+        'perf_helper',
         'previews',
         'ratings',
         'requests',
@@ -113,6 +115,7 @@ function(_) {
         var splash = $('#splash-overlay').addClass('hide');
         z.body.removeClass('overlayed').addClass('loaded');
         setTimeout(function() {
+            z.page.trigger('splash_removed');
             splash.remove();
         }, 1500);
     });
@@ -141,6 +144,7 @@ function(_) {
                 buttons.buttonInstalled(
                     require('utils').baseurl(val.manifestURL), val);
             });
+            z.page.trigger('mozapps_got_installed');
         };
     };
     if (capabilities.webApps) {

--- a/hearth/media/js/perf_events.js
+++ b/hearth/media/js/perf_events.js
@@ -1,0 +1,65 @@
+/* developer.mozilla.org/Apps/Build/Performance/Firefox_OS_app_responsiveness_guidelines */
+define('perf_events', ['z'], function(z) {
+    'use strict';
+
+    var splash_removed = false;
+    var mozapps_got_installed = false;
+    var app_loaded = false;
+
+    // PerformanceTestHelper events.
+    /*
+    z.page.one('reloaded_chrome', function() {
+        // Emit this event when your application designates that its core
+        // chrome or navigation interface exists in the DOM.
+        console.log('-moz-chrome-dom-loaded');
+        window.dispatchEvent(new CustomEvent('moz-chrome-dom-loaded'));
+    })
+    .one('build_start', function() {
+        // Emit this event when your application designates that the core
+        // chrome or navigation interface has its events bound and is ready for
+        // user interation.
+        console.log('-moz-chrome-interactive');
+        window.dispatchEvent(new CustomEvent('moz-chrome-interactive'));
+    })
+    .one('loaded', function() {
+        // Emit this event when your application designates that it is visually
+        // loaded.
+        console.log('-moz-visually-complete');
+        window.dispatchEvent(new CustomEvent('moz-app-visually-complete'));
+    })
+    */
+
+    z.page.one('splash_removed', function() {
+        console.log('-moz-content-interactive');
+        splash_removed = true;
+
+        // Only once splash is removed can stuff be done.
+        window.dispatchEvent(new CustomEvent('moz-chrome-dom-loaded'));
+        window.dispatchEvent(new CustomEvent('moz-chrome-interactive'));
+        window.dispatchEvent(new CustomEvent('moz-app-visually-complete'));
+
+        // Emit this event when your application designates that it has bound
+        // the events for the minimum set of functionality to allow the user to
+        // interact with the "above-the-fold" content.
+        window.dispatchEvent(new CustomEvent('moz-content-interactive'));
+
+        if (mozapps_got_installed && !app_loaded) {
+            // Emit this event when your application has been completely
+            // loaded.
+            console.log('-moz-app-loaded');
+            app_loaded = true;
+            window.dispatchEvent(new CustomEvent('moz-app-loaded'));
+        }
+    })
+    .one('mozapps_got_installed', function() {
+        mozapps_got_installed = true;
+
+        if (splash_removed && !app_loaded) {
+            // Emit this event when your application has been completely
+            // loaded.
+            console.log('-moz-app-loaded');
+            app_loaded = true;
+            window.dispatchEvent(new CustomEvent('moz-app-loaded'));
+        }
+    });
+});

--- a/hearth/media/js/perf_helper.js
+++ b/hearth/media/js/perf_helper.js
@@ -1,0 +1,39 @@
+/* Adapted from
+   https://raw.githubusercontent.com/mozilla-b2g/gaia/master/shared/js/performance_testing_helper.js */
+define('perf_helper', [], function() {
+    'use strict';
+
+     function dispatch(name) {
+       if (!window.mozPerfHasListener) {
+         return;
+       }
+
+       var now = window.performance.now();
+
+       setTimeout(function() {
+         var detail = {
+           name: name,
+           timestamp: now
+         };
+         var event = new CustomEvent('x-moz-perf', { detail: detail });
+
+         window.dispatchEvent(event);
+       });
+     }
+
+     [
+       'moz-chrome-dom-loaded',
+       'moz-chrome-interactive',
+       'moz-app-visually-complete',
+       'moz-content-interactive',
+       'moz-app-loaded'
+     ].forEach(function(eventName) {
+         window.addEventListener(eventName, function mozPerfLoadHandler() {
+           dispatch(eventName);
+         }, false);
+       });
+
+     window.PerformanceTestingHelper = {
+       dispatch: dispatch
+     };
+});


### PR DESCRIPTION
The docs are at https://developer.mozilla.org/en-US/Apps/Build/Performance/Firefox_OS_app_responsiveness_guidelines

There some ambiguity in what the events mean especially since we show the splash screen up until everything is loaded. I decided to just trigger/group some of the events together once the splash screen is loaded.
