### PR TITLE
change close button in active state (bug 979122)

### DIFF
--- a/src/media/css/header.styl
+++ b/src/media/css/header.styl
@@ -211,6 +211,10 @@
     width: 40px;
 }
 
+.close:active {
+    background: url(../img/pretty/close_active.svg) 50% no-repeat;
+}
+
 // Buttons that appear in headers.
 .header-button {
     color: $castle-skull-gray;


### PR DESCRIPTION
Not sure why the existing `close_active.svg` was not being added as a background to replace `close.svg` in active state, but this adds it.
