### PR TITLE
Remove premature login cancel so post-login popup gets shown (Bug 105052...

### DIFF
--- a/src/media/js/commonplace/login.js
+++ b/src/media/js/commonplace/login.js
@@ -123,7 +123,10 @@ define('login',
             // because the page never truly lost focus).
             var popup_interval = setInterval(function() {
                 if (!fxa_popup || fxa_popup.closed) {
-                    oncancel();
+                    // The oncancel was cancelling prematurely when window is closed,
+                    // prevents review dialog from popping up on login success.
+                    // oncancel();
+                    $('.loading-submit').removeClass('loading-submit').trigger('blur');
                     clearInterval(popup_interval);
                 } else {
                     // If login dialog ends up behind another window, we want

--- a/src/media/js/ratings.js
+++ b/src/media/js/ratings.js
@@ -92,16 +92,15 @@ define('ratings',
     }
 
     function loginToRate() {
-        login.login().fail(function() {
-            // Clear flag for open rating modal on cancel/fail of login.
-            open_rating = false;
-        });
 
         // Set a flag to know that we expect the modal to open
         // this prevents opening later if login was cancelled
         // as this flag is cleared in that case.
         open_rating = true;
-        z.page.one('loaded', function(){
+        function onLoginFail() {
+            open_rating = false;
+        }
+        function onLoginSuccess() {
             if (open_rating){
                 open_rating = false;
                 var $reviewButton = $('.write-review');
@@ -117,7 +116,9 @@ define('ratings',
                     }
                 }
             }
-        });
+        }
+        login.login().done(onLoginSuccess).fail(onLoginFail);
+        z.page.one('loaded', onLoginSuccess);
         return;
     }
 
@@ -147,7 +148,6 @@ define('ratings',
                 );
                 $ratingModal = $('.compose-review.modal');
             }
-
             z.body.trigger('decloak');
             $ratingModal.addClass('show');
             $ratingModal.find('select[name="rating"]').ratingwidget('large');


### PR DESCRIPTION
This takes out the `oncancel()` call from login.js which tests for a dismissed window. We miight want to take out the whole `popup_interval`. This might be a problem, but I have heard the whole popup is going away in favour of a solution that is embedded in the page, which would be better in a variety of ways.
