### PR TITLE
flexible tile .info width (bug 1091207)

### DIFF
--- a/src/media/css/feed.styl
+++ b/src/media/css/feed.styl
@@ -487,7 +487,10 @@ $tmobile_color = #E20074;
             margin-bottom: $vertical-text-margin;
         }
         .info {
+            clear: both;
             height: 30px;
+            padding-left: 0;
+            position: static;
         }
     }
 }
@@ -866,7 +869,7 @@ $tmobile_color = #E20074;
                     display: none;
                 }
                 > .info {
-                    height: 70px;
+                    height: 60px;
                     margin-left: 0;
                     width: 100%;
 

--- a/src/media/css/tiles.styl
+++ b/src/media/css/tiles.styl
@@ -4,15 +4,14 @@ $icon-size = 60px;
 $detail-icon-size = 64px;
 $tile-font-colour = $hungry-text;
 
-// Info is the wrapper for the app title, autor, stars, install button.
-$tile-info-width = 210px;
-$tile-info-width-desktop = 600px;
-
 // Mini tiles are grid layout app tiles.
 $mini-tile-width = 80px;
 
 // Detail page.
 $app-title-size = 20px;
+
+// Currently used in author truncation.
+$greater-than-mobile = unquote('(min-width: 330px)');
 
 // base class
 .mkt-tile {
@@ -28,7 +27,6 @@ $app-title-size = 20px;
     .icon {
         float: left;
         height: $icon-size;
-        margin-right: 10px;
         width: $icon-size;
     }
     h3,
@@ -44,19 +42,23 @@ $app-title-size = 20px;
     }
     .author {
         line-height: 18px;
+        width: 120px;
+    }
+    .heading,
+    .info {
+        height: $icon-size;
+    }
+    .heading {
+        position: relative;
     }
     .info {
-        float: left;
-        height: $icon-size;
-        position: relative;
-        width: $tile-info-width;
+        padding-left: $icon-size + 10;
+        position: absolute;
+        width: 100%;
 
         + .bad-app {
             padding-top: 8px;
         }
-    }
-    .mini-tile .info {
-        width: $mini-tile-width;
     }
     .tile-footer {
         border-radius: 0 0 5px 5px;
@@ -66,9 +68,6 @@ $app-title-size = 20px;
     }
     .desc {
         margin-top: 15px;
-    }
-    .author {
-        width: 120px;
     }
     .preview-container {
         height: 150px;
@@ -92,13 +91,11 @@ $app-title-size = 20px;
         font-weight: 300;
         line-height: 1;
     }
-    .info {
-        width: $tile-info-width - ($detail-icon-size - $icon-size);
-    }
     .author {
         // Vertically aligns app author to app title on the detail page.
         // TODO: Explore font rendering properties to address this.
         padding-left: 1px;
+        width: auto;
     }
     .rating {
         margin-bottom: 2px;
@@ -109,6 +106,13 @@ $app-title-size = 20px;
     .icon {
         height: $detail-icon-size;
         width: $detail-icon-size;
+    }
+    .heading,
+    .info {
+        height: $detail-icon-size;
+    }
+    .info {
+        padding-left: $detail-icon-size + 10;
     }
 }
 
@@ -165,16 +169,20 @@ $app-title-size = 20px;
     }
 }
 
-@media $at-least-desktop {
-    // 'columned' happens on collection detail landing pages.
-    ul:not(.columned) .mkt-tile .info,
-    ol:not(.columned) .mkt-tile .info {
-        width: $tile-info-width-desktop;
+// TODO: Remove this once bug 1093264 is resolved.
+// Targets "new" and "popular" pages.
+.mkt-tile[data-type] > .info {
+    padding-left: 0;
+    position: static;
+}
 
-        .author {
-            width: 100%;
-        }
+@media $greater-than-mobile {
+    .mkt-tile .author {
+        width: auto;
     }
+}
+
+@media $at-least-desktop {
     .grid-if-desktop .mkt-tile .price {
         display: block;
     }
@@ -185,8 +193,12 @@ $app-title-size = 20px;
         .mkt-tile {
             padding: 15px;
 
+            .heading,
             .info {
-                width: 586px;
+                height: $detail-icon-size;
+            }
+            .info {
+                padding-left: $detail-icon-size + 10;
             }
         }
         .author {

--- a/src/templates/_macros/market_tile.html
+++ b/src/templates/_macros/market_tile.html
@@ -15,12 +15,12 @@
 
   {% set tag = 'div' if is_detail else 'a' %}
 
-  <{{ tag }} class="product mkt-tile c"
+  <{{ tag }} class="product mkt-tile"
     {% if not is_detail %} href="{{ app.url or url('app', [app.slug])|urlparams(src=src) }}"{% endif %}
     data-slug="{{ app.slug }}"
     data-id="{{ app.id }}"
     {{ 'itemscope itemtype="http://schema.org/SoftwareApplication"' if not is_detail }}>
-    <div class="c">
+    <div class="heading">
       {{ deferred_icon(app.icons['64']) }}
       <div class="info">
         <h3 itemprop="name">{{ app.name|translate(app) }}</h3>


### PR DESCRIPTION
Mobile and Desktop should be unchanged by this. Below are some "tablet" sizes:

![](http://f.cl.ly/items/2R0u2729033D0z2g3j3E/Image%202014-10-30%20at%204.08.45%20PM.png)

![](http://f.cl.ly/items/3j3x2Z2x0X093r0T1a3O/Image%202014-10-30%20at%204.10.54%20PM.png)

![](http://f.cl.ly/items/0n442l0t2n1p1L3Z0n27/Image%202014-10-30%20at%204.12.35%20PM.png)
