### PR TITLE
fix hitting back on nav, use more css over js for active styling (bug 1058996)

### DIFF
--- a/src/media/css/feed.styl
+++ b/src/media/css/feed.styl
@@ -24,14 +24,14 @@ $vertical-tile-margin = 10px;  // Vertical space between feed tiles.
     ul.feed  {
         padding: 0;
     }
-    [data-page-type="root"] .feed {
+    [data-page-type~="homepage"] .feed {
         max-width: $feed-column-width * 3;
         width: $mobile-tile-width * 3 + $mobile-tile-margin * 2;
     }
 }
 
 @media (min-width: 640px) {
-    [data-page-type="root"] .feed .feed-item-item:not(.loadmore) {
+    [data-page-type~="homepage"] .feed .feed-item-item:not(.loadmore) {
         margin: 0 0 $vertical-tile-padding;
         right: none;
     }
@@ -39,13 +39,13 @@ $vertical-tile-margin = 10px;  // Vertical space between feed tiles.
 
 @media (min-width: 640px) and (max-width: 959px) {
     // Two column feed layout on tweener screens.
-    [data-page-type="root"] .feed {
+    [data-page-type~="homepage"] .feed {
         max-width: $feed-column-width * 2;
         width: $mobile-tile-width * 2 + $mobile-tile-margin;
     }
 }
 
-[data-page-type~="root"] ul.feed {
+[data-page-type~="homepage"] ul.feed {
     opacity: 0;  // Fade-in.
 }
 
@@ -53,11 +53,11 @@ $vertical-tile-margin = 10px;  // Vertical space between feed tiles.
 .feed {
     list-style-type: none;
     margin: 0 auto;
+    max-width: $feed-column-width;
     padding: 10px 0;
     position: relative;
     transition(opacity .2s .15s);
     width: 100%;
-    max-width: $feed-column-width;
 
     .feed-item-item {
         margin: 0 auto $vertical-tile-padding auto;

--- a/src/media/css/header.styl
+++ b/src/media/css/header.styl
@@ -426,8 +426,7 @@
     }
 }
 
-[data-page-type~=root],
-[data-page-type~=settings] {
+[data-page-type~=root] {
     main {
         padding-top: 48px;
     }
@@ -634,8 +633,7 @@ main {
             width: auto;
         }
     }
-    [data-page-type~=root],
-    [data-page-type~=settings] {
+    [data-page-type~=root] {
         .site-header {
             .site, .wordmark {
                 width: 35px;

--- a/src/media/css/navbar.styl
+++ b/src/media/css/navbar.styl
@@ -91,101 +91,86 @@
                 width: 50px;
             }
         }
-
-        .navbar {
-            disable-user-select();
-            display: inline-block;
-            height: auto;
-            opacity: 1;
-            padding: 8px 0;
-            position: absolute;
-            top: 0;
-            transition(unquote('right .5s ease-out, left .3s ease-in'));
-            width: 100%;
-            white-space: nowrap;
-
-            // Toggle navbars.
-            &.nav-mkt {
-                right: -100%;
-
-                &.active {
-                    right: -44px;
-
-                    // Sliding navbar.
-                    &[data-tab="homepage"] {
-                        right: -60px;
-                    }
-                    &[data-tab="new"] {
-                        right: -10px;
-                    }
-                    &[data-tab="popular"] {
-                        right: 53px;
-                    }
-                    &[data-tab="categories"] {
-                        right: 120px;
-                    }
-                }
-            }
-            &.nav-settings {
-                right: 100%;
-
-                &.active {
-                    right: 0;
-
-                    // Sliding navbar.
-                    &[data-tab="settings"] {
-                        right: -9px;
-                    }
-                    &[data-tab="purchases"] {
-                        right: 35px;
-                    }
-                    &[data-tab="help"] {
-                        right: 28px;
-                    }
-                    &[data-tab="feedback"] {
-                        right: 100px;
-                    }
-                }
-            }
-            li {
-                display: inline-block;
-                font-size: 15px;
-                margin: 0 10px;
-                position: relative;
-                text-align: center;
-                text-transform: uppercase;
-                top: 2px;
-                width: -moz-fit-content;
-                width: -webkit-fit-content;
-
-                a {
-                    color: $navbar-text;
-                    display: block;
-                    height: 38px;
-                    line-height: 32px;
-
-                    &:hover {
-                        border-bottom: 2px solid $bg-gray;
-                        text-decoration: none;
-                    }
-                }
-                &.active a {
-                    color: $breezy-blue;
-                    border-bottom: 3px solid $breezy-blue;
-
-                    &:hover {
-                        border-bottom-color: $breezy-blue;
-                    }
-                }
-
-                .desktop-cat-link {
-                    display: none;
-                }
-            }
-        }
         .account-links {
             display: none;
         }
+    }
+
+    .navbar {
+        disable-user-select();
+        display: inline-block;
+        height: auto;
+        opacity: 1;
+        padding: 8px 0;
+        position: absolute;
+        top: 0;
+        transition(unquote('right .5s ease-out, left .3s ease-in'));
+        white-space: nowrap;
+        width: 100%;
+
+        &.nav-mkt {
+            right: -100%;
+
+            &.active {
+                right: -44px;
+            }
+        }
+        &.nav-settings {
+            right: 100%;
+
+            &.active {
+                right: 0;
+            }
+        }
+        li {
+            display: inline-block;
+            font-size: 15px;
+            margin: 0 10px;
+            position: relative;
+            text-align: center;
+            text-transform: uppercase;
+            top: 2px;
+            width: -moz-fit-content;
+            width: -webkit-fit-content;
+
+            a {
+                color: $navbar-text;
+                display: block;
+                height: 38px;
+                line-height: 32px;
+
+                &:hover {
+                    border-bottom: 2px solid $bg-gray;
+                    text-decoration: none;
+                }
+            }
+            .desktop-cat-link {
+                display: none;
+            }
+        }
+    }
+
+    // Sliding navbar.
+    [data-page-type~="homepage"] .nav-mkt.active {
+        right: -60px;
+    }
+    [data-page-type~="new"] .nav-mkt.active {
+        right: -10px;
+    }
+    [data-page-type~="popular"] .nav-mkt.active {
+        right: 53px;
+    }
+    [data-page-type~="categories"] .nav-mkt.active {
+        right: 120px;
+    }
+    [data-page-type="root settings"] .nav-settings.active {
+        right: -9px;
+    }
+    [data-page-type~="purchases"] .nav-settings.active {
+        right: 35px;
+    }
+    [data-page-type~="feedback"] .nav-settings.active {
+        right: 100px;
     }
 }
 
@@ -235,6 +220,9 @@
                 height: 50px;
                 outline: 0;
 
+                &.tab-link {
+                    border-bottom: 0;
+                }
                 &:hover {
                     text-decoration: none;
                 }
@@ -283,3 +271,22 @@
         top: 0px;
     }
 }
+
+// Navbar active states.
+activeNavLi() {
+    a {
+        color: $breezy-blue;
+        border-bottom: 3px solid $breezy-blue;
+
+        &:hover {
+            border-bottom-color: $breezy-blue;
+        }
+    }
+}
+[data-page-type="root settings"] [data-tab="settings"] {
+    activeNavLi();
+}
+for tab in homepage new popular categories purchases feedback
+    [data-page-type~={tab}] [data-tab={tab}] {
+        activeNavLi();
+    }

--- a/src/media/js/views/categories.js
+++ b/src/media/js/views/categories.js
@@ -5,7 +5,7 @@ define('views/categories', ['categories'],
     'use strict';
 
     return function(builder, args, params) {
-        builder.z('type', 'root');
+        builder.z('type', 'root categories');
         builder.z('title', gettext('Categories'));
 
         builder.start('categories.html', {categories: cats});

--- a/src/media/js/views/feedback.js
+++ b/src/media/js/views/feedback.js
@@ -57,7 +57,7 @@ define('views/feedback',
             $('.linefit').linefit(2);
         });
 
-        builder.z('type', 'settings');
+        builder.z('type', 'root settings feedback');
         builder.z('title', gettext('Feedback'));
         builder.z('parent', urls.reverse('homepage'));
     };

--- a/src/media/js/views/homepage.js
+++ b/src/media/js/views/homepage.js
@@ -45,10 +45,7 @@ define('views/homepage',
         params = params || {};
 
         builder.z('title', '');
-
-        builder.z('type', 'root');
-        builder.z('search', params.name);
-        builder.z('title', params.name);
+        builder.z('type', 'root homepage');
 
         if ('src' in params) {
             delete params.src;

--- a/src/media/js/views/new.js
+++ b/src/media/js/views/new.js
@@ -11,7 +11,7 @@ define('views/new',
     return function(builder, args, params) {
         var title = gettext('Fresh and New Apps');
 
-        builder.z('type', 'root newpop');
+        builder.z('type', 'root newpop new');
         builder.z('title', title);
 
         builder.start('app_list.html', {

--- a/src/media/js/views/popular.js
+++ b/src/media/js/views/popular.js
@@ -11,7 +11,7 @@ define('views/popular',
     return function(builder, args, params) {
         var title = gettext('Popular All Time');
 
-        builder.z('type', 'root newpop');
+        builder.z('type', 'root newpop popular');
         builder.z('title', title);
 
         builder.start('app_list.html', {

--- a/src/media/js/views/purchases.js
+++ b/src/media/js/views/purchases.js
@@ -9,7 +9,7 @@ define('views/purchases', ['l10n', 'common/linefit', 'urls'],
 
         $('.linefit').linefit(2);
 
-        builder.z('type', 'settings');
+        builder.z('type', 'root settings purchases');
         builder.z('title', gettext('My Apps'));
         builder.z('parent', urls.reverse('homepage'));
     };

--- a/src/media/js/views/settings.js
+++ b/src/media/js/views/settings.js
@@ -43,7 +43,7 @@ define('views/settings',
 
         $('.linefit').linefit(2);
 
-        builder.z('type', 'settings');
+        builder.z('type', 'root settings');
         builder.z('title', gettext('Account Settings'));
         builder.z('parent', urls.reverse('homepage'));
     };

--- a/src/templates/nav.html
+++ b/src/templates/nav.html
@@ -1,7 +1,7 @@
 {% include "_macros/act_tray.html" %}
 
-{% macro navtab(code, name, url, active_tab) %}
-<li class="{{ code }} {{ 'active' if active_tab == code }}" data-tab="{{ code }}">
+{% macro navtab(code, name, url) %}
+<li class="{{ code }}" data-tab="{{ code }}">
   <a class="tab-link" href="{{ url }}">{{ name }}</a>
 </li>
 {% endmacro %}
@@ -10,12 +10,13 @@
 {{ act_tray(true, is_settings) }}
 
 {# Navigation tabs (Home, New, Popular, Categories). #}
-<ul class="navbar nav-mkt{% if not is_settings %} active{% endif %}" data-tab="{{ active_tab_mkt }}">
+{# Uses body[data-page-type] to set active styles on the navigation tabs. #}
+<ul class="navbar nav-mkt{% if not is_settings %} active{% endif %}">
   {# Tab name must match route name. #}
-  {{ navtab('homepage', _('Home'), url('homepage'), active_tab_mkt) }}
-  {{ navtab('new', _('New'), url('new'), active_tab_mkt) }}
-  {{ navtab('popular', _('Popular'), url('popular'), active_tab_mkt) }}
-  <li class="categories {{ 'active' if active_tab_mkt == 'categories'}}" data-tab="categories">
+  {{ navtab('homepage', _('Home'), url('homepage')) }}
+  {{ navtab('new', _('New'), url('new')) }}
+  {{ navtab('popular', _('Popular'), url('popular')) }}
+  <li class="categories" data-tab="categories">
     <a class="tab-link mobile-cat-link" href="{{ url('categories') }}">{{ _('Categories') }}</a>
     <a class="desktop-cat-link">{{ _('Categories') }}</a>
     <div class="hovercats"></div>
@@ -23,12 +24,11 @@
 </ul>
 
 {# Settings tabs (My Account, My Apps, Help, Feedback). #}
-<ul class="navbar nav-settings{% if is_settings %} active{% endif %}" data-tab="{{ active_tab_settings }}">
+<ul class="navbar nav-settings{% if is_settings %} active{% endif %}">
   {# Tab name must match route name. #}
-  {{ navtab('settings', _('My Account'), url('settings'), active_tab_settings) }}
-  {{ navtab('purchases', _('My Apps'), url('purchases'), active_tab_settings) }}
-  {# {{ navtab('help', _('Help'), '#', active_tab_settings) }} #}
-  {{ navtab('feedback', _('Feedback'), url('feedback'), active_tab_settings) }}
+  {{ navtab('settings', _('My Account'), url('settings')) }}
+  {{ navtab('purchases', _('My Apps'), url('purchases')) }}
+  {{ navtab('feedback', _('Feedback'), url('feedback')) }}
 </ul>
 
 <div class="mkt-tray{% if is_settings %} active{% endif %}">

--- a/tests/ui/navbar.js
+++ b/tests/ui/navbar.js
@@ -8,15 +8,15 @@ casper.test.begin('Test navbar', {
     test: function(test) {
 
         casper.waitForSelector('.navbar', function() {
-            test.assertExists('.nav-mkt[data-tab="homepage"].active', 'Check navbar initialised');
-            test.assertExists('.nav-mkt li[data-tab="homepage"].active', 'Check navbar li initialised');
-            test.assertExists('.nav-settings[data-tab="settings"]:not(.active)', 'Check settings exists but is not active.');
-            test.assertExists('.nav-settings li[data-tab="settings"].active', 'Check settings li exists');
+            test.assertExists('.nav-mkt.active', 'Check navbar initialised');
+            test.assertExists('.nav-mkt li[data-tab="homepage"]', 'Check navbar li initialised');
+            test.assertExists('.nav-settings:not(.active)', 'Check settings exists but is not active.');
+            test.assertExists('.nav-settings li[data-tab="settings"]', 'Check settings li exists');
             casper.click('.nav-mkt li[data-tab="categories"] a');
         });
 
-        casper.waitForSelector('.nav-mkt li[data-tab="categories"].active', function() {
-            test.assertExists('.nav-mkt[data-tab="categories"]', 'Check category tab active');
+        casper.waitForSelector('[data-page-type~="categories"]', function() {
+            test.assertExists('[data-page-type~=categories]', 'Check navigate to category');
             casper.click('.act-tray.mobile');
         });
 
@@ -26,13 +26,15 @@ casper.test.begin('Test navbar', {
         });
 
         casper.waitForSelector('.feedback.main', function() {
-            test.assertExists('.nav-settings[data-tab="feedback"]', 'Check feeback tab clicked');
+            test.assertExists('.feedback.main', 'Check navigate to feedback');
             casper.click('.mkt-tray');
         });
 
-        casper.waitForSelector('.nav-mkt', function() {
-            test.assertExists('.nav-mkt[data-tab="categories"]', 'Check we are back on cats tab');
-            test.assertExists('.nav-mkt li[data-tab="categories"].active', 'Check cat li has active class.');
+        casper.waitForSelector('.nav-mkt.active', function() {
+            test.assertExists('[data-page-type~=homepage]',
+                              'Check we are back on homepage');
+            test.assertExists('.nav-mkt.active',
+                              'Check nav-mkt has active class.');
         });
 
         casper.run(function() {

--- a/tests/ui/tabs.js
+++ b/tests/ui/tabs.js
@@ -7,7 +7,7 @@ casper.test.begin('Check tabs scroll position', {
 
     test: function(test) {
 
-        casper.waitForSelector('.navbar .active', function then() {
+        casper.waitForSelector('.navbar', function then() {
             var startScrollY = casper.evaluate(function() {
                 return window.scrollY;
             });
@@ -16,10 +16,10 @@ casper.test.begin('Check tabs scroll position', {
                 window.scrollTo(0, tabsTop);
                 return window.scrollY;
             }, casper.getElementBounds('.navbar').top);
-            casper.click('.navbar .active a');
+            casper.click('.navbar a');
         });
 
-        casper.waitForSelector('.navbar .active', function then() {
+        casper.waitForSelector('.navbar', function then() {
             var scrollY = casper.evaluate(function() {
                 return window.scrollY;
             });
@@ -28,7 +28,7 @@ casper.test.begin('Check tabs scroll position', {
             casper.back();
         });
 
-        casper.waitForSelector('.navbar .active', function then() {
+        casper.waitForSelector('.navbar', function then() {
             var scrollY = casper.evaluate(function() {
                 return window.scrollY;
             });


### PR DESCRIPTION
The behavior of the nav should remain the same. Except this fixes hitting "back" on desktop (i.e., there was duplicate pushStates, and hitting back didn't update the nav activness). Fixed by:
- remove duplicate navigation triggering
- defining the tab activeness in CSS using body[data-page-type] rather than CSS
