### PR TITLE
Allow newsletter signup on account page for desktop (bug 1112699)

### DIFF
--- a/src/media/js/newsletter.js
+++ b/src/media/js/newsletter.js
@@ -1,6 +1,6 @@
 define('newsletter',
-    ['capabilities', 'jquery', 'notification', 'requests', 'storage', 'urls', 'utils', 'z'],
-    function(capabilities, $, notification, requests, storage, urls, utils, z) {
+    ['capabilities', 'jquery', 'notification', 'nunjucks', 'requests', 'storage', 'urls', 'user', 'user_helpers', 'utils', 'z'],
+    function(capabilities, $, notification, nunjucks, requests, storage, urls, user, user_helpers, utils, z) {
     'use strict';
 
     function expandDetails($details) {
@@ -16,6 +16,23 @@ define('newsletter',
             }, 1);
         }
     }
+
+    z.page.on('click', '.account-settings .newsletter-signup', function(e) {
+        if (capabilities.widescreen()) {
+            e.preventDefault();
+            e.stopPropagation();
+            var footer = $('<div id="newsletter-footer"></div>');
+            footer.html(nunjucks.env.render('newsletter.html', {
+                user_region: user_helpers.region('restofworld'),
+                user_email: user.get_setting('email'),
+                user_lang: user_helpers.lang(),
+            }));
+            $('#newsletter-footer').remove();
+            $('#site-footer').prepend(footer);
+            $('#newsletter-footer .email').focus();
+            window.scrollTo(footer.offset());
+        }
+    });
 
     z.body.on('focus', '#newsletter-footer .email', function() {
         expandDetails($(this).siblings('.newsletter-details'));

--- a/src/templates/settings/main.html
+++ b/src/templates/settings/main.html
@@ -43,9 +43,9 @@
       </div>
     </div>
 
-    <h3 class="hide-on-desktop">{{ _('Newsletter') }}</h3>
+    <h3>{{ _('Newsletter') }}</h3>
 
-    <div class="brform simple-field c full-width newsletter-info hide-on-desktop">
+    <div class="brform simple-field c full-width newsletter-info">
       <p>
         {# This <span> is just to get a space before the link. #}
         <span>{{ _('Get Firefox News.') }}</span>


### PR DESCRIPTION
Previously you could only sign up once on desktop. This allows you to sign up again on the account page.

![newsletter-account-section-desktop mov](https://cloud.githubusercontent.com/assets/211578/5493780/84efc38e-86b3-11e4-86b7-610cb87ed68d.gif)
