### PR TITLE
Fix oversized sign in spinner in Chrome (bug 1082302)

### DIFF
--- a/src/media/css/header.styl
+++ b/src/media/css/header.styl
@@ -256,7 +256,8 @@ body {
 
         &.loading-submit {
             box-shadow: none;
-            hidetext();
+            // Make text transparent to keep the width the same.
+            color: transparent;
             outline: 0;
             spinner('loading');
             margin-left: 15px;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1082302

`text-indent: 101%;` and `width: auto;` was causing the sign in button to be 560px wide. We want to hide the text while making the button stay the same size so `color: transparent;` is all we need.

![screenshot 2014-10-20 12 20 06](https://cloud.githubusercontent.com/assets/211578/4705674/4997c7b8-587e-11e4-9c70-2ed932e099cf.png)

> After

![screenshot 2014-10-20 12 20 24](https://cloud.githubusercontent.com/assets/211578/4705675/49a6cee8-587e-11e4-9d2d-36bf4b7fd13f.png)

> Before

r? @spasovski 
