### PR TITLE
address the tablet clip on homepage also (bug 1064693)

### DIFF
--- a/src/media/css/feed.styl
+++ b/src/media/css/feed.styl
@@ -64,8 +64,8 @@ $grameenphone_color = #00ACE7;
 // TODO: Fix these properly with the feed.styl refactor.
 @media (min-width: 640px) and (max-width: 1024px) {
     // Address top-margin clip.
-    .feed.collection-landing {
-        top: 50px;
+    body[data-page-type~="homepage"] ul.feed, .feed.collection-landing {
+       margin-top: 48px;
     }
 }
 


### PR DESCRIPTION
This addresses both the homepage and the collection details. I don't like these quickie fixes but it's not the most terrible thing in feed.styl.
