### PR TITLE
Hide the FxA migration banners from native FxA devices (bug 1074857)

### DIFF
--- a/src/media/js/fxa_migration.js
+++ b/src/media/js/fxa_migration.js
@@ -1,5 +1,5 @@
-define('fxa_migration', ['settings', 'storage', 'user', 'z'],
-       function (settings, storage, user, z) {
+define('fxa_migration', ['capabilities', 'settings', 'storage', 'user', 'z'],
+       function (capabilities, settings, storage, user, z) {
 
     function canMigrate() {
         return migrationEnabled() && !doneMigration() && hasLoggedIn();
@@ -12,6 +12,10 @@ define('fxa_migration', ['settings', 'storage', 'user', 'z'],
     }
 
     function doneMigration() {
+        if (capabilities.nativeFxA()) {
+            // Native FxA devices setup an account on first run.
+            return true;
+        }
         if (user.get_setting('source') === 'firefox-accounts') {
             storage.setItem('fxa-migrated', true);
         }

--- a/src/tests/fxa_migration.js
+++ b/src/tests/fxa_migration.js
@@ -83,4 +83,24 @@
                 done();
             }, fail);
     });
+
+    test('canMigrate is false on nativeFxA',
+         function (done, fail) {
+        mock(
+            'fxa_migration',
+            {
+                settings: migrationEnabledSettings,
+                storage: new Storage({permissions: {}}),
+                capabilities: {
+                    nativeFxA: function () {
+                        return true;
+                    },
+                },
+            },
+            function (fxa_migration) {
+                ok_(!fxa_migration.canMigrate());
+                done();
+            }, fail);
+
+    });
 })();


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1074857
