### PR TITLE
Add padding so flag works with web font (bug 987696)

### DIFF
--- a/src/media/css/site.styl
+++ b/src/media/css/site.styl
@@ -438,7 +438,7 @@ form span.region {
     margin-top: 6px;
     min-height: 20px;
     overflow: visible;
-    padding: 2px 0 0 28px;
+    padding: 2px 0 2px 28px;
     text-overflow: normal;
 }
 


### PR DESCRIPTION
This didn't show up with Fira Sans installed on my machine, but was reproducible when I uninstalled it and picked up the Fira Sans Web font. Just needed 2px of padding at the bottom to allow the background image to display.
