### PR TITLE
Remove terms and pp from feedback (bug 1049952)

### DIFF
--- a/src/templates/settings/feedback.html
+++ b/src/templates/settings/feedback.html
@@ -24,17 +24,6 @@
         {% elif capabilities.firefoxAndroid %}
           <a href="https://support.mozilla.org/kb/install-android-apps-using-marketplace" class="button support" target="_blank">{{ _('Get Help') }}</a>
         {% endif %}
-
-      </li>
-      <li>
-        <a href="{{ url('privacy') }}" class="button support">
-          {{ _('Privacy Policy') }}</a>
-        </a>
-      </li>
-      <li>
-        <a href="{{ url('terms') }}" class="button support">
-          {{ _('Terms of Use') }}
-        </a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1049952#c4

I'm working on the basis "My Account" seems like the better place for these links.
