### PR TITLE
fix multi-app tiles errant height (bug 1058460)

### DIFF
--- a/src/media/css/feed.styl
+++ b/src/media/css/feed.styl
@@ -394,10 +394,6 @@ $vertical-tile-margin = 10px;  // Vertical space between feed tiles.
         display: inline-block;
         list-style-type: none;
         width: 100%;
-
-        img {
-            margin-bottom: 8px;
-        }
     }
     .app-name {
         color: $hungry-text;


### PR DESCRIPTION
The margin-bottom was being used as part of the parent `ul` height calculation and it serves no purpose as the `li` the `img` lives in has a fixed height.

![](http://f.cl.ly/items/2y3v1N1g320N3X2C2M06/Image%202014-08-28%20at%2011.09.18%20AM.png)
