### PR TITLE
Enable device filtering on desktop (bug 1054981)

### DIFF
--- a/src/media/js/routes_api_args.js
+++ b/src/media/js/routes_api_args.js
@@ -11,6 +11,8 @@ define('routes_api_args',
     } else if (caps.firefoxAndroid) {
         _dev = 'android';
         _device = caps.widescreen() ? 'tablet' : 'mobile';
+    } else {
+        _dev = _device = 'desktop';
     }
 
     if (_device == 'mobile' || _device == 'firefoxos') {

--- a/src/templates/tests.html
+++ b/src/templates/tests.html
@@ -26,6 +26,7 @@
 <script type="text/javascript" src="/tests/models.js"></script>
 <script type="text/javascript" src="/tests/requests.js"></script>
 <script type="text/javascript" src="/tests/rewriters.js"></script>
+<script type="text/javascript" src="/tests/routes_api_args.js"></script>
 <script type="text/javascript" src="/tests/storage.js"></script>
 <script type="text/javascript" src="/tests/urls.js"></script>
 <script type="text/javascript" src="/tests/user.js"></script>

--- a/src/tests/routes_api_args.js
+++ b/src/tests/routes_api_args.js
@@ -1,0 +1,135 @@
+(function() {
+var a = require('assert');
+var assert = a.assert;
+var eq_ = a.eq_;
+var mock = a.mock;
+
+test('base api arguments mobile', function(done, fail) {
+    mock(
+        'routes_api_args',
+        {
+            buckets: {profile: 'testprofile'},
+            capabilities: {firefoxOS: true},
+            user_helpers: {
+                carrier: function() {
+                    return 'testcarrier';
+                },
+                region: function(x, ignore_stored_geoip) {
+                    if (!ignore_stored_geoip) {
+                        fail('routes_api_args tried to use the geoip region stored in settings.');
+                    }
+                    return 'testregion';
+                }
+            }
+        }, function(routes_api_args) {
+            var args = routes_api_args();
+            assert(args.lang);
+            eq_(args.carrier, 'testcarrier');
+            eq_(args.region, 'testregion');
+            eq_(args.dev, 'firefoxos');
+            eq_(args.device, 'firefoxos');
+            eq_(args.limit, 10);
+            eq_(args.pro, 'testprofile');
+            done();
+        },
+        fail
+    );
+});
+
+test('base api arguments android', function(done, fail) {
+    mock(
+        'routes_api_args',
+        {
+            buckets: {profile: 'testprofileandroid'},
+            capabilities: {firefoxOS: false, firefoxAndroid: true, widescreen: function() { return false; }},
+            user_helpers: {
+                carrier: function() {
+                    return '';
+                },
+                region: function(x, ignore_stored_geoip) {
+                    if (!ignore_stored_geoip) {
+                        fail('routes_api_args tried to use the geoip region stored in settings.');
+                    }
+                    return 'testregion';
+                }
+            }
+        }, function(routes_api_args) {
+            var args = routes_api_args();
+            assert(args.lang);
+            eq_(args.carrier, '');
+            eq_(args.region, 'testregion');
+            eq_(args.dev, 'android');
+            eq_(args.device, 'mobile');
+            eq_(args.limit, 10);
+            eq_(args.pro, 'testprofileandroid');
+            done();
+        },
+        fail
+    );
+});
+
+test('base api arguments android tablet', function(done, fail) {
+    mock(
+        'routes_api_args',
+        {
+            buckets: {profile: 'testprofileandroidtablet'},
+            capabilities: {firefoxOS: false, firefoxAndroid: true,  widescreen: function() { return true; }},
+            user_helpers: {
+                carrier: function() {
+                    return '';
+                },
+                region: function(x, ignore_stored_geoip) {
+                    if (!ignore_stored_geoip) {
+                        fail('routes_api_args tried to use the geoip region stored in settings.');
+                    }
+                    return 'testregion';
+                }
+            }
+        }, function(routes_api_args) {
+            var args = routes_api_args();
+            assert(args.lang);
+            eq_(args.carrier, '');
+            eq_(args.region, 'testregion');
+            eq_(args.dev, 'android');
+            eq_(args.device, 'tablet');
+            eq_(args.limit, 25);
+            eq_(args.pro, 'testprofileandroidtablet');
+            done();
+        },
+        fail
+    );
+});
+
+test('base api arguments desktop', function(done, fail) {
+    mock(
+        'routes_api_args',
+        {
+            buckets: {profile: 'testprofiledesktop'},
+            capabilities: {firefoxOS: false, firefoxAndroid: false},
+            user_helpers: {
+                carrier: function() {
+                    return '';
+                },
+                region: function(x, ignore_stored_geoip) {
+                    if (!ignore_stored_geoip) {
+                        fail('routes_api_args tried to use the geoip region stored in settings.');
+                    }
+                    return 'testregion';
+                }
+            }
+        }, function(routes_api_args) {
+            var args = routes_api_args();
+            assert(args.lang);
+            eq_(args.carrier, '');
+            eq_(args.region, 'testregion');
+            eq_(args.dev, 'desktop');
+            eq_(args.device, 'desktop');
+            eq_(args.limit, 25);
+            eq_(args.pro, 'testprofiledesktop');
+            done();
+        },
+        fail
+    );
+});
+
+})();


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1054981

Note: the UI to deactivate the compatibility filtering is in a different bug, [bug 969244](https://bugzilla.mozilla.org/show_bug.cgi?id=969244), but is blocked by design considerations atm. I wanted to merge filtering first because I don't think the compatibility toggle button is that important anyway (why would you want to see apps you can't install ?). If you disagree r- me :-)
