### PR TITLE
Remove background color from operator shelves, instead hardcoding it per carrier (bug 1058163)

### DIFF
--- a/src/media/css/feed.styl
+++ b/src/media/css/feed.styl
@@ -13,6 +13,20 @@ $vertical-margin = 18px;  // Inner margin within a feed tile.
 $vertical-text-margin = 10px;  // Inner margin for text within a feed tile.
 $vertical-tile-margin = 10px;  // Vertical space between feed tiles.
 
+// Operator shelf colors and regions.
+$default_shelf_color = #ce001c;
+$movistar_regions = (mx co ar uy pe es cl ve ec gt sv ni pa cr);
+$movistar_color = #7AB800;
+$vivo_regions = (br);
+$vivo_color = #FF9900;
+$o2_regions = (de)
+$o2_color = #000066;
+$telenor_regions = (hu me rs)
+$telenor_color = #00ACE7;
+$grameenphone_regions = (bd)
+$grameenphone_color = #00ACE7;
+
+
 .feed .icon {
     height: 60px;
     width: 60px;
@@ -622,8 +636,44 @@ $vertical-tile-margin = 10px;  // Vertical space between feed tiles.
         height: 90px;
 
         .curve {
+            background-color: rgba($default_shelf_color, 0.6);
             top: 50px;
+
+            [data-carrier="telefonica"]& {
+                for region in $movistar_regions {
+                    [data-region={region}]& {
+                        background-color: rgba($movistar_color, 0.6);
+                    }
+                }
+                for region in $vivo_regions {
+                    [data-region={region}]& {
+                        background-color: rgba($vivo_color, 0.6);
+                    }
+                }
+            }
+            [data-carrier="o2"]& {
+                for region in $o2_regions {
+                    [data-region={region}]& {
+                        background-color: rgba($o2_color, 0.6);
+                    }
+                }
+            }
+            [data-carrier="telenor"]& {
+                for region in $telenor_regions {
+                    [data-region={region}]& {
+                        background-color: rgba($telenor_color, 0.6);
+                    }
+                }
+            }
+            [data-carrier="grameenphone"]& {
+                for region in $grameenphone_regions {
+                    [data-region={region}]& {
+                        background-color: rgba($grameenphone_color, 0.6);
+                    }
+                }
+            }
         }
+
         .info {
             position: relative;
             margin-top: 60px;

--- a/src/templates/_macros/feed_item.html
+++ b/src/templates/_macros/feed_item.html
@@ -198,15 +198,15 @@
 {% endmacro %}
 
 {% macro feed_shelf(shelf, landing) %}
-  {% set color = shelf.background_color %}
-
   <a href="{{ url('feed/feed_shelf', [shelf.slug])|
               urlparams(src='operator-shelf-element') }}"
      class="op-shelf fanchor" data-tracking-slug="{{ shelf.slug }}">
     <section class="feed-item shelf deferred-background {{ 'shelf-landing' if landing }}"
              style="background-image: url({{ PLACEHOLDER_ICON }})"
-             data-src="{{ shelf.background_image }}">
-      <div class="curve" style="background-color: {{ color|hex2rgba('.6') }}"></div>
+             data-src="{{ shelf.background_image }}"
+             data-carrier="{{ shelf.carrier }}"
+             data-region="{{ shelf.region }}">
+      <div class="curve"></div>
       <div class="info">
         <h1 class="name">{{ shelf.name|translate(shelf)|safe }}</h1>
       </div>


### PR DESCRIPTION
Upstream from transonic. r? @ngokevin 
