### PR TITLE
chrome-specific padding for the compat selector (bug 1093936)

### DIFF
--- a/src/media/css/pretty-select.styl
+++ b/src/media/css/pretty-select.styl
@@ -64,3 +64,10 @@
         padding: 5px;
     }
 }
+
+// Chrome-specific padding for the select styling.
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+    .pretty-select {
+        padding-left: 10px;
+    }
+}


### PR DESCRIPTION
## Old

https://www.dropbox.com/s/koula33kr2qqnww/Screenshot%202014-12-02%2014.30.20.png?dl=0
## New

![screen shot 2014-12-02 at 2 40 51 pm](https://cloud.githubusercontent.com/assets/674727/5272407/71c8f9c6-7a31-11e4-8249-a6d1b349258d.png)

It's hacky, but it seems to work.
