### PR TITLE
Move JSON tranforms into storage methods (bug 984984)

### DIFF
--- a/src/media/js/commonplace/cache.js
+++ b/src/media/js/commonplace/cache.js
@@ -1,6 +1,6 @@
 define('cache',
-    ['log', 'rewriters', 'settings', 'storage', 'user', 'utils', 'z'],
-    function(log, rewriters, settings, storage, user, utils, z) {
+    ['log', 'rewriters', 'settings', 'storage', 'user', 'utils', 'underscore', 'z'],
+    function(log, rewriters, settings, storage, user, utils, _, z) {
 
     var console = log('cache');
 
@@ -8,7 +8,7 @@ define('cache',
     var cache_key = 'request_cache';
 
     if (settings.offline_cache_enabled && settings.offline_cache_enabled()) {
-        cache = JSON.parse(storage.getItem(cache_key) || '{}');
+        cache = storage.getItem(cache_key) || {};
         flush_expired();
     }
 
@@ -43,9 +43,8 @@ define('cache',
         z.doc.trigger('save_cache', cache_key);
 
         // Persist only if the data has changed.
-        var cache_to_save_str = JSON.stringify(cache_to_save);
-        if (storage.getItem(cache_key) !== cache_to_save_str) {
-            storage.setItem(cache_key, cache_to_save_str);
+        if (! _.isEqual(storage.getItem(cache_key), cache_to_save)) {
+            storage.setItem(cache_key, cache_to_save);
             console.log('Persisting request cache');
         }
     }
@@ -154,7 +153,7 @@ define('cache',
             bust(key);
         },
         has: function(key) {
-            return storage.getItem(persistentCachePrefix + key);
+            return !!storage.getItem(persistentCachePrefix + key);
         },
         purge: function() {
             for (var i = 0; i < storage.length; i++) {

--- a/src/media/js/commonplace/log.js
+++ b/src/media/js/commonplace/log.js
@@ -10,8 +10,7 @@ define('log', ['storage', 'utils'], function(storage, utils) {
     var logs;
     var all_logs = [];
 
-    var raw_persistent_logs = storage.getItem('persistent_logs');
-    var persistent_logs = raw_persistent_logs ? JSON.parse(raw_persistent_logs) : {};
+    var persistent_logs = storage.getItem('persistent_logs') || {};
 
     var logger = function(type, tag, onlog) {
 
@@ -100,7 +99,7 @@ define('log', ['storage', 'utils'], function(storage, utils) {
                 persistent_logs[type] = [];
             }
             persistent_logs[type].push(log_args);
-            storage.setItem('persistent_logs', JSON.stringify(persistent_logs));
+            storage.setItem('persistent_logs', persistent_logs);
         };
         return logger.apply(this, args);
     };

--- a/src/media/js/commonplace/models.js
+++ b/src/media/js/commonplace/models.js
@@ -9,7 +9,7 @@ define('models',
     var data_store = {};
 
     if (settings.offline_cache_enabled && settings.offline_cache_enabled()) {
-        data_store = JSON.parse(storage.getItem(cache_key) || '{}');
+        data_store = storage.getItem(cache_key) || {};
     }
 
     // Persist the model cache.
@@ -25,8 +25,8 @@ define('models',
         // model caches. It's fine. It's fine.
 
         var data = {
-            'request_cache': JSON.stringify(cache.cache),
-            'model_cache': JSON.stringify(data_store)
+            'request_cache': cache.cache,
+            'model_cache': data_store
         };
 
         var size = (JSON.stringify(data.request_cache).length +
@@ -36,12 +36,12 @@ define('models',
                          'flushing cache');
             cache.flush();
             flush();
-            storage.setItem(cache_key, data_store_str);
+            storage.setItem(cache_key, data_store);
         } else {
             // Persist only if the data has changed.
-            var data_store_str = data[cache_key];
-            if (storage.getItem(cache_key) !== data_store_str) {
-                storage.setItem(cache_key, data_store_str);
+            var data_store_piece = data[cache_key];
+            if (! _.isEqual(storage.getItem(cache_key), data_store_piece)) {
+                storage.setItem(cache_key, data_store_piece);
                 console.log('Persisting model cache');
             }
         }
@@ -56,9 +56,8 @@ define('models',
         z.doc.trigger('save_cache', cache_key);
 
         // Persist only if the data has changed.
-        var data_store_str = JSON.stringify(data_store);
-        if (storage.getItem(cache_key) !== data_store_str) {
-            storage.setItem(cache_key, data_store_str);
+        if (! _.isEqual(storage.getItem(cache_key), data_store)) {
+            storage.setItem(cache_key, data_store);
             console.log('Persisting model cache');
         }
     }

--- a/src/media/js/commonplace/user.js
+++ b/src/media/js/commonplace/user.js
@@ -18,12 +18,12 @@ define('user',
     if (save_to_ls) {
         // Try to initialize items from localStorage.
         token = storage.getItem('user');
-        settings = JSON.parse(storage.getItem('settings') || '{}');
-        permissions = JSON.parse(storage.getItem('permissions') || '{}');
+        settings = storage.getItem('settings') || {};
+        permissions = storage.getItem('permissions') || {};
 
         var _stored = storage.getItem('user_apps');
         if (_stored) {
-            apps = JSON.parse(_stored);
+            apps = _stored;
         }
 
         log.unmention(token);
@@ -103,7 +103,7 @@ define('user',
     function save_settings() {
         if (save_to_ls) {
             console.log('Saving settings to localStorage');
-            storage.setItem('settings', JSON.stringify(settings));
+            storage.setItem('settings', settings);
         } else {
             console.log('Settings not saved to localStorage');
         }
@@ -121,7 +121,7 @@ define('user',
     function save_permissions() {
         if (save_to_ls) {
             console.log('Saving permissions to localStorage');
-            storage.setItem('permissions', JSON.stringify(permissions));
+            storage.setItem('permissions', permissions);
         } else {
             console.log('Permissions not saved to localStorage');
         }
@@ -160,7 +160,7 @@ define('user',
     function save_apps() {
         if (save_to_ls) {
             console.log('Saving user apps to localStorage');
-            storage.setItem('user_apps', JSON.stringify(apps));
+            storage.setItem('user_apps', apps);
         } else {
             console.log('User apps not saved to localStorage');
         }

--- a/src/media/js/newsletter.js
+++ b/src/media/js/newsletter.js
@@ -19,7 +19,7 @@ define('newsletter',
         }
         // 72 hours (1000 x 60 x 60 x 72)
         var timeDelta = 259200000;
-        var counter = +storage.getItem('newscounter');
+        var counter = storage.getItem('newscounter');
         if (counter == 4) return;
 
         var now = Date.now();
@@ -35,12 +35,12 @@ define('newsletter',
         // Increment counter if not expired otherwise save the time and set to 1.
         if (!counter || expired) {
             storage.setItem('newstimestamp', now);
-            storage.setItem('newscounter', '1');
+            storage.setItem('newscounter', 1);
         } else {
             if (counter++ == 2) {
                 injectSignupForm();
                 storage.removeItem('newstimestamp');
-                storage.setItem('newscounter', '4');
+                storage.setItem('newscounter', 4);
             } else {
                 storage.setItem('newscounter', counter);
             }

--- a/src/media/js/settings.js
+++ b/src/media/js/settings.js
@@ -131,9 +131,8 @@ define('settings', ['l10n', 'settings_local', 'underscore'], function(l10n, sett
             'None': gettext('No region in search')
         },
 
-        // URL of the Marketplace logo (must be HTTPS; shown when logging in via Persona).
+        // A data URI of the project logo (shown when logging in via Persona).
         persona_site_logo: base_settings.media_url + '/fireplace/img/logos/128.png',
-        // The URLs for the Persona ToS and Privacy Policy.
         persona_tos: null,
         persona_privacy: null,
 

--- a/src/media/js/views/debug.js
+++ b/src/media/js/views/debug.js
@@ -18,7 +18,7 @@ define('views/debug',
         notification.notification({message: 'Offline cache enabled', timeout: 1000});
 
     }).on('click', '#disable-offline-cache', function() {
-        storage.setItem('offline_cache_disabled', '1');
+        storage.setItem('offline_cache_disabled', 1);
         persistent_console_debug.log('Offline cache disabled:', new Date());
         require('views').reload();
         notification.notification({message: 'Offline cache disabled', timeout: 1000});
@@ -102,7 +102,7 @@ define('views/debug',
             recent_logs: recent_logs,
             persistent_logs: log.persistent.all,
             filter: log.filter,
-            request_cache: JSON.parse(storage.getItem('request_cache') || '{}')
+            request_cache: storage.getItem('request_cache') || {}
         });
 
         builder.z('type', 'leaf debug');

--- a/src/media/js/views/search.js
+++ b/src/media/js/views/search.js
@@ -37,7 +37,7 @@ define('views/search',
         }
         $('ol.listing').toggleClass('expanded', expanded);
         $('.expand-toggle').toggleClass('active', expand);
-        storage.setItem('expand-listings', expanded ? '1' : '');
+        storage.setItem('expand-listings', expanded ? true : false);
         if (expanded) {
             z.page.trigger('populatetray');
             // Set the `src` for hidden images so they get loaded.

--- a/src/templates/tests.html
+++ b/src/templates/tests.html
@@ -26,6 +26,7 @@
 <script type="text/javascript" src="/tests/models.js"></script>
 <script type="text/javascript" src="/tests/requests.js"></script>
 <script type="text/javascript" src="/tests/rewriters.js"></script>
+<script type="text/javascript" src="/tests/storage.js"></script>
 <script type="text/javascript" src="/tests/urls.js"></script>
 <script type="text/javascript" src="/tests/user.js"></script>
 <script type="text/javascript" src="/tests/utils.js"></script>

--- a/src/tests/storage.js
+++ b/src/tests/storage.js
@@ -1,0 +1,51 @@
+(function() {
+var a = require('assert');
+var assert = a.assert;
+var eeq_ = a.eeq_;
+var contains = a.contains;
+var _ = require('underscore');
+
+var storage = require('storage');
+
+test('storage returns proper types', function(done){
+    storage.setItem('number', 4);
+    eeq_(storage.getItem('number'), 4);
+    storage.removeItem('number');
+
+    storage.setItem('string', 'abcde');
+    eeq_(storage.getItem('string'), 'abcde');
+    storage.removeItem('string');
+
+    storage.setItem('boolean', true);
+    eeq_(storage.getItem('boolean'), true);
+    storage.removeItem('boolean');
+
+    storage.setItem('array', [1,2,3,4,5]);
+    assert(Array.isArray(storage.getItem('array')));
+    assert(_.isEqual(storage.getItem('array'), [1,2,3,4,5]));
+    storage.removeItem('array');
+
+    storage.setItem('object', {a: 1, b: 2, c: 3});
+    eeq_(typeof storage.getItem('object'), 'object');
+    assert(_.isEqual(storage.getItem('object'), {a: 1, b: 2, c: 3}));
+    storage.removeItem('object');
+
+    done();
+});
+
+test('remove items from storage', function(done){
+    var key = 'transient';
+    var value = {
+        unix: '30 definitions of regular expressions living under one roof',
+        windows: 'has detected the mouse has moved. Please restart your system for changes to take effect',
+        beos: 'These three are certain:/Death, taxes, and site not found./You, victim of one.'
+    };
+    assert(storage.getItem(key) === null);
+    storage.setItem(key, value);
+    assert(_.isEqual(storage.getItem(key), value));
+    storage.removeItem(key);
+    assert(storage.getItem(key) === null);
+    done();
+});
+
+})();


### PR DESCRIPTION
Added feature for storage methods to handle JSON conversion automatically.
Cleaned up all uses of storage to prevent duplicate encoding or decoding.
Wrote some basic tests.

I ran into some problems (syntax error while parsing JSON at startup) with this when testing when I didn't have all the existing JSON conversions cleaned out, which then persisted (because it is a persistence tool). Hopefully now that I've found them all, others won't have that, but it is something to watch out for.
