### PR TITLE
collection detail page grid fix (bug 1096649)

### DIFF
--- a/src/media/css/tiles.styl
+++ b/src/media/css/tiles.styl
@@ -183,8 +183,17 @@ $greater-than-mobile = unquote('(min-width: 330px)');
 }
 
 @media $at-least-desktop {
-    .grid-if-desktop .mkt-tile .price {
-        display: block;
+    .grid-if-desktop {
+        .heading {
+            height: auto;
+        }
+        .info {
+            padding: 0;
+            position: static;
+        }
+        .mkt-tile .price {
+            display: block;
+        }
     }
     .mkt-tile .rating .cnt {
         top: 1px;


### PR DESCRIPTION
@cvan was right the regression was made with the app tile `.info` width fix but that patch corrected many other issues so I'd rather keep it. Below should be every relevant page (with an app tile) tested but I was sure I tested this earlier when the regression happened.

![](https://cloud.githubusercontent.com/assets/391260/4986546/62485bd2-693c-11e4-8766-0c579cbfc320.png)

![](https://cloud.githubusercontent.com/assets/391260/4986549/6bd77c0a-693c-11e4-8f1b-3791a9a57bd8.png)

![](https://cloud.githubusercontent.com/assets/391260/4986552/777f8598-693c-11e4-9892-64d073390bab.png)

![](https://cloud.githubusercontent.com/assets/391260/4986558/8968c72e-693c-11e4-8bc2-715a7de923d7.png)

![](https://cloud.githubusercontent.com/assets/391260/4986559/8fb2710c-693c-11e4-91e6-201f8cc46398.png)

![](https://cloud.githubusercontent.com/assets/391260/4986563/945f698a-693c-11e4-81e8-8971a70229e3.png)

![](https://cloud.githubusercontent.com/assets/391260/4986566/9b5c3b28-693c-11e4-8f42-9b52a7db7327.png)

![](https://cloud.githubusercontent.com/assets/391260/4986569/a0f292ee-693c-11e4-9806-9ce1d07050e2.png)

![](https://cloud.githubusercontent.com/assets/391260/4986576/a68d2480-693c-11e4-98d7-7ad701264179.png)

![](https://cloud.githubusercontent.com/assets/391260/4986579/aace0bb8-693c-11e4-9a1f-1edae26c866f.png)

![](https://cloud.githubusercontent.com/assets/391260/4986585/b2f86d9c-693c-11e4-9f60-c0d21b5f80a5.png)

![](https://cloud.githubusercontent.com/assets/391260/4986588/b74c92e2-693c-11e4-8b1f-4dc77fe5db01.png)

![](https://cloud.githubusercontent.com/assets/391260/4986593/bb7c2990-693c-11e4-9bad-b60db3ab8b7e.png)

![](https://cloud.githubusercontent.com/assets/391260/4986595/bf3c7b52-693c-11e4-82ac-d1bc1bd06db5.png)

![](https://cloud.githubusercontent.com/assets/391260/4986596/c32d264e-693c-11e4-80e5-c2a9fa4b932a.png)

![](https://cloud.githubusercontent.com/assets/391260/4986598/c6f081c2-693c-11e4-8c44-bbbf10802ec4.png)
