### PR TITLE
improve CSS for site navigation bar (bug 1082161, bug 1083613, bug 1083614)

### DIFF
--- a/src/media/css/categories.styl
+++ b/src/media/css/categories.styl
@@ -12,7 +12,7 @@
         margin: 0 8px 20px;
         width: 90px;
     }
-    .cat-icon.cur-cat {
+    .cat-icon {
         background-color: $faint-gray;
         border: 1px solid $light-gray;
         border-radius: 65px;
@@ -25,6 +25,7 @@
 
         &:before {
             background-size: 90px;
+            display: inline-block;
             height: 30px;
             left: 5px;
             position: relative;

--- a/src/media/css/category-dropdown-desktop.styl
+++ b/src/media/css/category-dropdown-desktop.styl
@@ -1,55 +1,44 @@
 // Styles for the categories desktop overlay.
 @import "lib";
 
+.cat-hovercat {
+    // Do not use `border-box` so we can cover the borders via padding.
+    box-sizing: content-box;
+    color: $dark-gray;
+    display: block;
+    ellipsis();
+    height: 50px;
+    line-height: 50px;
+    position: relative;
+    text-align: left;
+    text-indent: 60px;
+    vertical-align: middle;
+    width: 100%;
+    z-index: 1;
+
+    &:hover {
+        background-color: $breezy-blue;
+        color: $white;
+
+        // To keep the text at the same vertical position.
+        line-height: 52px;
+
+        // To cover the borders.
+        padding: 0 1px 1px 0;
+        top: -1px;
+
+        // To keep the icon in the same place
+        // (to account for the -1px shift to cover the border).
+        &:before {
+            top: 11px;
+        }
+    }
+}
+
 .cat-overlay {
     display: none;
     padding: 10px;
     width: 0;  // Don't affect `fit-content` on mobile.
-
-    a {
-        // Do not use `border-box` so we can cover the borders via padding.
-        box-sizing: content-box;
-        color: $dark-gray;
-        display: block;
-        ellipsis();
-        height: 50px;
-        line-height: 50px;
-        position: relative;
-        text-align: left;
-        text-indent: 60px;
-        vertical-align: middle;
-        width: 100%;
-        z-index: 1;
-
-        &:before {
-            background: url(../img/pretty/cats-sprite.svg) no-repeat;
-            background-size: 90px auto;
-            content: "";
-            height: 30px;
-            left: 15px;
-            position: absolute;
-            top: 10px;
-            width: 30px;
-        }
-
-        &:hover {
-            background-color: $breezy-blue;
-            color: $white;
-
-            // To keep the text at the same vertical position.
-            line-height: 52px;
-
-            // To cover the borders.
-            padding: 0 1px 1px 0;
-            top: -1px;
-
-            // To keep the icon in the same place
-            // (to account for the -1px shift to cover the border).
-            &:before {
-                top: 11px;
-            }
-        }
-    }
 
     li {
         border-top: 1px solid $light-gray;
@@ -123,6 +112,17 @@
 }
 
 @media $at-least-desktop {
+    .tab-categories:hover {
+        .hovercats,
+        .cat-overlay {
+            display: block;
+        }
+    }
+
+    .cat-overlay {
+        width: 500px;
+    }
+
     .hovercats {
         background: $white;
         border-radius: 5px;
@@ -133,10 +133,6 @@
         top: 48px;
         transform(unquote('translate(-90%,0)'));
 
-        &.active, &.active .cat-overlay {
-            display: block;
-            width: 500px;
-        }
         &:after {
             border: 10px solid transparent;
             border-bottom: 10px solid #fff;

--- a/src/media/css/category-icons.styl
+++ b/src/media/css/category-icons.styl
@@ -7,36 +7,32 @@ $cat-icon-size-desktop = 60px;
 // One day if background-position-x/y works we can
 // factor a lot of this out.
 sprite-background-position($vertical-pos) {
-    &:before {
-        background-position: 50% $vertical-pos;
-    }
-    &:focus:before,
-    &:hover:before {
-        background-position: 100% $vertical-pos;
-    }
-    // Needed for the mobile screenwidth to have
-    // grey icons in the drop-down rather than blue.
-    &.cur-cat:focus:before,
-    &.cur-cat:hover:before,
-    &.cur-cat:before {
-        background-position: 0 $vertical-pos;
-    }
-    &.mobile-cat-header:focus:before,
-    &.mobile-cat-header:hover:before,
+    // White.
+    &.cat-hovercat:hover:before,
     &.mobile-cat-header:before {
         background-position: 100% $vertical-pos;
     }
-    &.desktop-cat-header:focus:before,
-    &.desktop-cat-header:hover:before,
+
+    // Blue.
+    // The icons in category drop-down menu.
+    // The icon in desktop header on cat landing.
+    // The icons on `/categories` index.
+    &.cat-hovercat:before,
+    &:before,
     &.desktop-cat-header:before {
         background-position: 0 $vertical-pos;
     }
+
+    // Gray.
+    // The icon in mobile header on cat landing.
+    &.mobile-cat-header:before {
+        background-position: 50% $vertical-pos;
+    }
 }
 
-.cat-icon,
-.cat-icon-a {
+.cat-icon {
     &:before {
-        // Default to 'all' icon
+        // Default to 'all' icon.
         background: url(../img/pretty/cats-sprite.svg) no-repeat 50% 93.8%;
         background-size: 3*$cat-icon-size-default;
         content: '';
@@ -47,6 +43,20 @@ sprite-background-position($vertical-pos) {
         width: $cat-icon-size-default;
     }
     sprite-background-position(93.8%);
+
+    // Other styles for `.cat-hovercat` are in `category-dropdown-desktop.styl`.
+    &.cat-hovercat {
+        &:before {
+            background: url(../img/pretty/cats-sprite.svg) no-repeat;
+            background-size: 90px auto;
+            content: "";
+            height: 30px;
+            left: 15px;
+            position: absolute;
+            top: 10px;
+            width: 30px;
+        }
+    }
 }
 
 .cat-entertainment,

--- a/src/media/css/navbar.styl
+++ b/src/media/css/navbar.styl
@@ -8,9 +8,46 @@
 
 .navbar a {
     text-decoration: none;
+}
 
-    &:focus {
-        outline: 0;
+.tab-item {
+    display: inline-block;
+    font-size: 15px;
+    position: relative;
+    text-align: center;
+    text-transform: uppercase;
+    width: -moz-fit-content;
+    width: -webkit-fit-content;
+    width: fit-content;
+}
+
+.tab-link {
+    border-bottom: 3px solid transparent;
+    color: $navbar-text;
+    display: block;
+
+    &:hover {
+        border-bottom-color: $bg-gray;
+        color: $medium-gray;
+    }
+}
+
+// Navbar active states.
+[data-page-type~=homepage] [data-tab=homepage],
+[data-page-type~=new] [data-tab=new],
+[data-page-type~=popular] [data-tab=popular],
+[data-page-type~=recommended] [data-tab=recommended],
+[data-page-type~=categories] [data-tab=categories],
+[data-page-type~=purchases] [data-tab=purchases],
+[data-page-type~=feedback] [data-tab=feedback],
+[data-page-type="root settings"] [data-tab=settings] {
+    .tab-link {
+        border-bottom: 3px solid $breezy-blue;
+        color: $breezy-blue;
+
+        &:hover {
+            border-bottom-color: $breezy-blue;
+        }
     }
 }
 
@@ -102,7 +139,6 @@
     .navbar {
         disable-user-select();
         display: inline-block;
-        height: auto;
         opacity: 1;
         padding: 8px 0;
         position: absolute;
@@ -129,32 +165,21 @@
                 visibility: visible;
             }
         }
-        li {
-            display: inline-block;
-            font-size: 15px;
-            position: relative;
-            text-align: center;
-            text-transform: uppercase;
-            top: 2px;
-            width: -moz-fit-content;
-            width: -webkit-fit-content;
+    }
 
-            a {
-                color: $navbar-text;
-                display: block;
-                height: 38px;
-                line-height: 32px;
-                padding: 0 10px;
+    .tab-item {
+        top: 2px;
+    }
 
-                &:hover {
-                    border-bottom: 2px solid $bg-gray;
-                    text-decoration: none;
-                }
-            }
-            .desktop-cat-link {
-                display: none;
-            }
-        }
+    .tab-link {
+        color: $navbar-text;
+        height: 38px;
+        line-height: 32px;
+        padding: 0 10px;
+    }
+
+    .desktop-cat-link {
+        display: none;
     }
 }
 
@@ -166,86 +191,84 @@
     }
     .site-nav {
         background-color: #E0E0E0;
-        height: 50px;
         margin: 0 auto;
         z-index: 25;
     }
     .navbar {
         disable-user-select();
         display: inline-block;
-        height: auto;
         margin: 0 auto;
         left: 0;
+        height: 100%;
         opacity: 1;
         position: absolute;
         right: 0 !important;  // navbar.js sets rule on `style`, so override.
         top: 0;
         width: -moz-fit-content;
         width: -webkit-fit-content;
+        width: fit-content;
+    }
 
-        > li {
-            display: inline-block;
-            font-size: 15px;
-            line-height: 50px;
-            padding: 0 60px;
-            position: relative;
-            text-align: center;
-            text-transform: uppercase;
-            width: -moz-fit-content;
-            width: -webkit-fit-content;
+    .tab-categories:hover .tab-link {
+        color: $breezy-blue;
+    }
 
-            &.active > a {
-                color: $breezy-blue;
-            }
-            > a {
-                color: $medium-gray;
-                display: block;
-                height: 50px;
-                outline: 0;
+    .tab-item {
+        line-height: 50px;
+        padding: 0 60px;
 
-                &.tab-link {
-                    border-bottom: 0;
-                }
-                &:hover {
-                    text-decoration: none;
-                }
-            }
-            a:not([href]):hover {
-                cursor: default;
-            }
-        }
-        .categories {
-            &:hover {
-                color: $breezy-blue;
-
-                > a {
-                    color: $breezy-blue;
-
-                    &:after {
-                        border-top-color: $breezy-blue;
-                    }
-                }
-            }
-            > a {
-                &:after {
-                    border: 4px solid transparent;
-                    border-top: 7px solid $dark-gray;
-                    content: "";
-                    margin-left: 8px;
-                    position: absolute;
-                    top: 20px;
-                }
-            }
-        }
-        .mobile-cat-link {
-            display: none;
-        }
-        .desktop-cat-link {
-            display: inline;
+        &.active > .tab-link {
+            color: $breezy-blue;
         }
     }
+    .tab-link {
+        display: block;
+        outline: 0;
+        height: $header-height;
+    }
+
+    .mobile-cat-link {
+        display: none;
+    }
+
+    .desktop-cat-link {
+        display: inline;
+
+        &:after {
+            border: 4px solid transparent;
+            border-top: 7px solid $dark-gray;
+            content: "";
+            margin-left: 8px;
+            position: absolute;
+            top: 20px;
+        }
+
+        &:hover {
+            border-bottom-color: transparent;
+        }
+    }
+
+    .tab-categories {
+        cursor: pointer;
+
+        &:hover {
+            color: $breezy-blue;
+
+            .desktop-cat-link:after {
+                border-top-color: $breezy-blue;
+            }
+        }
+    }
+
     [data-page-type~=settings] .header-button.settings {
         background-image: url(../img/pretty/settings_gear.svg);
+    }
+
+    [data-page-type~=categories] [data-tab=categories] {
+        &:hover .tab-link,
+        .tab-link:hover {
+            border-bottom-color: transparent;
+        }
     }
 }
 
@@ -262,24 +285,5 @@
 @media $wider-desktop {
     .site-nav {
         top: 0;
-    }
-}
-
-// Navbar active states.
-[data-page-type~=homepage] [data-tab=homepage],
-[data-page-type~=new] [data-tab=new],
-[data-page-type~=popular] [data-tab=popular],
-[data-page-type~=recommended] [data-tab=recommended],
-[data-page-type~=categories] [data-tab=categories],
-[data-page-type~=purchases] [data-tab=purchases],
-[data-page-type~=feedback] [data-tab=feedback],
-[data-page-type="root settings"] [data-tab=settings] {
-    > a {
-        border-bottom: 3px solid $breezy-blue;
-        color: $breezy-blue;
-
-        &:hover {
-            border-bottom-color: $breezy-blue;
-        }
     }
 }

--- a/src/media/js/navbar.js
+++ b/src/media/js/navbar.js
@@ -217,25 +217,9 @@ define('navbar',
         fitNavbar($('.navbar.active .initial-active'));
 
         // Desktop categories hover menu.
-        var catsTrigger = '.navbar > .categories';
-        var $menu = $('.hovercats');
-
-        $menu.html(
+        $('.hovercats').html(
             nunjucks.env.render('cat_overlay.html', {categories: cats})
         );
-
-        z.body.on('mouseenter', catsTrigger, function() {
-            $menu.addClass('active');
-        }).on('mouseleave', catsTrigger, function() {
-            $menu.removeClass('active');
-        }).on('click', catsTrigger + ' li a', function(e) {
-            e.stopPropagation();
-            $menu.removeClass('active');
-        }).on('mouseenter', catsTrigger + ' li a', function() {
-            $(this).removeClass('cur-cat');
-        }).on('mouseleave', catsTrigger + ' li a', function() {
-            $(this).addClass('cur-cat');
-        });
 
         initNavbarButtons();
     }

--- a/src/templates/cat_overlay.html
+++ b/src/templates/cat_overlay.html
@@ -1,7 +1,7 @@
 <ol class="cat-overlay c">
   {% for cat in categories %}
     <li>
-      <a class="cat-{{ cat.slug }} cur-cat" title="{{ cat.name }}" href="{{ url('category', [cat.slug]) }}">
+      <a class="cat-{{ cat.slug }} cat-icon cat-hovercat" title="{{ cat.name }}" href="{{ url('category', [cat.slug]) }}">
          {{ cat.name }}
       </a>
     </li>

--- a/src/templates/categories.html
+++ b/src/templates/categories.html
@@ -1,7 +1,7 @@
 <section class="category-index main">
   {% for cat in categories %}
     <a href="{{ url('category', [cat.slug]) }}">
-      <div class="cat-{{ cat.slug }} cat-icon cur-cat" data-cat-slug="{{ cat.slug }}">
+      <div class="cat-{{ cat.slug }} cat-icon cat-idx" data-cat-slug="{{ cat.slug }}">
         <p>{{ cat.name }}</p>
       </div>
     </a>

--- a/src/templates/nav.html
+++ b/src/templates/nav.html
@@ -1,7 +1,7 @@
 {% include "_macros/act_tray.html" %}
 
 {% macro navtab(code, name, url, path) %}
-<li class="{{ code }} {{ 'initial-active' if path == url }}"
+<li class="tab-item {{ code }}{{ ' initial-active' if path == url }}"
     data-tab="{{ code }}">
   <a class="tab-link" href="{{ url }}">{{ name }}</a>
 </li>
@@ -21,22 +21,22 @@
   {% if logged_in and recommendations %}
     {{ navtab('recommended', _('Recommended'), url('recommended'), path) }}
   {% endif %}
-  <li class="categories {{ 'initial-active' if path == url('categories') }}"
+  <li class="tab-item tab-categories{{ ' initial-active' if path == url('categories') }}"
       data-tab="categories">
     <a class="tab-link mobile-cat-link" href="{{ url('categories') }}">{{ _('Categories') }}</a>
-    <a class="desktop-cat-link">{{ _('Categories') }}</a>
+    <a class="tab-link desktop-cat-link">{{ _('Categories') }}</a>
     <div class="hovercats"></div>
   </li>
 </ul>
 
 {# Settings tabs (My Account, My Apps, Help, Feedback). #}
-<ul class="navbar nav-settings{% if is_settings %} active{% endif %}">
+<ul class="navbar nav-settings{{ ' active' if is_settings }}">
   {# Tab name must match route name. #}
   {{ navtab('settings', _('My Account'), url('settings'), path) }}
   {{ navtab('purchases', _('My Apps'), url('purchases'), path) }}
   {{ navtab('feedback', _('Feedback'), url('feedback'), path) }}
 </ul>
 
-<div class="mkt-tray{% if is_settings %} active{% endif %}">
+<div class="mkt-tray{{ ' active' if is_settings }}">
   <a class="header-button icon back-to-marketplace" title="{{ _('Back to Marketplace') }}"></a>
 </div>


### PR DESCRIPTION
# tasks completed
- remove unused rules, optimise selectors, and make things more OOCSS-y
- improve navigation hover states ([bug 1082161](https://bugzilla.mozilla.org/show_bug.cgi?id=1082161))
- use CSS instead of JS to toggle category drop-down on desktop ([bug 1083613](https://bugzilla.mozilla.org/show_bug.cgi?id=1083613))
- add borders to desktop navigation items ([bug 1083614](https://bugzilla.mozilla.org/show_bug.cgi?id=1083614))
- fixed CSS to actually hide the link outlines on focus
- remove `cur-cat` class and use more descriptive classes
- remove specificity all over the space to reduce complex cascading
- considerable cleanup to `sprite-background-position` for category icons
# before
## normal nav link hovered

![screenshot 2014-10-15 21 32 53](https://cloud.githubusercontent.com/assets/203725/4657634/89759476-54ed-11e4-8c9c-9957a8d1a618.png)
## "categories" link hovered

![screenshot 2014-10-15 21 29 47](https://cloud.githubusercontent.com/assets/203725/4657624/58acb928-54ed-11e4-8198-ef6397770799.png)
# after
## normal nav link hovered

![screenshot 2014-10-15 21 32 38](https://cloud.githubusercontent.com/assets/203725/4657631/7ba52c12-54ed-11e4-8a01-51671bff2894.png)
## "categories" link hovered

![screenshot 2014-10-15 21 32 29](https://cloud.githubusercontent.com/assets/203725/4657632/7bac2a80-54ed-11e4-9f24-575f364db989.png)
