### PR TITLE
Adjust min-width for compatibility select (bug 1093936, bug 1102929)

### DIFF
--- a/src/media/css/compat-filtering.styl
+++ b/src/media/css/compat-filtering.styl
@@ -10,8 +10,8 @@
 
     select {
         font-size: 13px;
-        min-width: 180px;
         vertical-align: middle;
+        width: 229px;
     }
     label {
         color: $hungry-text;
@@ -36,8 +36,6 @@
         text-align: center;
     }
     .compat-filter .pretty-select {
-        width: 229px;
-
         &:before {
             right: 5px;
         }

--- a/src/media/css/pretty-select.styl
+++ b/src/media/css/pretty-select.styl
@@ -50,7 +50,7 @@
         cursor: pointer;
         height: 40px;
         max-width: none;
-        min-width: 243px;
+        min-width: 229px;
         outline: 0;
 
         &:-moz-focusring {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1093936
https://bugzilla.mozilla.org/show_bug.cgi?id=1102929

Screenshots (note that it was already too small and cutting the text on prod):

**Prod**
![screen shot 2014-12-04 at 15 11 19](https://cloud.githubusercontent.com/assets/187006/5281647/fdff763a-7aff-11e4-983a-7e03c5d47fa1.png)
![screen shot 2014-12-04 at 15 11 31](https://cloud.githubusercontent.com/assets/187006/5281649/fe00aa3c-7aff-11e4-9757-93a66468d2f1.png)

**This PR** (In french, but the lengths of the texts are similar in english)
![screen shot 2014-12-04 at 15 16 53](https://cloud.githubusercontent.com/assets/187006/5281646/fdfbddc2-7aff-11e4-908b-0cf57f814a81.png)
![screen shot 2014-12-04 at 15 16 57](https://cloud.githubusercontent.com/assets/187006/5281648/fdffbb0e-7aff-11e4-8169-1dfc4d0cb271.png)
