### PR TITLE
Do not force portrait orientation (bug 844186)

### DIFF
--- a/src/hosted-manifest.webapp
+++ b/src/hosted-manifest.webapp
@@ -40,7 +40,6 @@
       "zh-TW": {}
   },
   "name": "Marketplace",
-  "orientation": ["portrait-primary"],
   "type": "web",
   "version": "hosted-version"
 }

--- a/src/manifest.webapp
+++ b/src/manifest.webapp
@@ -40,7 +40,6 @@
     "zh-TW": {}
   },
   "name": "Marketplace",
-  "orientation": ["portrait-primary"],
   "origin": "app://packaged.marketplace.firefox.com",
   "permissions": {
     "mobilenetwork": {

--- a/yulelog/manifest.webapp
+++ b/yulelog/manifest.webapp
@@ -40,7 +40,6 @@
         "zh-TW": {}
     },
     "name": "Marketplace",
-    "orientation": ["portrait-primary"],
     "origin": "app://marketplace.firefox.com",
     "permissions": {
         "mobilenetwork": {"description": "To detect mobile carrier and regional information."}


### PR DESCRIPTION
The Fireplace part of this fix, to allow orientation to match device rather than forcing portrait orientation.
