### PR TITLE
Don't wait on persona if we are using Firefox Accounts fallback (bug 1039868)

### DIFF
--- a/src/media/js/commonplace/capabilities.js
+++ b/src/media/js/commonplace/capabilities.js
@@ -26,6 +26,8 @@ define('capabilities', ['settings'], function(settings) {
         'phantom': navigator.userAgent.match(/Phantom/)  // Don't use this if you can help it.
     };
 
+    // Note: persona will be true for nativeFxA, since it uses the same JavaScript API.
+    // FallbackFxA uses a completely different path, though.
     static_caps.persona = function() {
         return ((!!navigator.id || !!navigator.mozId) &&
                 !static_caps.phantom &&

--- a/src/media/js/commonplace/login.js
+++ b/src/media/js/commonplace/login.js
@@ -3,6 +3,8 @@ define('login',
     function(cache, capabilities, defer, $, log, notification, settings, _, urls, user, utils, requests, z) {
 
     var console = log('login');
+    var persona_def = defer.Deferred();
+    var persona_loaded = persona_def.promise();
 
     var fxa_popup;
     var opt = {
@@ -24,12 +26,6 @@ define('login',
 
     function signInNotification() {
         notification.notification({message: gettext('You have been signed in')});
-    }
-
-    if (capabilities.fallbackFxA()) {
-        // This lets us change the cursor for the "Sign in" link. (We do this
-        // for Native FxA + Native Persona + Fallback Persona below.)
-        z.body.addClass('persona-loaded');
     }
 
     z.win.on('focus', function() {
@@ -205,71 +201,83 @@ define('login',
         });
     }
 
-    var persona_def = defer.Deferred();
-    var persona_loaded = persona_def.promise();
+    function loadPersona() {
+        var persona_loading_start = +(new Date());
+        var persona_loading_time = 0;
+        var persona_step = 25;  // 25 milliseconds
 
-    var persona_loading_start = +(new Date());
-    var persona_loading_time = 0;
-    var persona_step = 25;  // 25 milliseconds
+        // If we don't have navigator.id/mozId and the shim script is absent,
+        // we need to inject it.
+        if (!capabilities.persona() &&
+            !$('script[src="' + settings.persona_shim_url + '"]').length) {
+            var s = document.createElement('script');
+            s.async = true;
+            s.src = settings.persona_shim_url;
+            document.body.appendChild(s);
+        }
 
-    var GET = utils.getVars();
+        // Check for navigator.id/mozId every persona_step milliseconds to
+        // resolve (or reject if we waited too long) the promise.
+        var persona_interval = setInterval(function() {
+            persona_loading_time = +(new Date()) - persona_loading_start;
+            if (capabilities.persona()) {
+                console.log('Persona loaded (' + persona_loading_time / 1000 + 's)');
+                persona_def.resolve();
+                clearInterval(persona_interval);
+            } else if (persona_loading_time >= settings.persona_timeout) {
+                console.error('Persona timeout (' + persona_loading_time / 1000 + 's)');
+                persona_def.reject();
+                clearInterval(persona_interval);
+            }
+        }, persona_step);
 
-    var persona_shim_included = $('script[src="' + settings.persona_shim_url + '"]').length;
+        persona_loaded.done(function() {
+            // This lets us change the cursor for the "Sign in" link.
+            z.body.addClass('persona-loaded');
+            var opts;
+            var email = user.get_setting('email') || '';
+            if (email) {
+                console.log('Detected user', email);
+            } else {
+                console.log('No previous user detected');
+            }
 
-    // If for some reason Zamboni got `?nativepersona=true` but we actually
-    // don't have native Persona, then let's inject a script to load the shim.
-    if (!persona_shim_included && !capabilities.persona()) {
-        var s = document.createElement('script');
-        s.async = true;
-        s.src = settings.persona_shim_url;
-        document.body.appendChild(s);
+            if (capabilities.persona()) {
+                console.log('Calling navigator.id.watch');
+                opts = {
+                    loggedInUser: email,
+                    onready: function() {},
+                    onlogin: gotVerifiedEmail,
+                    onlogout: function() {
+                        z.body.removeClass('logged-in');
+                        z.page.trigger('reload_chrome').trigger('logout');
+                    }
+                };
+                if (capabilities.nativeFxA()) {
+                    opts.wantIssuer = 'firefox-accounts';
+                }
+                navigator.id.watch(opts);
+            }
+        }).fail(function() {
+            notification.notification({
+                message: gettext('Persona cannot be reached. Try again later.')
+            });
+        });
+
+        return persona_loaded;
     }
 
-    var persona_interval = setInterval(function() {
-        persona_loading_time = +(new Date()) - persona_loading_start;
-        if (capabilities.persona()) {
-            console.log('Persona loaded (' + persona_loading_time / 1000 + 's)');
-            persona_def.resolve();
-            clearInterval(persona_interval);
-        } else if (persona_loading_time >= settings.persona_timeout) {
-            console.error('Persona timeout (' + persona_loading_time / 1000 + 's)');
-            persona_def.reject();
-            clearInterval(persona_interval);
-        }
-    }, persona_step);
-
-    persona_loaded.done(function() {
-        // This lets us change the cursor for the "Sign in" link.
+    // Try to load persona.
+    if (!capabilities.fallbackFxA()) {
+        loadPersona();
+    } else {
+        // Fallback FxA doesn't use navigator.id, so we don't have anything to
+        // inject and can immediately add the "persona-loaded" class instead of
+        // waiting on the promise. This lets us change the cursor for the
+        // "Sign in" link.
+        persona_def.reject();
         z.body.addClass('persona-loaded');
-        var opts;
-        var email = user.get_setting('email') || '';
-        if (email) {
-            console.log('Detected user', email);
-        } else {
-            console.log('No previous user detected');
-        }
-
-        if (capabilities.persona()) {
-            console.log('Calling navigator.id.watch');
-            opts = {
-                loggedInUser: email,
-                onready: function() {},
-                onlogin: gotVerifiedEmail,
-                onlogout: function() {
-                    z.body.removeClass('logged-in');
-                    z.page.trigger('reload_chrome').trigger('logout');
-                }
-            };
-            if (capabilities.nativeFxA()) {
-                opts.wantIssuer = 'firefox-accounts';
-            }
-            navigator.id.watch(opts);
-        }
-    }).fail(function() {
-        notification.notification({
-            message: gettext('Persona cannot be reached. Try again later.')
-        });
-    });
+    }
 
     return {login: startLogin};
 });


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1039868

We'll also need a zamboni PR to not include the persona shim in the template if the waffle for firefox accounts is on, but that's [a different bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1038985), which is handled in mozilla/zamboni#2343.
