### PR TITLE
Stop animating hidden throbber (bug 1091654)

### DIFF
--- a/src/media/css/splash.styl
+++ b/src/media/css/splash.styl
@@ -20,6 +20,12 @@
 
         .throbber {
             display: none;
+
+            > b {
+                // bug 962594, Firefox still tries to animate stuff in display: none
+                // It consumes power for nothing...
+                animation: none;
+            }
         }
     }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1091654

See https://bugzilla.mozilla.org/show_bug.cgi?id=962594
