### PR TITLE
Add missing info about french region (flag, mcc detection) (bug 1043960)

### DIFF
--- a/package/files.txt
+++ b/package/files.txt
@@ -27,6 +27,7 @@ media/img/icons/regions/cr.png
 media/img/icons/regions/de.png
 media/img/icons/regions/ec.png
 media/img/icons/regions/es.png
+media/img/icons/regions/fr.png
 media/img/icons/regions/gr.png
 media/img/icons/regions/gt.png
 media/img/icons/regions/hu.png

--- a/src/media/css/site.styl
+++ b/src/media/css/site.styl
@@ -442,7 +442,7 @@ form span.region {
     text-overflow: normal;
 }
 
-for region in ar br cl cn co cr de ec es gr gt hu it me mx ni pa pe pl rs sv uk us uy ve restofworld
+for region in ar br cl cn co cr de ec es fr gr gt hu it me mx ni pa pe pl rs sv uk us uy ve restofworld
     .region-{region} {
         background-image: url(unquote('../img/icons/regions/' + region + '.png'));
     }

--- a/src/media/js/mobilenetwork.js
+++ b/src/media/js/mobilenetwork.js
@@ -54,7 +54,10 @@ define('mobilenetwork',
         460: 'cn',
 
         // Japan
-        440: 'jp'
+        440: 'jp',
+
+        // France
+        208: 'fr'
     };
 
     var carriers = [


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1043960

`REGION_CHOICES_SLUG` and zamboni already knows about this region, the image was already there, so we just needed to include it in the package and adjust the CSS.
