### PR TITLE
Add icon style for category dropdown of new carrier (bug 1043469) 	

### DIFF
--- a/src/media/css/cat-dropdown.styl
+++ b/src/media/css/cat-dropdown.styl
@@ -127,6 +127,18 @@ a[class*="cat-telenor-"]:active:before {
     background-position: 0 -54px;
 }
 
+a[class*="cat-grameenphone-bd"]:before,
+a[class*="cat-grameenphone-bd"]:hover:before,
+a[class*="cat-grameenphone-bd"]:active:before {
+    background: url(../img/carriers/telenor.svg) 0 -26px;
+    background-size: 28px auto;
+}
+
+a[class*="cat-grameenphone-bd"]:hover:before,
+a[class*="cat-grameenphone-bd"]:active:before {
+    background-position: 0 -54px;
+}
+
 a[class*="cat-am-"]:before,
 a[class*="cat-am-"]:hover:before,
 a[class*="cat-am-"]:active:before,


### PR DESCRIPTION
Region and carrier appear to be in place already, we should just need styling for the slug in the drop-down.
