### PR TITLE
Handle zamboni not sending fxa data

### DIFF
--- a/src/media/js/commonplace/site_config.js
+++ b/src/media/js/commonplace/site_config.js
@@ -8,8 +8,10 @@ define('site_config', ['defer', 'requests', 'settings', 'urls'],
     function fetch() {
         var def = defer.Deferred();
         requests.get(urls.api.url('site-config')).done(function(data) {
-            settings.fxa_auth_url = data.fxa.fxa_auth_url;
-            settings.fxa_auth_state = data.fxa.fxa_auth_state;
+            if (data.hasOwnProperty('fxa')) {
+                settings.fxa_auth_url = data.fxa.fxa_auth_url;
+                settings.fxa_auth_state = data.fxa.fxa_auth_state;
+            }
             settings.switches = data.waffle.switches || [];
             def.resolve(data);
         }).always(function() {

--- a/src/templates/tests.html
+++ b/src/templates/tests.html
@@ -29,6 +29,7 @@
 <script type="text/javascript" src="/tests/models.js"></script>
 <script type="text/javascript" src="/tests/requests.js"></script>
 <script type="text/javascript" src="/tests/rewriters.js"></script>
+<script type="text/javascript" src="/tests/site_config.js"></script>
 <script type="text/javascript" src="/tests/storage.js"></script>
 <script type="text/javascript" src="/tests/urls.js"></script>
 <script type="text/javascript" src="/tests/user.js"></script>

--- a/src/tests/site_config.js
+++ b/src/tests/site_config.js
@@ -52,6 +52,9 @@ test('sets fxa auth', function(done, fail) {
         {
             requests: {
                 get: mockSiteConfigRequestSuccess({
+                    waffle: {
+                        switches: ['dummy-switch']
+                    },
                     fxa: {
                         fxa_auth_url: 'http://ngokevin.com',
                         fxa_auth_state: 'somemoreseolongtoken'
@@ -71,4 +74,33 @@ test('sets fxa auth', function(done, fail) {
         fail
     );
 });
+
+test('handles no fxa auth data', function(done, fail) {
+    var settings = {
+        api_cdn_whitelist: {}
+    };
+    mock(
+        'site_config',
+        {
+            requests: {
+                get: mockSiteConfigRequestSuccess({
+                    waffle: {
+                        switches: ['dummy-switch']
+                    },
+                })
+            },
+            settings: settings,
+        },
+        function(siteConfig) {
+            var promise = siteConfig.promise;
+            promise.then(function() {
+                eq_(settings.fxa_auth_url, undefined);
+                eq_(settings.fxa_auth_state, undefined);
+                done();
+            });
+        },
+        fail
+    );
+});
+
 })();


### PR DESCRIPTION
r? @ngokevin 

Handle zamboni not returning fxa data. Add `site_config.js` test to `tests.html`.
