### PR TITLE
add title attr to desktop categories

### DIFF
--- a/src/templates/cat_overlay.html
+++ b/src/templates/cat_overlay.html
@@ -1,7 +1,7 @@
 <ol class="cat-overlay c">
   {% for cat in categories %}
     <li>
-      <a class="cat-{{ cat.slug }} cur-cat" href="{{ url('category', [cat.slug]) }}">
+      <a class="cat-{{ cat.slug }} cur-cat" title="{{ cat.name }}" href="{{ url('category', [cat.slug]) }}">
          {{ cat.name }}
       </a>
     </li>


### PR DESCRIPTION
The only reason this is a PR is in case we don't want the browser's hover tooltip. This would address the issue where the category gets ellipsed and the user has no way to determine the full text. An "abbr" doesn't make much sense here but that would be an alternative.
