### PR TITLE
Use v2 API urls in api_cdn_whitelist/offline_cache_whitelist (bug 1058523, bug 1058515)

### DIFF
--- a/src/media/js/settings.js
+++ b/src/media/js/settings.js
@@ -46,9 +46,9 @@ define('settings', ['l10n', 'settings_local', 'underscore'], function(l10n, sett
         // These are the only API endpoints that should be served from the CDN
         // (key: URL; value: max-age in seconds).
         api_cdn_whitelist: {
-            '/api/v1/fireplace/search/': 60 * 3,  // 3 minutes
-            '/api/v1/fireplace/search/featured/': 60 * 3,  // 3 minutes
-            '/api/v1/apps/category/': 60 * 60,  // 1 hour
+            '/api/v2/fireplace/search/': 60 * 3,  // 3 minutes
+            '/api/v2/fireplace/search/featured/': 60 * 3,  // 3 minutes
+            '/api/v2/apps/category/': 60 * 60,  // 1 hour
             '/api/v2/feed/get/': 60 * 30,  // 30 minutes
         },
 
@@ -73,8 +73,8 @@ define('settings', ['l10n', 'settings_local', 'underscore'], function(l10n, sett
         // Keep in mind that the cache is always refreshed asynchronously;
         // these TTLs apply to only when the app is first launched.
         offline_cache_whitelist: {
-            '/api/v1/fireplace/consumer-info/': 60 * 60 * 24 * 7,  // 1 week
-            '/api/v1/fireplace/search/featured/': 60 * 60 * 24 * 7,  // 1 week
+            '/api/v2/fireplace/consumer-info/': 60 * 60 * 24 * 7,  // 1 week
+            '/api/v2/fireplace/search/featured/': 60 * 60 * 24 * 7,  // 1 week
             '/api/v2/feed/get/': 60 * 60 * 24 * 1  // 1 day
         },
         offline_cache_enabled: offline_cache_enabled,


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1058523
https://bugzilla.mozilla.org/show_bug.cgi?id=1058515
