### PR TITLE
Fix navbar rendering when navigation.stack is empty (bug 1088419)

### DIFF
--- a/src/media/js/navbar.js
+++ b/src/media/js/navbar.js
@@ -209,7 +209,7 @@ define('navbar',
                 logged_in: user.logged_in(),
                 recommendations: settings.switches &&
                                  settings.switches.indexOf('recommendations') !== -1,
-                path: stack[stack.length - 1].path,
+                path: stack.length ? stack[stack.length - 1].path : '',
                 z: z
             })
         ).addClass('secondary-header');
@@ -243,4 +243,8 @@ define('navbar',
     // Render navbar.
     z.page.one('loaded', render);
     z.win.on('resize', _.debounce(render, 100));
+
+    return {
+        'render': render,
+    };
 });

--- a/src/templates/tests.html
+++ b/src/templates/tests.html
@@ -5,4 +5,5 @@
 <script type="text/javascript" src="/tests/compatibility_filtering.js"></script>
 <script type="text/javascript" src="/tests/fxa_migration.js"></script>
 <script type="text/javascript" src="/tests/mobilenetwork.js"></script>
+<script type="text/javascript" src="/tests/navbar.js"></script>
 <script type="text/javascript" src="/tests/waffles.js"></script>

--- a/src/tests/navbar.js
+++ b/src/tests/navbar.js
@@ -1,0 +1,38 @@
+(function() {
+var a = require('assert');
+var eq_ = a.eq_;
+var contains = a.contains;
+var mock = a.mock;
+var defer = require('defer');
+var urls = require('urls');
+
+test('navbar render context path', function(done, fail) {
+    var expected_path = '/testing';
+    var stack = [{path: '/ignoreme'}, {path: expected_path}];
+    mock(
+        'navbar',
+        {
+            navigation: {stack: function() { return stack; }},
+            nunjucks: {
+                env: {
+                    render: function(template, context) {
+                        if (template == 'nav.html') {
+                            eq_(context.path, expected_path);
+                        }
+                    }
+                }
+            },
+        },
+        function(navbar) {
+            navbar.render();
+            stack = [];
+            expected_path = '';
+            navbar.render();
+
+            done();
+        },
+        fail
+    );
+});
+
+})();


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1088419

It shouldn't happen, but thanks to New Relic we have evidence that it does. My guess is that there is a race condition somewhere causing the navbar to be rendered before navigation stack is built.

This adds a simple check to prevent raising a `TypeError` that completely breaks Marketplace for the affected users.
