### PR TITLE
Hide logout button from native FxA (bug 1073177)

### DIFF
--- a/src/media/css/account.styl
+++ b/src/media/css/account.styl
@@ -1,5 +1,17 @@
 @import 'lib';
 
+// Don't show logout links to native FxA users (bug 1073177).
+.native-fxa {
+    .logout,
+    .logout.button.only-logged-in {
+        display: none;
+    }
+
+    .account-settings .reviewer-tools {
+        margin-top: 0;
+    }
+}
+
 .account-settings {
     background: #fff;
     width: 100%;

--- a/src/media/js/main.js
+++ b/src/media/js/main.js
@@ -111,6 +111,15 @@ function(_) {
     settings.persona_privacy = format.format(doc_location, {type: 'privacy'});
 
     z.body.addClass('html-' + require('l10n').getDirection());
+    // We might want to style things differently for native FxA users,
+    // specifically they should need to log out through settings instead
+    // of through Marketplace (hide logout buttons for bug 1073177).
+    // Unfortunately we need to wait for the switches to load.
+    consumer_info.promise.then(function () {
+        if (capabilities.nativeFxA()) {
+            z.body.addClass('native-fxa');
+        }
+    });
     if (settings.body_classes) {
         z.body.addClass(settings.body_classes);
     }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1073177

Hide the logout button from fireplace for native Firefox Accounts users.

![no-logout](https://cloud.githubusercontent.com/assets/211578/4474447/fb810cb0-495f-11e4-95d4-652057aca833.png)
