### PR TITLE
feed pagination with isotope (bug 1053405)

### DIFF
--- a/src/media/css/feed.styl
+++ b/src/media/css/feed.styl
@@ -896,3 +896,14 @@ $vertical-tile-margin = 10px;  // Vertical space between feed tiles.
         text-decoration: none;
     }
 }
+
+/*  Give loadmore button its own row. Leaves ugly gaps though.
+.loadmore.feed-item-item {
+    max-width: 100%;
+    width: 100%;
+
+    button {
+        width: $mobile-tile-width;
+    }
+}
+*/

--- a/src/templates/_macros/more_button.html
+++ b/src/templates/_macros/more_button.html
@@ -1,5 +1,5 @@
-{% macro more_button(next_page_url) %}
-<li class="loadmore">
+{% macro more_button(next_page_url, li_classes) %}
+<li class="loadmore {{ li_classes }}">
   <button class="button alt" data-url="{{ (apiHost(next_page_url) + next_page_url)|safe }}">{{ _('More') }}</button>
   <div class="spinner alt btn-replace"></div>
 </li>

--- a/src/templates/feed.html
+++ b/src/templates/feed.html
@@ -2,13 +2,15 @@
 {% include '_macros/market_tile.html' %}
 {% include '_macros/more_button.html' %}
 
-{% set source = 'all' %}
-
-{% defer (url=anonApi('feed'), id='feed-items') %}
+{% defer (url=anonApi('feed')|urlparams(limit=10), id='feed-items') %}
   <ul class="feed feed-items c">
     {% for item in this.objects %}
       <li class="feed-item-item">{{ feed_item(item) }}</li>
     {% endfor %}
+
+    {% if response.meta.next %}
+      {{ more_button(response.meta.next, li_classes='feed-item-item') }}
+    {% endif %}
   </ul>
 {% placeholder %}
   <p class="spinner padded alt"></p>

--- a/src/templates/feed/feed_item.html
+++ b/src/templates/feed/feed_item.html
@@ -1,0 +1,6 @@
+{# For main feed on the homepage. #}
+{% include '_macros/feed_item.html' %}
+
+<li class='feed-item-item'>
+  {{ feed_item(item) }}
+</li>


### PR DESCRIPTION
The paginated elements fade in! How awesome.
- Rather than hacking builder, I handled the pagination manually to get it into the Isotope flow.
- Decrease from 25 to 10 at a time.
- Might make the button 320px instead of 300px...or full width of the page.

![screen shot 2014-08-14 at 1 18 44 pm](https://cloud.githubusercontent.com/assets/674727/3926300/40402ccc-23f0-11e4-8663-6a52a9bc6e8f.png)
![screen shot 2014-08-14 at 1 18 50 pm](https://cloud.githubusercontent.com/assets/674727/3926304/441c1b94-23f0-11e4-8426-99998996fd50.png)
![screen shot 2014-08-14 at 1 18 53 pm](https://cloud.githubusercontent.com/assets/674727/3926305/44fd104a-23f0-11e4-804c-f371b46a4463.png)
