### PR TITLE
allow half-stars in aggregate ratings (bug 971205)

### DIFF
--- a/hearth/media/css/ratings.styl
+++ b/hearth/media/css/ratings.styl
@@ -179,18 +179,41 @@ select[name=rating] {
 }
 
 .stars {
-    background: url(../img/pretty/stars_small.svg) no-repeat;
+    background-color: $earl-gray;
+    clip-path: url("../img/pretty/stars_small.svg#stars-clip");
+    color: transparent;
     display: inline-block;
-    hidetext();
+    height: 12px;
     margin-right: 4px;
+    overflow: hidden;
+    position: relative;
+    text-indent: 101%;
+    white-space: nowrap;
     vertical-align: top;
-    width: 64px;
-    &.stars-4 { background-position: -13px 0; }
-    &.stars-3 { background-position: -26px 0; }
-    &.stars-2 { background-position: -39px 0; }
-    &.stars-1 { background-position: -52px 0; }
-    &.stars-0 { background-position: -65px 0; }
+    width: 65px;
+    &:after {
+        background-color: $sailor-blue;
+        content: "";
+        clip-path: url("../img/pretty/stars_small.svg#stars-clip");
+        display: inline-block;
+        height: 12px;
+        left: 0;
+        position: absolute;
+        top: 0;
+    }
+    &.stars-5:after   { width: 65px; }
+    &.stars-4-5:after { width: 59px; }
+    &.stars-4:after   { width: 52px; }
+    &.stars-3-5:after { width: 46px; }
+    &.stars-3:after   { width: 39px; }
+    &.stars-2-5:after { width: 33px; }
+    &.stars-2:after   { width: 26px; }
+    &.stars-1-5:after { width: 20px; }
+    &.stars-1:after   { width: 13px; }
+    &.stars-0-5:after { width:  7px; }
+    &.stars-0:after   { width:  0; }
 }
+
 
 .html-rtl .stars {
     margin: 0 0 0 4px;
@@ -198,15 +221,24 @@ select[name=rating] {
 
 tinyStars() {
     .stars {
-        background-size: auto 9px;
+        clip-path: url("../img/pretty/stars_small.svg#stars-small-clip");
         height: 9px;
-
-        &.stars-4 { background-position: -10px 0; }
-        &.stars-3 { background-position: -20px 0; }
-        &.stars-2 { background-position: -29px 0; }
-        &.stars-1 { background-position: -39px 0; }
-        &.stars-0 { background-position: -49px 0; }
-        width: 48px;
+        width: 48.75px;
+        &:after {
+            clip-path: url("../img/pretty/stars_small.svg#stars-small-clip");
+            height: 9px;
+        }
+        &.stars-5:after   { width: 48px; }
+        &.stars-4-5:after { width: 44px; }
+        &.stars-4:after   { width: 39px; }
+        &.stars-3-5:after { width: 34px; }
+        &.stars-3:after   { width: 29px; }
+        &.stars-2-5:after { width: 25px; }
+        &.stars-2:after   { width: 19px; }
+        &.stars-1-5:after { width: 15px; }
+        &.stars-1:after   { width: 10px; }
+        &.stars-0-5:after { width:  5px; }
+        &.stars-0:after   { width:  0; }
     }
 }
 

--- a/hearth/media/img/pretty/stars_small.svg
+++ b/hearth/media/img/pretty/stars_small.svg
@@ -1,20 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg width="130px" height="12px" viewBox="0 0 130 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+<svg width="65px" height="40px" viewBox="0 0 65 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>Review_Stars_regular</title>
-    <description>Created with Sketch (http://www.bohemiancoding.com/sketch)</description>
-    <defs></defs>
-    <g id="Assets" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Review_Stars_regular">
-            <path d="M32.4999999,9.75 L28.6793962,11.7586107 L29.4090664,7.50430536 L26.3181326,4.49138968 L30.5896985,3.87069432 L32.5000001,7.21644966e-16 L34.4103028,3.87069528 L38.6818684,4.49139277 L35.5909334,7.50430617 L36.3206037,11.7586108 L32.4999999,9.75 Z M32.4999999,9.75" id="Star 1" fill="#0096DD"></path>
-            <path d="M19.4999999,9.75 L15.6793962,11.7586107 L16.4090664,7.50430536 L13.3181326,4.49138968 L17.5896985,3.87069432 L19.5000001,7.21644966e-16 L21.4103028,3.87069528 L25.6818684,4.49139277 L22.5909334,7.50430617 L23.3206037,11.7586108 L19.4999999,9.75 Z M19.4999999,9.75" id="Star 1" fill="#0096DD"></path>
-            <path d="M6.49999986,9.75 L2.67939617,11.7586107 L3.40906636,7.50430536 L0.318132598,4.49138968 L4.58969854,3.87069432 L6.50000008,7.21644966e-16 L8.41030277,3.87069528 L12.6818684,4.49139277 L9.59093337,7.50430617 L10.3206037,11.7586108 L6.49999986,9.75 Z M6.49999986,9.75" id="Star 1" fill="#0096DD"></path>
-            <path d="M58.4999999,9.75 L54.6793962,11.7586107 L55.4090664,7.50430536 L52.3181326,4.49138968 L56.5896985,3.87069432 L58.5000001,7.21644966e-16 L60.4103028,3.87069528 L64.6818684,4.49139277 L61.5909334,7.50430617 L62.3206037,11.7586108 L58.4999999,9.75 Z M58.4999999,9.75" id="Star 1" fill="#0096DC"></path>
-            <path d="M45.4999999,9.75 L41.6793962,11.7586107 L42.4090664,7.50430536 L39.3181326,4.49138968 L43.5896985,3.87069432 L45.5000001,7.21644966e-16 L47.4103028,3.87069528 L51.6818684,4.49139277 L48.5909334,7.50430617 L49.3206037,11.7586108 L45.4999999,9.75 Z M45.4999999,9.75" id="Star 1" fill="#0096DD"></path>
-            <path d="M97.4999999,9.75 L93.6793962,11.7586107 L94.4090664,7.50430536 L91.3181326,4.49138968 L95.5896985,3.87069432 L97.5000001,7.21644966e-16 L99.4103028,3.87069528 L103.681868,4.49139277 L100.590933,7.50430617 L101.320604,11.7586108 L97.4999999,9.75 Z M97.4999999,9.75" id="Star 1" fill="#A7A7A7"></path>
-            <path d="M84.4999999,9.75 L80.6793962,11.7586107 L81.4090664,7.50430536 L78.3181326,4.49138968 L82.5896985,3.87069432 L84.5000001,7.21644966e-16 L86.4103028,3.87069528 L90.6818684,4.49139277 L87.5909334,7.50430617 L88.3206037,11.7586108 L84.4999999,9.75 Z M84.4999999,9.75" id="Star 1" fill="#A7A7A7"></path>
-            <path d="M71.4999999,9.75 L67.6793962,11.7586107 L68.4090664,7.50430536 L65.3181326,4.49138968 L69.5896985,3.87069432 L71.5000001,7.21644966e-16 L73.4103028,3.87069528 L77.6818684,4.49139277 L74.5909334,7.50430617 L75.3206037,11.7586108 L71.4999999,9.75 Z M71.4999999,9.75" id="Star 1" fill="#A7A7A7"></path>
-            <path d="M110.5,9.75 L106.679396,11.7586107 L107.409066,7.50430536 L104.318133,4.49138968 L108.589699,3.87069432 L110.5,7.21644966e-16 L112.410303,3.87069528 L116.681868,4.49139277 L113.590933,7.50430617 L114.320604,11.7586108 L110.5,9.75 Z M110.5,9.75" id="Star 1" fill="#A7A7A7"></path>
-            <path d="M123.5,9.75 L119.679396,11.7586107 L120.409066,7.50430536 L117.318133,4.49138968 L121.589699,3.87069432 L123.5,7.21644966e-16 L125.410303,3.87069528 L129.681868,4.49139277 L126.590933,7.50430617 L127.320604,11.7586108 L123.5,9.75 Z M123.5,9.75" id="Star 1" fill="#A7A7A7"></path>
-        </g>
-    </g>
+    <defs>
+        <path d="M6.5, 9.75 
+                 L2.68,11.76 
+                 L3.41,7.5 
+                 L0.32,4.49 
+                 L4.59,3.87 
+                 L6.5,0 
+                 L8.41,3.87 
+                 L12.68,4.49 
+                 L9.59,7.5 
+                 L10.32,11.75 
+                 L6.5,9.75 
+                 Z" id="star" fill="#000"></path>
+        <clipPath id="stars-clip">
+            <use xlink:href="#star" x="0" y="0" />
+            <use xlink:href="#star" x="13" y="0" />
+            <use xlink:href="#star" x="26" y="0" />
+            <use xlink:href="#star" x="39" y="0" />
+            <use xlink:href="#star" x="52" y="0" />
+        </clipPath>
+        <clipPath id="stars-small-clip">
+            <!-- Note: scaling applies to x and y as well as size -->
+            <use xlink:href="#star" x="0" y="0" transform="scale(0.75)" />
+            <use xlink:href="#star" x="13" y="0" transform="scale(0.75)" />
+            <use xlink:href="#star" x="26" y="0" transform="scale(0.75)" />
+            <use xlink:href="#star" x="39" y="0" transform="scale(0.75)" />
+            <use xlink:href="#star" x="52" y="0" transform="scale(0.75)" />
+        </clipPath>
+    </defs>
+    <!-- In normal use, we only refer to the clipPaths and there would be nothing visible
+         in this file. So below we use the stars to have a visible test. -->
+    <rect x="0" y="0" width="65" height="12" fill="#A7A7A7" clip-path="url(#stars-small-clip)" />
+    <rect x="0" y="0" width="32.5" height="12" fill="#0096DD" clip-path="url(#stars-small-clip)" />
+    <use xlink:href="#star" x="20" y="20" />
+    <use xlink:href="#star" x="35" y="20" transform="scale(0.75)" />
 </svg>

--- a/hearth/media/js/helpers_local.js
+++ b/hearth/media/js/helpers_local.js
@@ -31,6 +31,22 @@ define('helpers_local',
         return text;
     };
 
+    // We want to take a float and return a string of either the
+    // integer value or integer + .5, whichever is closest
+    filters.roundToNearestHalf = function(number) {
+        var intPart = Math.floor(number);
+        var floatPart = number - intPart;
+        if (floatPart < 0.25) {
+            floatPart = 0;
+        } else if (floatPart > 0.75) {
+            floatPart = 0;
+            intPart += 1;
+        } else {
+            floatPart = 0.5;
+        }
+        return '' + (intPart + floatPart);
+    };
+
     function has_installed(manifestURL) {
         return z.apps.indexOf(manifestURL) !== -1;
     }

--- a/hearth/templates/_macros/stars.html
+++ b/hearth/templates/_macros/stars.html
@@ -1,8 +1,7 @@
 {% macro stars(rating, detailpage=false, aggregate=True) %}
-  {% set rating = rating|round %}
   {% set rating_itemprop = 'ratingValue' if aggregate else 'reviewRating' %}
   <meta itemprop="worstRating" content="1">
-  <span class="stars{{ ' large' if detailpage }} large stars-{{ rating }}" title="{{ title }}">
+  <span class="stars{{ ' large' if detailpage }} large stars-{{ rating | roundToNearestHalf | replace(".", "-") }}" title="{{ title }}">
     {{ _('Rated {stars} out of {maxstars} stars',
          stars='<span itemprop="' + rating_itemprop + '">' + rating + '</span>',
          maxstars='<span itemprop="bestRating">5</span>') }}


### PR DESCRIPTION
This involved rewriting the SVG and applying it as a clipping path to a span (and a span:after) on the page using CSS. One span is the grey background, the other span is the blue background, both are overlaid on each other with the same clip path and depending on the number of stars to be show, the length of the blue one is changed.

Tested in both regular and small sizes (small only shows on mobile) in various views. The number of stars gets cached locally, so half-stars may not show up until the app is rated again.
