### PR TITLE
Override dev/device parameter with the query string (bug 1060062)

### DIFF
--- a/src/templates/search/main.html
+++ b/src/templates/search/main.html
@@ -10,11 +10,23 @@
   {% if params.sort %}
     {% set api_url = api_url|urlparams(sort=params.sort) %}
   {% endif %}
+  {% if params.dev %}
+    {% set api_url = api_url|urlparams(dev=params.dev) %}
+  {% endif %}
+  {% if params.device %}
+    {% set api_url = api_url|urlparams(device=params.device) %}
+  {% endif %}
   {% defer (url=api_url, pluck='objects', as='app', paginate='ol.listing', id='searchresults') %}
     <header class="secondary-header c">
       <h2 class="linefit">
         {{ _plural('<b>{n}</b> Result', '<b>{n}</b> Results', n=response.meta.total_count) }}
-        <span class="subtitle hide-on-mobile">{{ _('Showing <b>1</b>&ndash;<b class="total-results">{total}</b>', total=len(this)) }}</span>
+        {% if params.dev == 'desktop' %}
+          {# Per https://bugzilla.mozilla.org/show_bug.cgi?id=1060062#c4, we show the user that
+             only desktop apps are returned if the query string has a dev=desktop parameter. #}
+          <span class="subtitle hide-on-mobile">{{ _('Showing <b>1</b>&ndash;<b class="total-results">{total}</b> Desktop Apps', total=len(this)) }}</span>
+        {% else %}
+          <span class="subtitle hide-on-mobile">{{ _('Showing <b>1</b>&ndash;<b class="total-results">{total}</b>', total=len(this)) }}</span>
+        {% endif %}
       </h2>
       <a href="#" class="expand-toggle" title="{{ _('Expand') }}"></a>
     </header>

--- a/tests/ui/search.js
+++ b/tests/ui/search.js
@@ -11,30 +11,78 @@ casper.test.begin('Search baseline tests', {
         });
 
         casper.waitForSelector('.search-listing li', function() {
-            test.assertUrlMatch(/\/search\?q=test/);
+            test.assertUrlMatch(/\/search\?q=test$/);
             test.assertVisible('#search-q');
             test.assertDoesntExist('#featured');
             // There should be 26 elements in the listing: 25 items + "load more".
             test.assertExists('.search-listing li:nth-child(26)');
             test.assertDoesntExist('.search-listing li:nth-child(27)');
             test.assertSelectorHasText('#search-results h2', '42 Results');
+            test.assertSelectorHasText('#search-results h2 .subtitle', 'Showing 1–25');
+            helpers.assertAPICallWasMade('/api/v2/fireplace/search/', {
+                cache: '1', lang: 'en-US', limit: '25', q: 'test', region: 'us', vary: '0'
+            });
             test.assertVisible('.search-listing li a.mkt-tile');
             test.assertVisible('#search-results .expand-toggle');
             casper.click('li.loadmore button');
         });
 
-        casper.waitForSelector('.search-listing li:nth-child(26)', function() {
-            test.assertUrlMatch(/\/search\?q=test/);
+        casper.waitForSelector('.search-listing li:nth-child(42)', function() {
+            test.assertUrlMatch(/\/search\?q=test$/);
             test.assertSelectorHasText('#search-results h2', '42 Results');
+            test.assertSelectorHasText('#search-results h2 .subtitle', 'Showing 1–42');
+            helpers.assertAPICallWasMade('/api/v2/fireplace/search/', {
+                cache: '1', lang: 'en-US', limit: '25', q: 'test', offset: '25', region: 'us', vary: '0'
+            });
             casper.click('.header-button.back');
             casper.fill('#search', {q: 'test'}, true);
         });
 
-        casper.waitForSelector('.search-listing li:nth-child(26)', function() {
-            test.assertUrlMatch(/\/search\?q=test/);
+        casper.waitForSelector('.search-listing li:nth-child(42)', function() {
+            test.assertUrlMatch(/\/search\?q=test$/);
             test.assertSelectorHasText('#search-results h2', '42 Results');
+            test.assertSelectorHasText('#search-results h2 .subtitle', 'Showing 1–42');
             casper.click('.search-listing li a.mkt-tile:first-child');
             test.assertUrlMatch(/\/app\/[a-zA-Z0-9]+/);
+        });
+
+        // Test device filtering using query string.
+        casper.thenOpen(helpers.makeUrl('/search?q=test&dev=desktop'), function() {
+            casper.waitForSelector('#splash-overlay.hide', function() {
+                test.assertUrlMatch(/\/search\?q=test&dev=desktop$/);
+                helpers.assertAPICallWasMade('/api/v2/fireplace/search/', {
+                    cache: '1', dev: 'desktop', lang: 'en-US', limit: '25', q: 'test', region: 'us', vary: '0'
+                });
+
+                // There should be 26 elements in the listing: 25 items + "load more".
+                test.assertExists('.search-listing li:nth-child(26)');
+                test.assertDoesntExist('.search-listing li:nth-child(27)');
+                test.assertSelectorHasText('#search-results h2', '42 Results');
+                test.assertSelectorHasText('#search-results h2 .subtitle', 'Showing 1–25 Desktop Apps');
+                test.assertVisible('.search-listing li a.mkt-tile');
+                test.assertVisible('#search-results .expand-toggle');
+                casper.click('li.loadmore button');
+            });
+
+            casper.waitForSelector('.search-listing li:nth-child(42)', function() {
+                test.assertUrlMatch(/\/search\?q=test&dev=desktop$/);
+                test.assertSelectorHasText('#search-results h2', '42 Results');
+                test.assertSelectorHasText('#search-results h2 .subtitle', 'Showing 1–42 Desktop Apps');
+                casper.click('.header-button.back');
+                casper.fill('#search', {q: 'test'}, true);
+            });
+
+            // Doing a new search when we are filtering by device clears the filtering,
+            // so cache rewriting isn't done : it's a new search.
+            casper.waitForSelector('.search-listing li:nth-child(26)', function() {
+                casper.waitForUrl(/\/search\?q=test$/, function() {
+                    test.assertUrlMatch(/\/search\?q=test$/);
+                    test.assertSelectorHasText('#search-results h2', '42 Results');
+                    test.assertSelectorHasText('#search-results h2 .subtitle', 'Showing 1–25');
+                    casper.click('.search-listing li a.mkt-tile:first-child');
+                    test.assertUrlMatch(/\/app\/[a-zA-Z0-9]+/);
+                });
+            });
         });
 
         casper.run(function() {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1060062

This will allow /discovery to execute a search for desktop apps only while not affecting anything else (since the UX to allow the user to change how their searches are filtered is still in flux)
