### PR TITLE
remove `window.performance.now` polyfill in favour of polyfill in `marketplace-core-modules` (bug 1090572)

### DIFF
--- a/src/media/js/main.js
+++ b/src/media/js/main.js
@@ -73,19 +73,6 @@ function(_) {
         window.navigator.id = navigator.id = navigator.mozId;
     }
 
-    if (!capabilities.performance) {
-        // Polyfill `performance.now` for old browsers,
-        // namely IE and WebKit (PhantomJS).
-        if (!window.performance) {
-            window.performance = {};
-        }
-        if (!window.performance.now) {
-            window.performance.now = function() {
-                // Avoid using `Date.now` because of IE 8 and lower.
-                return +new Date();
-            };
-        }
-    }
     var start_time = performance.now();
 
     console.log('Dependencies resolved, starting init');


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1090572

see mozilla/marketplace-core-modules#7
