### PR TITLE
Always show the Register link (bug 1081880)

### DIFF
--- a/src/templates/header.html
+++ b/src/templates/header.html
@@ -16,8 +16,6 @@
   <span class="flex-span"></span>
 
   {{ act_tray(false) }}
-  {% if capabilities.fallbackFxA() %}
-    <a href="#" class="header-button persona register">{{ _('Register') }}</a>
-  {% endif %}
+  <a href="#" class="header-button persona register">{{ _('Register') }}</a>
   <a href="#" class="header-button button t persona">{{ _('Sign In') }}</a>
 </nav>

--- a/src/templates/settings/main.html
+++ b/src/templates/settings/main.html
@@ -36,18 +36,12 @@
 
     <footer>
       <p class="only-logged-in inline"><button type="submit" class="button action">{{ _('Save Changes') }}</button></p>
-      {% if capabilities.fallbackFxA() %}
-        <p class="only-logged-out extras">
-          <a href="#" class="button persona register only-logged-out">{{ _('Register') }}</a>
-        </p>
-        <p class="only-logged-out extras">
-          <a href="#" class="button persona only-logged-out">{{ _('Sign In') }}</a>
-        </p>
-      {% else %}
-        <p class="only-logged-out extras">
-          <a href="#" class="button persona only-logged-out">{{ _('Sign In / Sign Up') }}</a>
-        </p>
-      {% endif %}
+      <p class="only-logged-out extras">
+        <a href="#" class="button persona register only-logged-out">{{ _('Register') }}</a>
+      </p>
+      <p class="only-logged-out extras">
+        <a href="#" class="button persona only-logged-out">{{ _('Sign In') }}</a>
+      </p>
       <p class="extras only-logged-in">
         <a href="#" class="button logout only-logged-in">{{ _('Sign Out') }}</a>
       </p>

--- a/src/templates/user/purchases.html
+++ b/src/templates/user/purchases.html
@@ -47,12 +47,8 @@
   <footer class="only-logged-out">
     <article class="extras">
       <p class="notice">{{ _('You must be signed in to view your apps.') }}</p>
-      {% if capabilities.fallbackFxA() %}
-        <a class="button full persona register" href="#">{{ _('Register') }}</a>
-        <a class="button full persona" href="#">{{ _('Sign In') }}</a>
-      {% else %}
-        <a class="button full persona" href="#">{{ _('Sign In / Sign Up') }}</a>
-      {% endif %}
+      <a class="button full persona register" href="#">{{ _('Register') }}</a>
+      <a class="button full persona" href="#">{{ _('Sign In') }}</a>
     </article>
   </footer>
 </section>

--- a/tests/ui/account_settings.js
+++ b/tests/ui/account_settings.js
@@ -13,7 +13,8 @@ casper.test.begin('Test account settings', {
             test.assertUrlMatch(/\/settings/);
             test.assertTitle('Account Settings | Firefox Marketplace');
             test.assertVisible('.account-settings .persona');
-            test.assertSelectorHasText('.account-settings .persona', 'Sign In / Sign Up');
+            test.assertSelectorHasText('.account-settings .persona', 'Sign In');
+            test.assertSelectorHasText('.account-settings .persona', 'Register');
             test.assertNotVisible('.account-settings .logout');
             test.assertNotVisible('.account-settings button[type="submit"]');
             test.assertNotVisible('.account-settings input[name="email"]');
@@ -45,7 +46,8 @@ casper.test.begin('Test account settings', {
         casper.waitForSelector('.account-settings .only-logged-out', function() {
             test.assertUrlMatch(/\/settings/);
             test.assertVisible('.account-settings .persona');
-            test.assertSelectorHasText('.account-settings .persona', 'Sign In / Sign Up');
+            test.assertSelectorHasText('.account-settings .persona', 'Sign In');
+            test.assertSelectorHasText('.account-settings .persona', 'Register');
             test.assertNotVisible('.account-settings .logout');
             test.assertNotVisible('.account-settings footer p:first-child button');
         });


### PR DESCRIPTION
Instead of #749.

I couldn't get the Register button to show/hide based on the FxA waffle. This makes the Register button always appear even when Persona is the auth system. Since the next deploy switches us to FxA we won't see this with Persona.

r? @cvan 
