### PR TITLE
Use region provided by zamboni in index.html if present (bug 1082855)

### DIFF
--- a/src/media/js/consumer_info.js
+++ b/src/media/js/consumer_info.js
@@ -6,9 +6,9 @@
 */
 define('consumer_info',
     ['defer', 'log', 'mobilenetwork', 'requests', 'settings', 'urls', 'user',
-     'user_helpers'],
+     'user_helpers', 'z'],
     function(defer, log, mobilenetwork, requests, settings, urls, user,
-             user_helpers) {
+             user_helpers, z) {
     var logger = log('consumer_info');
     var already_had_region = !!user_helpers.region(undefined, true);
 
@@ -26,11 +26,21 @@ define('consumer_info',
     function fetch(force) {
         var def = defer.Deferred();
 
+        // If we don't already have a region, try looking in the body for
+        // data-region and use that if present. It'd set by zamboni on the
+        // index.html it serves.
+        if (!already_had_region) {
+            var body_region = z.body.data('region');
+            if (body_region) {
+                user_helpers.set_region_geoip(body_region);
+                already_had_region = true;
+            }
+        }
+
         // We have to call the API when:
-        // - User is logged out and no SIM (we need the region)
-        // - User is logged out and SIM doesn't provide a known region
-        //   (again, we need the region)
-        // - User logged in (we need the installed/purchased/developed apps
+        // - User is logged out and we don't know the region already, or it's
+        //   not valid (we need the region to do all other API calls)
+        // - User is logged in (we need the installed/purchased/developed apps
         //   list, possibly region as well)
         // - The caller is forcing us
         if (force || !already_had_region || user.logged_in()) {

--- a/src/tests/consumer_info.js
+++ b/src/tests/consumer_info.js
@@ -142,6 +142,46 @@ test('consumer_info API is not called if unnecessary', function(done, fail) {
     );
 });
 
+test('consumer_info API is not called if region is present in the body', function(done, fail) {
+    var geoip_region = null;
+    var settings = {
+        api_cdn_whitelist: {}
+    };
+    mock(
+        'consumer_info',
+        {
+            mobilenetwork: {},
+            requests: {get: function(url) { fail('We tried to make a request to ' + url); return defer.Deferred(); }},
+            settings: settings,
+            user: {logged_in: function() { return false; }},
+            user_helpers: {
+                region: function(x, y) { return ''; },
+                carrier: function() { return ''; },
+                set_region_geoip: function(r) { geoip_region = r; }
+            },
+            z: {
+                body: {
+                    data: function(key) {
+                        if (key == 'region') {
+                            return 'es';
+                        }
+                    },
+                },
+                win: {
+                    on: function() {}
+                }
+            }
+        },
+        function(consumer_info) {
+            consumer_info.promise.then(function() {
+                done();
+                eq_(geoip_region, 'es');
+            });
+        },
+        fail
+    );
+});
+
 test('consumer_info API is called if user is logged in', function(done, fail) {
     var geoip_region = null;
     var settings = {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1082855

If the user is logged out this avoids the call to consumer_info entirely for the iframed app / website. It does nothing for the true packaged app, since it has its own static index.html.
