### PR TITLE
add "Get Involved" link to desktop footer and mobile Account Settings (bug 1001208)

### DIFF
--- a/src/templates/footer.html
+++ b/src/templates/footer.html
@@ -4,6 +4,7 @@
   </div>
   <div class="group links">
     <a href="/developers/">{{ _('Developer Hub') }}</a>
+    <a href="https://wiki.mozilla.org/Marketplace/Contributing/Apps" target="_blank">{{ _('Get Involved') }}</a>
     <a href="#" class="submit-feedback">{{ _('Feedback') }}</a>
     {% if capabilities.firefoxOS %}
       <a href="https://support.mozilla.org/products/firefox-os/marketplace" target="_blank">{{ _('Support') }}</a>

--- a/src/templates/settings/main.html
+++ b/src/templates/settings/main.html
@@ -53,6 +53,9 @@
         <a href="#" class="button logout only-logged-in">{{ _('Sign Out') }}</a>
       </p>
       <p class="hide-on-desktop extras">
+        <a href="https://wiki.mozilla.org/Marketplace/Contributing/Apps" target="_blank" class="button support">{{ _('Get Involved') }}</a>
+      </p>
+      <p class="hide-on-desktop extras">
         <a href="{{ url('privacy') }}" class="button support">{{ _('Privacy Policy') }}</a>
       </p>
       <p class="hide-on-desktop extras">


### PR DESCRIPTION
see https://bugzilla.mozilla.org/show_bug.cgi?id=1001208#c30

related: #795

![screenshot 2014-11-13 18 35 08](https://cloud.githubusercontent.com/assets/203725/5040486/5d443474-6b64-11e4-874d-1b456100ce0d.png)
