### PR TITLE
add `short_name`s to W3C-standardised manifests (bug 1084548)

### DIFF
--- a/src/manifests/dev.json
+++ b/src/manifests/dev.json
@@ -1,4 +1,5 @@
 {
+  "short_name": "MktLocal",
   "name": "Firefox Marketplace",
   "icons": [
     {

--- a/src/manifests/server.json
+++ b/src/manifests/server.json
@@ -1,4 +1,5 @@
 {
+  "short_name": "MktServer",
   "name": "Firefox Marketplace",
   "icons": [
     {

--- a/src/manifests/standard.json
+++ b/src/manifests/standard.json
@@ -1,4 +1,5 @@
 {
+  "short_name": "Marketplace",
   "name": "Firefox Marketplace",
   "icons": [
     {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1084548

r? @ngokevin 
