### PR TITLE
Added title attrs to facilitate reading long lines (bug 1079172).

### DIFF
--- a/src/templates/_macros/feed_item.html
+++ b/src/templates/_macros/feed_item.html
@@ -12,8 +12,8 @@
     <a href="{{ url('app', [app.slug])|urlparams(src=src or 'feed') }}" class="app-link c">
       {{ deferred_icon(app.icons[64], app.name|translate(app)) }}
       <div class="info">
-        <h2 class="app-name elliflow">{{ app.name|translate(app) }}</h2>
-        <p class="author elliflow">{{ app.author }}</p>
+        <h2 class="app-name elliflow" title="{{ app.name|translate(app) }}">{{ app.name|translate(app) }}</h2>
+        <p class="author elliflow" title="{{ app.author }}">{{ app.author }}</p>
         <div class="rating vital{{ ' unrated' if not app.ratings.count }}" itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating">
           {% if app.ratings.average %}
             {{ stars(app.ratings.average) }}

--- a/src/templates/_macros/market_tile.html
+++ b/src/templates/_macros/market_tile.html
@@ -23,12 +23,12 @@
     data-slug="{{ app.slug }}"
     data-id="{{ app.id }}"
     {% if link %}itemscope itemtype="http://schema.org/SoftwareApplication"{% endif %}>
-    {{ deferred_icon(app.icons['64']) }}
+    {{ deferred_icon(app.icons['64'], app.name|translate(app)) }}
     <div class="info">
-      <h3 class="elliflow" itemprop="name">{{ app.name|translate(app) }}</h3>
+      <h3 class="elliflow" itemprop="name" title="{{ app.name|translate(app) }}">{{ app.name|translate(app) }}</h3>
       {% if app.author %}
         {# TODO: When we get user profiles, update this to be a proper Person itemprop #}
-        <div class="author elliflow vital subdetail" itemprop="creator">
+        <div class="author elliflow vital subdetail" itemprop="creator" title="{{ app.author }}">
           {% if not link -%}
             <a href="{{ url('search')|urlparams(author=app.author) }}">{{ app.author }}</a>
           {% else -%}
@@ -103,9 +103,10 @@
   {% if not imgAlreadyDeferred(src) %}
     {# Defer image loading. #}
     <img class="icon deferred" src="{{ PLACEHOLDER_ICON }}"
-         data-src="{{ src }}" alt="{{ alt or '' }}" height="64" width="64" itemprop="image">
+         data-src="{{ src }}" title="{{ alt or '' }}" alt="{{ alt or '' }}"
+         height="64" width="64" itemprop="image">
   {% else %}
-    <img class="icon" src="{{ src }}" alt="{{ alt or '' }}"
+    <img class="icon" src="{{ src }}" title="{{ alt or '' }}" alt="{{ alt or '' }}"
          height="64" width="64" itemprop="image">
   {% endif %}
 {% endmacro %}


### PR DESCRIPTION
Fixes [bug 1079172](https://bugzilla.mozilla.org/show_bug.cgi?id=1079172). I’ve added title attributes to anything with an `elliflow` class, and also some img elements.

On the `market_tile` macro there is a problem where the `.info` div displays above the icon, so the tooltip doesn’t display on mouseover. The `.icon` and `.info` classes sound very generic, so I didn’t want to change their styles to fix this problem because I fear causing further problems. Someone more familiar with the styles may want to point me in the right direction.
