### PR TITLE
[WIP] submit JS errors to Ashes on `window.onerror` (bug 965040)

### DIFF
--- a/src/media/js/settings.js
+++ b/src/media/js/settings.js
@@ -165,5 +165,8 @@ define('settings', ['l10n', 'settings_local', 'underscore'], function(l10n, sett
         iframe_installer_src: 'https://marketplace.firefox.com/iframe-install.html',
         iframe_potatolytics_src: 'https://marketplace.firefox.com/potatolytics.html',
         offline_msg: gettext('Sorry, you are currently offline. Please try again later.'),
+
+        // The URL to post reports to Ashes <https://github.com/mozilla/ashes>.
+        ashes_report_url: 'https://ashes.paas.allizom.org/post_report',
     });
 });

--- a/src/media/js/views/debug.js
+++ b/src/media/js/views/debug.js
@@ -63,7 +63,7 @@ define('views/debug',
             report_version: 1.0,
             profile: buckets.profile
         })};
-        requests.post('https://ashes.paas.allizom.org/post_report', data).done(function(data) {
+        requests.post(settings.ashes_report_url, data).done(function(data) {
             notification.notification({
                 message: 'ID: ' + data.id,
                 timeout: 30000
@@ -90,6 +90,33 @@ define('views/debug',
         z.page.trigger('reload_chrome');
         notification.notification({message: 'Carrier updated to ' + val});
     });
+
+    window.onerror = function (errorMsg, url, lineNumber) {
+        var console = log('raven');
+        console.log('Attempting to submit error to Ashes: ' + errorMsg);
+
+        var data = {body: JSON.stringify({
+            app: settings.app_name,
+            origin: window.location.protocol + '//' + window.location.host,
+
+            logs: log.all,
+            persistent_logs: log.persistent.all,
+            capabilities: capabilities,
+            settings: settings,
+            report_version: 1.0,
+            profile: buckets.profile,
+
+            errors: {
+                message: errorMsg,
+                url: url,
+                line: lineNumber
+            }
+        })};
+
+        requests.post(settings.ashes_report_url, data).done(function (data) {
+            console.log('Submitted error to Ashes: ' + data.id);
+        });
+    };
 
     return function(builder, args) {
         var recent_logs = log.get_recent(100);


### PR DESCRIPTION
Raven.js is a bit too much for my liking. I tried submitting the errors to [Ashes](https://github.com/mozilla/ashes/), but unfortunately Ashes won't accept any arbitrary data format.

<hr>

![screenshot 2014-10-16 16 23 41](https://cloud.githubusercontent.com/assets/203725/4672254/ef9ba2ec-558b-11e4-95ea-cacff0ad8a3b.png)

<hr>

![screenshot 2014-10-16 16 23 51](https://cloud.githubusercontent.com/assets/203725/4672255/ef9e0820-558b-11e4-8492-3d3fbb6f6777.png)

<hr>
# Ashes TODOs
1. add an "Errors" tab [in `script.js` here](https://github.com/mozilla/ashes/blob/285d6ca/static/script.js#L83-L90), following the "Settings" mapping (`<dt>` for each key and `<dd>` for each value in the `errors` object)
2. add an endpoint (behind auth, obviously) to the [Ashes API](https://ashes.paas.allizom.org/) that lists all reports with their IDs (currently, you have to know the URL to be able to see its page - and you must be logged in)
