### PR TITLE
Make the "Learn more" links go to SUMO (bug 1074864)

### DIFF
--- a/src/templates/fx_accounts_popup.html
+++ b/src/templates/fx_accounts_popup.html
@@ -13,7 +13,7 @@
             </div>
           </form>
           <div class="links">
-            <a href="#">{{ _('Learn more') }}</a>
+            <a href="https://support.mozilla.org/kb/use-firefox-accounts-manage-your-marketplace-apps" target="blank">{{ _('Learn more') }}</a>
           </div>
         </section>
       </div>
@@ -32,7 +32,7 @@
             </div>
           </form>
           <div class="links">
-            <a href="#">{{ _('Learn more') }}</a>
+            <a href="https://support.mozilla.org/kb/use-firefox-accounts-manage-your-marketplace-apps" target="blank">{{ _('Learn more') }}</a>
           </div>
         </section>
       </div>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1074864
