### PR TITLE
fix un-unquote'd `transition` in `navbar.styl`

### DIFF
--- a/src/media/css/navbar.styl
+++ b/src/media/css/navbar.styl
@@ -79,7 +79,7 @@
         height: 50px;
         overflow: hidden;
         position: relative;
-        transition(bottom .5s, margin-bottom .5s);
+        transition(unquote('bottom .5s, margin-bottom .5s'));
 
         // act-tray is link to Settings tabs (e.g., Settings, Purchases).
         // mkt-tray is link to Marketplace tabs (e.g., Home, New, Popular).


### PR DESCRIPTION
# in `navbar.styl`

> ```
> transition(unquote('bottom .5s, margin-bottom .5s'));
> ```
# in `navbar.styl.css`

> ```
> -webkit-transition: bottom 0.5s;
> transition: bottom 0.5s;
> ```
