### PR TITLE
replace isotope (100KB) with salvattore (5KB) for feed layout (bug 1092331)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,6 @@
 
     "document-register-element": "0.1.2",
     "flipsnap": "0.3.0",
-    "isotope": "2.0.0",
-    "jquery-bridget": "1.0.1"
+    "salvattore-moox": "1.0.9"
   }
 }

--- a/config.js
+++ b/config.js
@@ -9,8 +9,7 @@ var localConfig = extend(true, {
         // [Source, excluding bower_components]: [Destination].
         'document-register-element/build/document-register-element.max.js': config.LIB_DEST_PATH,
         'flipsnap/flipsnap.js': config.LIB_DEST_PATH,
-        'jquery-bridget/jquery.bridget.js': config.LIB_DEST_PATH,
-        'isotope/dist/isotope.pkgd.js': config.LIB_DEST_PATH
+        'salvattore-moox/dist/salvattore.js': config.LIB_DEST_PATH,
     },
     cssBundles: {
         'splash.css': ['splash.styl.css']
@@ -22,8 +21,7 @@ var localConfig = extend(true, {
         paths: {
             'document-register-element': 'lib/document-register-element.max',
             'flipsnap': 'lib/flipsnap',
-            'isotope': 'lib/isotope.pkgd',
-            'jquery-bridget/jquery.bridget': 'lib/jquery.bridget'
+            'salvattore': 'lib/salvattore',
         },
         shim: {
             'flipsnap': {
@@ -31,6 +29,9 @@ var localConfig = extend(true, {
             },
             'document-register-element': {
                 'exports': 'window.document.registerElement'
+            },
+            'salvattore': {
+                'exports': 'salvattore'
             }
         }
     },

--- a/src/dev.html
+++ b/src/dev.html
@@ -38,6 +38,8 @@
     <link rel="stylesheet" href="/media/css/detail.styl.css">
     <link rel="stylesheet" href="/media/css/error-screens.styl.css">
     <link rel="stylesheet" href="/media/css/feed.styl.css">
+    <link rel="stylesheet" href="/media/css/feed-layout.styl.css">
+    <link rel="stylesheet" href="/media/css/feed-loadmore.styl.css">
     <link rel="stylesheet" href="/media/css/feedback.styl.css">
     <link rel="stylesheet" href="/media/css/forms.styl.css">
     <link rel="stylesheet" href="/media/css/form-modal.styl.css">

--- a/src/media/css/feed-layout.styl
+++ b/src/media/css/feed-layout.styl
@@ -1,0 +1,87 @@
+/*
+    Defines the layout of the feed "tiles". Mostly columns.
+    Uses Salvattore to produce the columns (e.g., .size1of2).
+*/
+$feed-column-width = 320px;
+$feed-tile-width = 300px;
+$feed-tile-margin = 15px;
+
+[data-columns] {
+    margin: 0 auto;
+
+    .size-1of2,
+    .size-1of3 {
+        float: left;
+        max-width: $feed-column-width;
+        width: $feed-tile-width + $feed-tile-margin;
+    }
+}
+
+@media screen and (max-width: 639px) {
+    // One column.
+    .home-feed,
+    .feed-landing.collection-landing,
+    .feed-landing.shelf-landing {
+        width: $feed-column-width;
+    }
+
+    .home-feed,
+    .collection-landing [data-columns],
+    .shelf-landing [data-columns] {
+        &::before {
+            content: '1 .column.size-1of1';
+        }
+    }
+}
+
+@media screen and (min-width: 640px) {
+    // Two columns at the most.
+    .feed-landing.collection-landing,
+    .feed-landing.shelf-landing {
+        width: $feed-column-width * 2;
+    }
+
+    .collection-landing [data-columns],
+    .shelf-landing [data-columns] {
+        &::before {
+            content: '2 .column.size-1of2';
+        }
+    }
+
+    .shelf-landing .header-block {
+        margin: 0 auto;
+
+        .feed-item {
+            border-radius: 5px;
+        }
+    }
+}
+
+@media screen and (min-width: 640px) and (max-width: 959px) {
+    // Two to three columns.
+    .home-feed {
+        width: $feed-column-width * 2;
+
+        &::before {
+            content: '2 .column.size-1of2';
+        }
+    }
+}
+
+@media screen and (min-width: 960px) {
+    // Three columns.
+    .home-feed {
+        width: $feed-column-width * 3;
+
+        &::before {
+            content: '3 .column.size-1of3';
+        }
+    }
+}
+
+@media screen and (min-width: 640px) and (max-width: 709px) {
+    .feed-landing.collection-landing,
+    .feed-landing.shelf-landing {
+        padding-top: 18px;
+    }
+}

--- a/src/media/css/feed-loadmore.styl
+++ b/src/media/css/feed-loadmore.styl
@@ -1,0 +1,23 @@
+@import 'lib';
+
+[data-page-type~=homepage],
+[data-page-type~=app-list] {
+    .loadmore {
+        // Put loadmore button on its own row.
+        margin-bottom: 0;
+        max-width: 100%;
+        padding-bottom: 0;
+        padding-top: 15px;
+        width: 100%;
+    }
+}
+
+@media $at-least-desktop {
+    [data-page-type~=homepage] .loadmore button {
+        width: 620px;
+    }
+    [data-page-type~=app-list] .loadmore {
+        clear: both;
+        width: $desktop-content;
+    }
+}

--- a/src/media/css/feed.styl
+++ b/src/media/css/feed.styl
@@ -28,46 +28,15 @@ $grameenphone_color = #00ACE7;
 $tmobile_regions = (hu pl);
 $tmobile_color = #E20074;
 
-@media $at-least-desktop {
-    // Three column feed layout on tweener screens.
-    section.feed,
-    ul.feed {
-        padding: 0;
-    }
-    body[data-page-type~="homepage"] ul.feed {
-        margin-top: 0;
-        max-width: $feed-column-width * 3;
-        width: $mobile-tile-width * 3 + $mobile-tile-margin * 2;
-    }
-}
-
-@media (min-width: 640px) {
-    [data-page-type~="homepage"] .feed .feed-item-item:not(.loadmore) {
-        margin: 0 0 $vertical-tile-padding;
-        right: none;
-    }
-}
-
-@media (min-width: 640px) and (max-width: 959px) {
-    // Two column feed layout on tweener screens.
-    [data-page-type~="homepage"] .feed {
-        max-width: $feed-column-width * 2;
-        width: $mobile-tile-width * 2 + $mobile-tile-margin;
-    }
-
-}
 
 [data-page-type~="homepage"] ul.feed {
     margin-top: 4px;
-    opacity: 0;  // Fade-in.
 }
 
 // Main container for feed elements on the homepage.
 .feed {
     list-style-type: none;
     margin: 0 auto;
-    max-width: $feed-column-width;
-    padding: 10px 0;
     position: relative;
     transition(opacity .2s .15s);
     width: 100%;
@@ -401,7 +370,7 @@ $tmobile_color = #E20074;
     max-width: $mobile-tile-width;
 
     &.grouped {
-        margin-bottom: $vertical-tile-margin;
+        margin-bottom: $vertical-tile-padding;
     }
     .feed-tile-header {
         color: $hungry-text;
@@ -853,10 +822,6 @@ $tmobile_color = #E20074;
                     &:nth-child(2n) {
                         margin-right: 0;
                     }
-                    &.loadmore {
-                        clear: both;
-                        width: $desktop-content;
-                    }
                 }
             }
             .multi-app-tile.mkt-tile {
@@ -946,21 +911,6 @@ $tmobile_color = #E20074;
     &:hover,
     &:active {
         text-decoration: none;
-    }
-}
-
-.loadmore.feed-item-item {
-    // Put loadmore button on its own row.
-    margin-bottom: 0;
-    max-width: 100%;
-    padding-bottom: 12px;
-    padding-top: 15px;
-    width: 100%;
-}
-
-@media $at-least-desktop {
-    .loadmore.feed-item-item button {
-        width: 620px;
     }
 }
 

--- a/src/media/js/utils_local.js
+++ b/src/media/js/utils_local.js
@@ -1,19 +1,14 @@
-define('utils_local', [
-    'defer',
-    'jquery',
-    'log',
-    'settings',
-    'urls',
-    'z'
-], function(defer, $, log, settings, urls, z) {
+define('utils_local',
+    ['defer', 'jquery', 'log', 'salvattore', 'settings', 'underscore', 'urls', 'z'],
+    function(defer, $, log, salvattore, settings, _, urls, z) {
 
-    var console = log('utils_local');
+    var logger = log('utils_local');
     var check_interval;
 
     function isSystemDateRecent() {
         var rval = new Date().getFullYear() >= 2010;
         if (!rval) {
-            console.log('System date appears to be incorrect!');
+            logger.log('System date appears to be incorrect!');
         }
         return rval;
     }
@@ -42,7 +37,7 @@ define('utils_local', [
     function offline(def, socket) {
         if (z.onLine) {
             // Fire event for going offline.
-            console.log('Offline detected.');
+            logger.log('Offline detected.');
             z.win.trigger('offline_detected');
             z.onLine = false;
         }
@@ -56,7 +51,7 @@ define('utils_local', [
         if (!z.onLine) {
             // Fire event for going online.
             // Fire event to start loading images.
-            console.log('Online detected.');
+            logger.log('Online detected.');
             z.win.trigger('online_detected');
             z.onLine = true;
         }
@@ -84,7 +79,7 @@ define('utils_local', [
             if (navigator.mozTCPSocket === null) {
                 return checkOnlineDesktop();
             }
-            console.log('Checking online state with socket');
+            logger.log('Checking online state with socket');
             var host = (new URL(settings.cdn_url)).host;
             var port = 80;
             var socket = navigator.mozTCPSocket.open(host, port);
@@ -123,9 +118,21 @@ define('utils_local', [
         check_interval = setInterval(checkOnline, 10000);
     }
 
+    function initSalvattore(elem) {
+        // Initializes Salvattore layout on an element.
+        var coll = document.querySelector('.collection-landing [data-columns]');
+        if (elem) {
+            salvattore.register_grid(elem);
+        }
+        z.win.on('resize', _.debounce(function() {
+            salvattore.recreate_columns(elem);
+        }, 100));
+    }
+
     return {
         build_localized_field: build_localized_field,
         checkOnline: checkOnline,
+        initSalvattore: initSalvattore,
         isSystemDateRecent: isSystemDateRecent,
         items: items,
         pollOnlineState: pollOnlineState,

--- a/src/media/js/views/feed/feed_collection.js
+++ b/src/media/js/views/feed/feed_collection.js
@@ -1,6 +1,5 @@
-define('views/feed/feed_collection',
-    ['jquery', 'isotope', 'l10n', 'utils', 'z'],
-    function($, Isotope, l10n, utils, z) {
+define('views/feed/feed_collection', ['jquery', 'l10n', 'utils', 'utils_local', 'z'],
+    function($, l10n, utils, utils_local, z) {
     'use strict';
     var gettext = l10n.gettext;
 
@@ -16,20 +15,8 @@ define('views/feed/feed_collection',
 
         builder.onload('feed-collection', function(feed_collection) {
             builder.z('title', utils.translate(feed_collection.name));
-
-            // Masonry the apps around the feed element.
-            var feed_elm = document.querySelector('ul.feed');
-            if (feed_elm) {
-                new Isotope(feed_elm, {
-                    itemSelector: '.detail-item',
-                    layoutMode: 'masonry',
-                    masonry: {
-                        columnWidth: 320,
-                        gutter: -10,
-                        isFitWidth: true
-                    }
-                });
-            }
+            utils_local.initSalvattore(
+                document.querySelector('.collection-landing [data-columns]'));
         });
     };
 });

--- a/src/media/js/views/feed/feed_shelf.js
+++ b/src/media/js/views/feed/feed_shelf.js
@@ -1,6 +1,5 @@
-define('views/feed/feed_shelf',
-    ['jquery', 'isotope', 'l10n', 'utils', 'z'],
-    function($, Isotope, l10n, utils, z) {
+define('views/feed/feed_shelf', ['jquery', 'l10n', 'utils', 'utils_local', 'z'],
+    function($, l10n, utils, utils_local, z) {
     'use strict';
     var gettext = l10n.gettext;
 
@@ -15,19 +14,10 @@ define('views/feed/feed_shelf',
             slug: slug
         });
 
-        builder.onload('shelf', function(shelf) {
-            builder.z('title', utils.translate(shelf.name));
-
-            // Masonry the apps around the feed element.
-            var iso = new Isotope(document.querySelector('ul.feed'), {
-                itemSelector: '.detail-item',
-                layoutMode: 'masonry',
-                masonry: {
-                    columnWidth: 320,
-                    gutter: -10,
-                    isFitWidth: true
-                }
-            });
+        builder.onload('shelf', function(data) {
+            builder.z('title', utils.translate(data.name));
+            utils_local.initSalvattore(
+                document.querySelector('.shelf-landing [data-columns]'));
         });
     };
 });

--- a/src/templates/_includes/more_button.html
+++ b/src/templates/_includes/more_button.html
@@ -1,0 +1,5 @@
+<li class="loadmore feed-item-item">
+  <button class="button support" data-url="{{ (apiHost(url) + url)|safe }}">
+    {{ _('More') }}
+  </button>
+</li>

--- a/src/templates/_macros/feed_item.html
+++ b/src/templates/_macros/feed_item.html
@@ -217,18 +217,18 @@
     {% if coll.type == feed.COLL_LISTING %}
       {{ feed_collection(coll, true) }}
     {% else %}
-      <ul class="feed columned">
-        <li class="detail-item header-block">
+      <div class="feed" data-columns>
+        <div class="detail-item header-block">
           {{ feed_collection(coll, true) }}
           {% if coll.description %}
             <p class="desc">{{ coll.description|translate(coll) }}</p>
           {% endif %}
-        </li>
+        </div>
 
         {% if coll.apps %}
           {% if coll.apps[0].group %}
             {% for group in feed.group_apps(coll.apps) %}
-              <li class="detail-item">
+              <div class="detail-item">
                 <section class="feed-layout-grid multi-app-tile mkt-tile grouped c">
                   <h1 class="feed-tile-header grouped">{{ group.name }}</h1>
                   <ul class="app-list">
@@ -237,13 +237,13 @@
                     {% endfor %}
                   </ul>
                 </section>
-              </li>
+              </div>
             {% endfor %}
           {% else %}
             {% for app in coll.apps %}
-              <li class="item result app c detail-item">
+              <div class="item result app c detail-item">
                 {{ market_tile(app, src='collection-element') }}
-              </li>
+              </div>
             {% endfor %}
           {% endif %}
         {% else %}
@@ -264,18 +264,18 @@
         <p class="desc">{{ shelf.description|translate(shelf) }}</p>
       {% endif %}
     </div>
-    <ul class="feed columned">
+    <div class="feed" data-columns>
       {% if shelf.apps %}
         {% for app in shelf.apps %}
-          <li class="item result app c detail-item">
+          <div class="item result app c detail-item">
             {{ market_tile(app, src='operator-shelf-element') }}
-          </li>
+          </div>
         {% endfor %}
       {% else %}
         {# L10n: Please do your best to capture the essence of Scooby Doo. #}
         {{ _("Ruh roh! No apps here, Shaggy!") }}
       {% endif %}
-    </ul>
+    </div>
   </section>
 {% endmacro %}
 

--- a/src/templates/app_list.html
+++ b/src/templates/app_list.html
@@ -20,12 +20,11 @@
         {% for app in this %}
           {{ mini_tile(app, src=source) }}
         {% endfor %}
-
+      </ul>
+      {% if response.meta.next %}
         {# Render the more button if there's another page of results #}
-        {% if response.meta.next %}
-          {{ more_button(response.meta.next) }}
-        {% endif %}
-      </ol>
+        {{ more_button(response.meta.next) }}
+      {% endif %}
     {% placeholder %}
       <p class="spinner padded alt"></p>
     {% empty %}

--- a/src/templates/feed.html
+++ b/src/templates/feed.html
@@ -3,15 +3,14 @@
 {% include '_macros/more_button.html' %}
 
 {% defer (url=anonApi('feed')|urlparams(limit=10), id='feed-items') %}
-  <ul class="feed feed-items columned c">
+  <div class="feed feed-items home-feed columned c" data-columns>
     {% for item in this.objects %}
-      <li class="feed-item-item">{{ feed_item(item) }}</li>
+      <div class="feed-item-item">{{ feed_item(item) }}</div>
     {% endfor %}
-
-    {% if response.meta.next %}
-      {{ more_button(response.meta.next, li_classes='feed-item-item') }}
-    {% endif %}
-  </ul>
+  </div>
+  {% if response.meta.next %}
+    {{ more_button(response.meta.next, ['feed-item-item']) }}
+  {% endif %}
 {% placeholder %}
   <p class="spinner padded alt"></p>
 {% except %}

--- a/src/templates/feed/feed_item.html
+++ b/src/templates/feed/feed_item.html
@@ -1,6 +1,6 @@
 {# For main feed on the homepage. #}
 {% include '_macros/feed_item.html' %}
 
-<li class='feed-item-item'>
+<div class="feed-item-item">
   {{ feed_item(item) }}
-</li>
+</div>


### PR DESCRIPTION
- Salvattore is like a CSS-driven version of Masonry/Isotope. Much leaner at 5KB unmin.
- I had to fork someone's fork of Salvattore that has balanced-height column support and I registered it to Bower as salvattore-moox.

![screen shot 2014-11-10 at 2 39 57 pm](https://cloud.githubusercontent.com/assets/674727/4985169/847bf216-692a-11e4-8fa8-8d3a6902ee1b.png)
![screen shot 2014-11-12 at 7 18 41 am](https://cloud.githubusercontent.com/assets/674727/5012614/59eb6168-6a3c-11e4-8ccb-2bfd62629999.png)
![screen shot 2014-11-12 at 7 18 37 am](https://cloud.githubusercontent.com/assets/674727/5012589/3a3a6a6c-6a3c-11e4-9054-fc6393b810ab.png)

![screen shot 2014-11-12 at 7 17 48 am](https://cloud.githubusercontent.com/assets/674727/5012595/40f1fdb6-6a3c-11e4-8c14-1f61d5b0c392.png)
![screen shot 2014-11-12 at 7 17 59 am](https://cloud.githubusercontent.com/assets/674727/5012598/4270aff2-6a3c-11e4-833a-6863913890a0.png)
