### PR TITLE
Don't underline navbar links on hover; instead give it a mid-grey bottom border.

### DIFF
--- a/src/media/css/navbar.styl
+++ b/src/media/css/navbar.styl
@@ -144,15 +144,25 @@
                 text-align: center;
                 width: 70px;
 
-                &.active a {
-                    border-bottom: 2px solid $flamin-hot-cheetos-orange;
-                }
                 a {
                     color: $medium-gray;
                     display: block;
                     height: 38px;
                     line-height: 38px;
+
+                    &:hover{
+                        border-bottom: 2px solid $bg-gray;
+                        text-decoration: none;
+                    }
                 }
+                &.active a {
+                    border-bottom: 2px solid $flamin-hot-cheetos-orange;
+
+                    &:hover {
+                        border-bottom-color: $flamin-hot-cheetos-orange;
+                    }
+                }
+
                 .desktop-cat-link {
                     display: none;
                 }


### PR DESCRIPTION
r? @spasovski @ngokevin

![screen shot 2014-08-21 at 6 42 34 pm](https://cloud.githubusercontent.com/assets/23885/4005601/4f232172-2995-11e4-93a1-2945b3b33b9a.png)

"New" is active, "Popular" is hover.
