### PR TITLE
remove extra top margin on feed app preview tiles (bug 1109232)

### DIFF
--- a/src/media/css/tiles.styl
+++ b/src/media/css/tiles.styl
@@ -71,7 +71,7 @@ $greater-than-mobile = unquote('(min-width: 330px)');
     }
     .preview-container {
         height: 150px;
-        margin: 15px 0 -15px -10px; // To ignore parent's padding.
+        margin: 0 0 -15px -10px;  // To ignore parent's padding.
         overflow: hidden;
         width: 300px;
 


### PR DESCRIPTION
## Before

![screen shot 2014-12-09 at 11 29 05 am](https://cloud.githubusercontent.com/assets/674727/5364184/991557f8-7f96-11e4-8032-38c2ac1cd6a7.png)
## After

![screen shot 2014-12-09 at 11 28 58 am](https://cloud.githubusercontent.com/assets/674727/5364183/9893924a-7f96-11e4-98c8-f6f8e21ab805.png)
