### PR TITLE
Link editorial brand titles (bug 1048515)

### DIFF
--- a/src/media/css/feed.styl
+++ b/src/media/css/feed.styl
@@ -186,6 +186,24 @@ $vertical-tile-margin = 10px;
     &.mkt-tile {
         position: relative;
     }
+    .feed-tile-header-wrap {
+        float: none !important;
+    }
+    .fanchor {
+        display: table-cell;  // So we can vertically center the children.
+        height: 60px;
+        padding-left: 60px;
+        vertical-align: middle;
+
+        &:hover {
+            border: none;
+            text-decoration: underline;
+        }
+    }
+    .feed-tile-header {
+        margin: 0 0 0 10px !important;
+        padding: 0 !important;
+    }
     .view-all {
         color: $view-all-blue;
         border-bottom: 1px solid $view-all-blue;

--- a/src/templates/_macros/feed_item.html
+++ b/src/templates/_macros/feed_item.html
@@ -65,7 +65,9 @@
 
   <section class="feed-brand feed-layout-{{ brand.layout }} multi-app-tile mkt-tile c" data-brand-type="{{ brand.type }}">
     <div class="feed-tile-header-wrap">
-      <h1 class="feed-tile-header" data-brand-color="{{ color }}">{{ feed.get_brand_name(brand) }}</h1>
+      <a href="{{ url('feed/feed_brand', [brand.slug])|urlparams(src='feed') }}" class="fanchor">
+        <h1 class="feed-tile-header" data-brand-color="{{ color }}">{{ feed.get_brand_name(brand) }}</h1>
+      </a>
     </div>
     <ul class="app-list">
       {% for app in brand.apps %}


### PR DESCRIPTION
r? @spasovski

No screenshots because it's visually the same, except that the title will now remain vertically-centered when taking up more than 1 line. `!important`s are jank, but @spasovski is going to do some refactoring immediately after merge that should remove the need for them, so I'm not going to waste my time.
