### PR TITLE
refresh app detail page pt.1, app header (bug 1103201)

### DIFF
--- a/src/dev.html
+++ b/src/dev.html
@@ -38,8 +38,9 @@
       <link rel="stylesheet" href="/media/css/categories.styl.css">
       <link rel="stylesheet" href="/media/css/category-dropdown-desktop.styl.css">
       <link rel="stylesheet" href="/media/css/compat-filtering.styl.css">
-      <link rel="stylesheet" href="/media/css/detail-content-ratings.styl.css">
-      <link rel="stylesheet" href="/media/css/detail.styl.css">
+      <link rel="stylesheet" href="/media/css/detail/base.styl.css">
+      <link rel="stylesheet" href="/media/css/detail/content-ratings.styl.css">
+      <link rel="stylesheet" href="/media/css/detail/tile.styl.css">
       <link rel="stylesheet" href="/media/css/error-screens.styl.css">
       <link rel="stylesheet" href="/media/css/feed/feed.styl.css">
       <link rel="stylesheet" href="/media/css/feed/brands.styl.css">
@@ -55,6 +56,7 @@
       <link rel="stylesheet" href="/media/css/notification.styl.css">
       <link rel="stylesheet" href="/media/css/promo-grid.styl.css">
       <link rel="stylesheet" href="/media/css/pretty-select.styl.css">
+      <link rel="stylesheet" href="/media/css/previews-tray.styl.css">
       <link rel="stylesheet" href="/media/css/purchase.styl.css">
       <link rel="stylesheet" href="/media/css/ratings.styl.css">
       <link rel="stylesheet" href="/media/css/search.styl.css">

--- a/src/media/css/buttons.styl
+++ b/src/media/css/buttons.styl
@@ -1,81 +1,21 @@
 @import 'lib';
 
-/*
- * Style guide: http://pwalm.github.io/marketplace-style-guides/buttons.html
- *
- * <elm class="button">Normal Button</elm>
- * <elm class="button action">Positive Action like Yes or Launch</elm>
- * <elm class="button alt">Alternate Style - External Links?</elm>
- * <elm class="button cancel">Negative Action like Cancel or Delete</elm>
- * <elm class="button support">Support Action - Less Visual Emphasis</elm>
- *
- * All button sizes are $medium unless overridden by a compound class: 't', 's', 'l'.
- * On larger screens "button fat" will give you a 100% width button.
- *
- */
-
-// Default state.
-$btn = #4CB1FF; // blue
-$action = #64BE3C; // green
-$alt = #FFDC32; // yellow
-$cancel = #F54B3C; // red
-$support = #797979; // dark grey
-
-// Hover state.
-$btn-hvr = #42CAFE;
-$action-hvr = #66D171;
-$alt-hvr = #FFE26E;
-$cancel-hvr = #FF6C70;
-$support-hvr = #9B9B9B;
-
-// Active state.
-$btn-act = #3D86BD;
-$action-act = #4D8D31;
-$alt-act = #BEA435;
-$cancel-act = #B63932;
-$support-act = #5B5B5B;
-
-// Disabled state.
-$disabled = #CBCBCB;
-
-// Button sizes.
-$tiny = 24px;
-$small = 36px;
-$medium = 48px;
-$large = 60px;
-
-// Horizontal padding around the button's text.
-$h-padding = 10px;
-
-// Button font-size.
-$font-size = 15px;
-
 // Install button width.
 $btn-install-width = 90px;
 
 // Install button font-size.
-$install-font-size = 12px;
-
-commonprops($color, $border) {
-    background: $color;
-
-    if ($border == 'none') {
-        border-bottom: 0;
-    } else {
-        border-bottom: 1px solid $border;
-    }
-}
+$btn-install-font-size = 12px;
 
 .button {
     border: 0;
-    color: #fff;
-    commonprops($btn, $btn-act);
+    color: $white;
+    btn_color($action-positive, $action-positive-tapped);
     display: inline-block;
     ellipsis();
-    font: 400 $font-size/$medium $open-stack;
-    height: $medium;
+    font: 400 $btn-font-size/$medium $primary-font-family;
+    height: $btn-medium;
     line-height: 1;
-    padding: 0 $h-padding;
+    padding: 0 $btn-h-padding;
     text-align: center;
     text-decoration: none;
     white-space: nowrap;
@@ -84,40 +24,40 @@ commonprops($color, $border) {
         text-decoration: none;
     }
     &:hover, &:focus {
-        background: $btn-hvr;
+        background: $action-positive-hover;
     }
     // Override `button:not([disabled]):active` from site.styl.
     &:not([disabled]):active,
     &:active {
-        commonprops($btn-act, 'none');
+        btn_color($action-positive-tapped, 'none');
     }
     &.action {
-        commonprops($action, $action-act);
+        btn_color($action-success, $action-success-tapped);
 
-        &:hover, &:focus { background: $action-hvr; }
-        &:active { background: $action-act; }
+        &:hover, &:focus { background: $action-success-hover; }
+        &:active { background: $action-success-tapped; }
     }
     &.alt {
-        commonprops($alt, $alt-act);
+        btn_color($action-wait, $action-wait-tapped);
 
-        &:hover, &:focus { background: $alt-hvr; }
-        &:active { background: $alt-act; }
+        &:hover, &:focus { background: $action-wait-hover; }
+        &:active { background: $action-wait-tapped; }
     }
     &.cancel {
-        commonprops($cancel, $cancel-act);
+        btn_color($action-error, $action-error-tapped);
 
-        &:hover, &:focus { background: $cancel-hvr; }
-        &:active { background: $cancel-act; }
+        &:hover, &:focus { background: $action-error-hover; }
+        &:active { background: $action-error-tapped; }
     }
     &.support {
-        commonprops($support, $support-act);
+        btn_color($action-neutral, $action-neutral-tapped);
 
-        &:hover, &:focus { background: $support-hvr; }
-        &:active { background: $support-act; }
+        &:hover, &:focus { background: $action-neutral-hover; }
+        &:active { background: $action-neutral-tapped; }
     }
     &.disabled,
     &[disabled] {
-        commonprops($disabled, 'none');
+        btn_color($action-disabled, 'none');
     }
     &[disabled],
     &.disabled,
@@ -131,13 +71,13 @@ commonprops($color, $border) {
         pointer-events: auto;
     }
     &.t, &.product {
-        height: $tiny;
+        height: $btn-tiny;
     }
     &.s {
-        height: $small;
+        height: $btn-small;
     }
     &.l {
-        height: $large;
+        height: $btn-large;
     }
 
     // Waiting/Loading spinner.
@@ -195,9 +135,9 @@ a.button {
 .mkt-tile .install {
     // Unset many .button properties.
     // To compensate for the larger click target.
-    commonprops(transparent, 'none');
+    btn_color(transparent, 'none');
     cursor: pointer;
-    font-size: $install-font-size;
+    font-size: $btn-install-font-size;
     height: 34px; // Actual click-target height. Queen Krupa request.
     min-width: $btn-install-width;
     padding: 0;
@@ -206,13 +146,13 @@ a.button {
 
     em {
         // This em becomes the visual button.
-        commonprops($btn, $btn-act);
+        btn_color($action-positive, $action-positive-tapped);
         display: inline-block;
         ellipsis();
         font-style: normal;
-        height: $tiny;
-        line-height: $tiny;
-        padding: 0 $h-padding;
+        height: $btn-tiny;
+        line-height: $btn-tiny;
+        padding: 0 $btn-h-padding;
         vertical-align: bottom;
         width: $btn-install-width;
     }
@@ -222,24 +162,24 @@ a.button {
     // Accomodate a better vertical align since this state has no box-shadow.
     &[disabled] {
         em {
-            commonprops($disabled, 'none')
+            btn_color($action-disabled, 'none')
         }
         &:hover, &:active {
             em {
-                background: $disabled;
+                background: $action-disabled;
             }
         }
     }
     &:hover em {
-        background: $btn-hvr;
+        background: $action-positive-hover;
     }
     &:active em {
-        commonprops($btn-act, 'none');
+        btn_color($action-positive-tapped, 'none');
     }
     &.spinning, &.purchasing {
-        background: $btn-act;
+        background: $action-positive-tapped;
         bottom: 1px;
-        height: $tiny;
+        height: $btn-tiny;
 
         em {
             display: none;
@@ -253,12 +193,12 @@ a.button {
 // Install button launch state.
 .mkt-tile .launch {
     em {
-        commonprops($action, $action-act);
+        btn_color($action-success, $action-success-active);
     }
     &:hover em {
-        background: $action-hvr;
+        background: $action-success-hover;
     }
     &:active em {
-        background: $action-act;
+        background: $action-success-tapped;
     }
 }

--- a/src/media/css/detail/base.styl
+++ b/src/media/css/detail/base.styl
@@ -1,19 +1,29 @@
-@import 'lib';
+/* Miscellaneous base and layout styles for the app detail page. */
+@import '../lib';
+
+[data-page-type~="detail"] {
+    .subheader {
+        display: none;
+    }
+    section.main.full {
+        padding-bottom: 0;
+    }
+}
 
 .infobox.blurbs {
     border-top: 0;
 }
 
 .detail .support > div {
-    // Necessary to not clobber desktop L+R
+    // Necessary to not clobber desktop L+R.
     padding-bottom: 24px;
     padding-top: 24px;
 }
 
 .detail {
-    background: #fff;
-    border-radius: 10px;
-    box-shadow: 0 1px 1px $cement-gray;
+    background: $white;
+    border-radius: 0;
+    box-shadow: 0 1px 1px $greyscale-grey;
     margin: 10px;
 
     h3 {
@@ -25,7 +35,7 @@
 .regionbanner {
     background: url(../img/pretty/alert.svg) 12px 50% no-repeat #82C80A;
     background-size: 48px;
-    color: #fff;
+    color: $white;
     padding-left: 60px;
 }
 
@@ -175,14 +185,12 @@ section.releasenotes {
     }
 }
 
-// Statistics page is not mobile-optimized. Hide button to that page at non-
-// desktop widths.
-// TODO: Kill this once bug 924519 is resolved.
+// Stats not mobile-optimized. Hide button on non-desktop.
+// TODO: Remove once bug 924519 is resolved.
 .statistics {
     display: none;
 }
 
-// ***************** Wide Mobile (> 671px)
 @media $base-desktop {
     .upsell-wrapper {
         background: #fff;
@@ -224,11 +232,8 @@ section.releasenotes {
     .show-toggle {
         display: none;
     }
-
     .detail {
-        border-radius: 10px;
         margin: 0 auto;
-        max-width: $desktop-content;
         overflow: hidden;
     }
     .secondary-header .leading {

--- a/src/media/css/detail/content-ratings.styl
+++ b/src/media/css/detail/content-ratings.styl
@@ -1,4 +1,5 @@
-@import 'lib';
+/* The content ratings section of the app detail page. */
+@import '../lib';
 
 .content-ratings-wrapper {
     border-top: 1px solid $cloud-gray;
@@ -113,8 +114,6 @@
 .usk .content-ratings-right {
     left: 0;
 }
-
-// ***************** Wide Mobile (> 671px)
 
 @media $base-desktop {
     .content-ratings-wrapper {

--- a/src/media/css/detail/tile.styl
+++ b/src/media/css/detail/tile.styl
@@ -1,0 +1,125 @@
+/* The app tile section at the top of the app detail page. */
+@import '../lib';
+
+.app-header.full {
+    padding-bottom: 0;
+
+    > div {
+        padding-bottom: 0;
+        padding-top: 0;
+    }
+}
+
+[data-page-type~="detail"] {
+    .mkt-tile {
+        padding-bottom: 10px;
+    }
+    .app-notices {
+        border-top: 2px solid $tile-border;
+        padding: 2px 0;
+        text-align: center;
+        width: 100%;
+
+        > span {
+            background: $action-positive;
+            border-radius: 100px;
+            color: $white;
+            display: inline-block;
+            font-weight: 300;
+            margin: 5px;
+            padding: 8px 15px;
+            text-transform: lowercase;
+
+            &.positive {
+                background: $action-success;
+            }
+            &.negative {
+                background: $action-error;
+            }
+        }
+    }
+}
+
+@media $base-tablet {
+    [data-page-type~="detail"] {
+        .subheader {
+            display: block;
+        }
+        .detail,
+        .main,
+        .mkt-tile {
+            overflow: visible
+        }
+        .heading {
+            margin-bottom: 70px;
+        }
+        .mkt-tile {
+            padding-bottom: 50px;
+            position: relative;
+            margin: 0 auto;
+            width: 50%;
+
+            .icon {
+                // Get the icon in the middle.
+                bottom: 15px;
+                height: 128px;
+                left: 0;
+                margin: 0 auto;
+                right: 0;
+                position: absolute;
+                text-align: center;
+                width: 128px;
+            }
+            .info {
+                padding: 0;
+                position: relative;
+            }
+            [itemprop="name"] {
+                desktop_mega();
+                margin-bottom: 30px;
+                padding-top: 55px;
+                text-align: center;
+            }
+            [itemprop="creator"] {
+                font-weight: 300;
+                font-size: 20px;
+            }
+            .rating {
+                font-weight: 300;
+                font-size: 20px;
+                padding: 25px 0;
+            }
+            .install {
+                height: $btn-small;
+
+                em {
+                    font-size: 15px;
+                    height: $btn-small;
+                    line-height: $btn-small;
+                }
+            }
+        }
+        .rating-link {
+            display: table;
+            width-fit-content();
+        }
+        .cnt {
+            float: left;
+            margin-right: 10px;
+        }
+        .stars {
+            float: right;
+            top: 1px;
+            position: relative;
+        }
+        .app-notices {
+            padding: 20px 0;
+        }
+    }
+}
+
+@media $base-desktop {
+    [data-page-type~="detail"] .mkt-tile .stars {
+        top: 4px;
+    }
+}

--- a/src/media/css/lib/buttons.styl
+++ b/src/media/css/lib/buttons.styl
@@ -1,0 +1,36 @@
+@import 'colors';
+
+/*
+ * Style guide: http://pwalm.github.io/marketplace-style-guides/buttons.html
+ *
+ * <elm class="button">Normal Button</elm>
+ * <elm class="button action">Positive Action like Yes or Launch</elm>
+ * <elm class="button alt">Alternate Style - External Links?</elm>
+ * <elm class="button cancel">Negative Action like Cancel or Delete</elm>
+ * <elm class="button support">Support Action - Less Visual Emphasis</elm>
+ *
+ * All button sizes are $medium unless overridden by a compound class: 't', 's', 'l'.
+ * On larger screens "button fat" will give you a 100% width button.
+ *
+ */
+// Button sizes.
+$btn-tiny = 24px;
+$btn-small = 36px;
+$btn-medium = 48px;
+$btn-large = 60px;
+
+// Horizontal padding around the button's text.
+$btn-h-padding = 10px;
+
+// Button font-size.
+$btn-font-size = 15px;
+
+btn_color($color, $border) {
+    background: $color;
+
+    if ($border == 'none') {
+        border-bottom: 0;
+    } else {
+        border-bottom: 1px solid $border;
+    }
+}

--- a/src/media/css/lib/colors.styl
+++ b/src/media/css/lib/colors.styl
@@ -18,17 +18,21 @@ $action-wait-hover = #ffe26e;
 $action-error = #f54b3c;  // Red.
 $action-error-tapped = #b63932;
 $action-error-hover = #ff6c70;
+$action-neutral = #797979;
+$action-neutral-tapped = #5b5b5b;
+$action-neutral-hover = #9b9b9b;
+$action-disabled = #cbcbcb;
 
 // Greyscale.
 $greyscale-black = #1a1a1a;
 $greyscale-black-tapped = #131313;
 $greyscale-black-hover = #535353;
-$greyscale-dark-grey= #797979;
-$greyscale-dark-grey-tapped = #5b5b5b;
-$greyscale-dark-grey-hover = #9b9b9b;
-$greyscale-grey = #cbcbcb;
-$greyscale-grey-tapped = #cbcbcb;
-$greyscale-grey-hover = #cbcbcb;
+$greyscale-dark-grey= $action-neutral;
+$greyscale-dark-grey-tapped = $action-neutral-tapped;
+$greyscale-dark-grey-hover = $action-neutral-hover;
+$greyscale-grey = $action-disabled;
+$greyscale-grey-tapped = $action-disabled;
+$greyscale-grey-hover = $action-disabled;
 $greyscale-light-grey = #f1f1f1;
 $greyscale-light-grey-tapped = #b5b5b5;
 $greyscale-light-grey-hover = #f5f5f5;

--- a/src/media/css/lib/index.styl
+++ b/src/media/css/lib/index.styl
@@ -1,10 +1,15 @@
+@import 'buttons';
 @import 'colors';
 @import 'feed';
 @import 'layout';
 @import 'mixins';
+@import 'typography';
+
 @import 'regions';
 
-// Font Stacks
-$primary-font-family = "Fira Sans OT", "Fira Sans", FiraSansWeb, sans-serif;
-// Deprecated.
-$open-stack = "Fira Sans OT", "Fira Sans", FiraSansWeb, sans-serif;
+
+desktop-h2() {
+    font-size: 40px;
+    font-weight: 300;
+    line-height: 50px;
+}

--- a/src/media/css/lib/mixins.styl
+++ b/src/media/css/lib/mixins.styl
@@ -270,3 +270,10 @@ disable-user-select() {
     -webkit-user-select: none;
     user-select: none;
 }
+
+width-fit-content() {
+    width: -webkit-fit-content;
+    width: -moz-fit-content;
+    width: -ms-fit-content;
+    width: fit-content;
+}

--- a/src/media/css/lib/typography.styl
+++ b/src/media/css/lib/typography.styl
@@ -1,0 +1,16 @@
+// Font Stacks
+$primary-font-family = "Fira Sans OT", "Fira Sans", FiraSansWeb, sans-serif;
+// Deprecated.
+$open-stack = "Fira Sans OT", "Fira Sans", FiraSansWeb, sans-serif;
+
+desktop_mega() {
+    font-size: 40px;
+    font-weight: 300;
+    line-height: 50px;
+}
+
+desktop_h2() {
+    color: $greyscale-black;
+    font-size: 20px;
+    font-weight: 300;
+}

--- a/src/media/css/listing.styl
+++ b/src/media/css/listing.styl
@@ -1,7 +1,5 @@
 @import 'lib';
 
-$triangle-size = 20px;
-
 .grid, .listing {
     clear: both;
     list-style: none;
@@ -73,126 +71,7 @@ grid-style() {
     grid-style();
 }
 
-.listing.grid-if-desktop .mkt-tile + .tray,
-.listing.grid-if-desktop .mkt-tile + .tray img {
-    display: none;
-}
-
-// Previews tray.
-.expanded .mkt-tile + .tray {
-    display: block;
-}
-
-.mkt-tile + .tray {
-    background: $salt-flat-white;
-    border-radius: 0 0 10px 10px;
-    display: none;
-    height: 230px;
-    overflow: hidden;
-    padding: 21px 0 0;
-    position: relative;
-
-    &.single {
-        // No dots so make it smaller. Leave 15px from bottom of screenshot to bottom of tray.
-        height: 201px;
-    }
-    &.single .dots {
-        display: none;
-    }
-    .slider {
-        margin-top: 15px;
-        overflow: hidden;
-        user-select: none;
-        -webkit-user-select: none;
-        -moz-user-select: none;
-    }
-    ul {
-        height: 150px; // 150 + 15
-        list-style-type: none;
-        margin: 0 auto;
-        overflow: hidden;
-        padding: 0;
-        white-space: nowrap;
-    }
-    li {
-        float: left;
-        margin-left: 15px;
-        text-align: center;
-        width: 150px; // Max height/width of image.
-        &:first-child {
-            margin-left: 0;
-        }
-        // The following creates a square container
-        // that is as tall as the li is wide and
-        // positions the img vertically and
-        // horizontally center.
-        .thumbnail {
-            display: block;
-            padding-bottom: 100%;
-            position: relative;
-            width: 100%;
-        }
-    }
-}
-.tray img {
-    -moz-user-select: none;
-    bottom: 0;
-    display: block;
-    left: 0;
-    margin: auto;
-    max-height: 100%;
-    max-width: 100%;
-    position: absolute;
-    right: 0;
-    top: 0;
-}
-
-.mkt-tile + .single li {
-    width: 100%;
-
-    img {
-        position: static;
-    }
-}
-
-$dot-size = 13px;
-
-.tray {
-    .dots {
-        margin-top: 13px;
-        height: $dot-size;
-        text-align: center;
-        width: 100%;
-    }
-    .dot {
-        background: $salt-flat-white;
-        // Don't use shorthand, we do transitions.
-        border-color: $cloud-gray;
-        border-radius: ($dot-size/2);
-        border-style: solid;
-        border-width: 3px;
-        cursor: pointer;
-        display: inline-block;
-        height: $dot-size;
-        margin: 0 3px;
-        transition-duration: 0.15s;
-        transition-property: border-color, border-width;
-        width: $dot-size;
-
-        &.current,
-        &:hover,
-        &:active {
-            border-color: $sailor-blue;
-        }
-        &.current {
-            background: $sailor-blue;
-        }
-    }
-}
-
-.bad-app,
-.shots .next,
-.shots .prev {
+.bad-app {
     display: none;
 }
 
@@ -292,59 +171,6 @@ div .deferred-background {
 }
 
 @media $base-desktop {
-    .shots {
-        position: relative;
-
-        .next, .prev {
-            border-radius: 0 30px 30px 0;
-            border: 15px solid rgba(#252525,.7);
-            height: 60px;
-            margin-top: -30px;
-            outline: 0;
-            position: absolute;
-            top: 50%;
-            transition(all .2s linear);
-            width: 0;
-            z-index: 16;
-            &:after {
-                background: url(../img/icons/slider_arrow.png) no-repeat;
-                content: "";
-                float: right;
-                height: 22px;
-                left: 7px;
-                position: relative;
-                top: 4px;
-                width: 15px;
-            }
-            &:hover {
-                border-color: rgba(#252525,.9);
-                border-left-width: 22px;
-            }
-            &:active {
-                border-color: rgba(#777,.9);
-            }
-        }
-        .next {
-            border-radius: 30px 0 0 30px;
-            right: 0;
-
-            &:after {
-                transform(scaleX(-1));
-            }
-            &:hover {
-                border-left-width: 15px;
-                border-right-width: 22px;
-            }
-        }
-        .prev {
-            left: 0;
-        }
-    }
-    #lightbox {
-        .next, .prev {
-            box-shadow: 0 0 4px #fff;
-        }
-    }
     .island {
         border-radius: 10px;
     }
@@ -427,10 +253,6 @@ div .deferred-background {
     }
 }
 
-.purchases .mkt-tile + .tray {
-    display: none;
-}
-
 .gallery {
     background: $seavan-salt-white;
 }
@@ -454,16 +276,6 @@ div .deferred-background {
     display: none;
 }
 
-
-@media $retina {
-    .shots .next, .shots .prev {
-        &:after {
-            background: url(../img/icons/slider_arrow-2x.png) no-repeat;
-            background-size: 15px auto;
-        }
-    }
-}
-
 .listing {
     margin-bottom: 10px;
 
@@ -483,18 +295,10 @@ div .deferred-background {
     }
 }
 
-.search-listing .mkt-tile + .tray {
-    border-radius: 0 0 5px 5px;
-}
-
 @media $base-desktop {
     .listing li {
         &.item {
             margin: 25px 0 0;
-
-            .mkt-tile + .tray {
-                border-radius: 0 0 5px 5px;
-            }
         }
         a {
             position: static;
@@ -530,31 +334,6 @@ ratings-sidebar() {
         clear: left;
         float: right;
     }
-    &.expanded .mkt-tile + .tray {
-        &:before, &:after {
-            border-bottom: $triangle-size solid $salt-flat-white;
-            bottom: 0;
-            content: "";
-            display: block;
-            height: 0;
-            position: absolute;
-            top: 0;
-            width: 50%;
-            z-index: 5;
-        }
-        &:before {
-            // dotted gets rid of strange edge rendering in b2g.
-            border-right: $triangle-size dotted transparent;
-            left: -($triangle-size);
-        }
-        &:after {
-            border-left: $triangle-size dotted transparent;
-            right: -($triangle-size);
-        }
-    }
-
-    &.expanded .mkt-tile + .tray:before,
-    &.expanded .mkt-tile + .tray:after,
     &.product-details .mkt-tile {
         background: #fff;
     }
@@ -566,37 +345,21 @@ ratings-sidebar() {
         .mkt-tile {
             border-radius: 10px 10px 0 0;
             ratings-sidebar();
-            + .tray {
-                border-radius: 0;
-            }
         }
     }
 }
 
 @media $base-desktop {
-    .mkt-tile + .tray {
-        border-radius: 0;
-    }
     .listing {
         &:not(.grid-if-desktop) .mkt-tile {
             ratings-sidebar();
         }
         &.product-details {
             border-radius: 10px;
-
-            .mkt-tile {
-                + .tray:after,
-                + .tray:before {
-                    background-image: none;
-                }
-            }
         }
         &.grid-if-desktop li {
             width: (100% / 7);
         }
-    }
-    .search-listing .mkt-tile + .tray {
-        border-radius: 0 0 10px 10px;
     }
     .app-list.grid {
         li:nth-child(7n) {

--- a/src/media/css/previews-tray.styl
+++ b/src/media/css/previews-tray.styl
@@ -1,0 +1,251 @@
+@import 'lib';
+
+$dot-size = 13px;
+$triangle-size = 20px;
+
+.listing.grid-if-desktop .tray,
+.listing.grid-if-desktop .tray img {
+    display: none;
+}
+
+// Previews tray.
+.expanded .tray {
+    display: block;
+}
+
+.tray {
+    background: $salt-flat-white;
+    border-radius: 0 0 10px 10px;
+    display: none;
+    height: 230px;
+    overflow: hidden;
+    padding: 21px 0 0;
+    position: relative;
+
+    &.single {
+        // No dots so make it smaller. Leave 15px from bottom of screenshot to bottom of tray.
+        height: 201px;
+    }
+    &.single .dots {
+        display: none;
+    }
+    .slider {
+        margin-top: 15px;
+        overflow: hidden;
+        user-select: none;
+        -webkit-user-select: none;
+        -moz-user-select: none;
+    }
+    ul {
+        height: 150px; // 150 + 15
+        list-style-type: none;
+        margin: 0 auto;
+        overflow: hidden;
+        padding: 0;
+        white-space: nowrap;
+    }
+    li {
+        float: left;
+        margin-left: 15px;
+        text-align: center;
+        width: 150px; // Max height/width of image.
+        &:first-child {
+            margin-left: 0;
+        }
+        // The following creates a square container
+        // that is as tall as the li is wide and
+        // positions the img vertically and
+        // horizontally center.
+        .thumbnail {
+            display: block;
+            padding-bottom: 100%;
+            position: relative;
+            width: 100%;
+        }
+    }
+}
+.tray img {
+    -moz-user-select: none;
+    bottom: 0;
+    display: block;
+    left: 0;
+    margin: auto;
+    max-height: 100%;
+    max-width: 100%;
+    position: absolute;
+    right: 0;
+    top: 0;
+}
+
+.mkt-tile + .single li {
+    width: 100%;
+
+    img {
+        position: static;
+    }
+}
+
+.tray {
+    .dots {
+        margin-top: 13px;
+        height: $dot-size;
+        text-align: center;
+        width: 100%;
+    }
+    .dot {
+        background: $salt-flat-white;
+        // Don't use shorthand, we do transitions.
+        border-color: $cloud-gray;
+        border-radius: ($dot-size/2);
+        border-style: solid;
+        border-width: 3px;
+        cursor: pointer;
+        display: inline-block;
+        height: $dot-size;
+        margin: 0 3px;
+        transition-duration: 0.15s;
+        transition-property: border-color, border-width;
+        width: $dot-size;
+
+        &.current,
+        &:hover,
+        &:active {
+            border-color: $sailor-blue;
+        }
+        &.current {
+            background: $sailor-blue;
+        }
+    }
+}
+
+.shots .next,
+.shots .prev {
+    display: none;
+}
+
+.purchases .tray {
+    display: none;
+}
+
+.search-listing .tray {
+    border-radius: 0 0 5px 5px;
+}
+
+.expanded .tray {
+    &:before, &:after {
+        border-bottom: $triangle-size solid $salt-flat-white;
+        bottom: 0;
+        content: "";
+        display: block;
+        height: 0;
+        position: absolute;
+        top: 0;
+        width: 50%;
+        z-index: 5;
+    }
+    &:before {
+        // dotted gets rid of strange edge rendering in b2g.
+        border-right: $triangle-size dotted transparent;
+        left: -($triangle-size);
+    }
+    &:after {
+        border-left: $triangle-size dotted transparent;
+        right: -($triangle-size);
+    }
+}
+.expanded .tray:before,
+.expanded .tray:after {
+    background: #fff;
+}
+.product-details .tray {
+    border-radius: 0;
+}
+
+[data-page-type~="detail"] .tray {
+    // Offset div padding.
+    right: 10px;
+    width: unquote('calc(100% + 20px)');
+}
+
+@media $base-desktop {
+    .listing li .tray {
+        border-radius: 0 0 5px 5px;
+    }
+    .tray {
+        border-radius: 0;
+    }
+    .listing.product-details {
+        .mkt-tile {
+            + .tray:after,
+            + .tray:before {
+                background-image: none;
+            }
+        }
+    }
+    .search-listing .tray {
+        border-radius: 0 0 10px 10px;
+    }
+    .shots {
+        position: relative;
+
+        .next, .prev {
+            border-radius: 0 30px 30px 0;
+            border: 15px solid rgba(#252525,.7);
+            height: 60px;
+            margin-top: -30px;
+            outline: 0;
+            position: absolute;
+            top: 50%;
+            transition(all .2s linear);
+            width: 0;
+            z-index: 16;
+
+            &:after {
+                background: url(../img/icons/slider_arrow.png) no-repeat;
+                content: "";
+                float: right;
+                height: 22px;
+                left: 7px;
+                position: relative;
+                top: 4px;
+                width: 15px;
+            }
+            &:hover {
+                border-color: rgba(#252525,.9);
+                border-left-width: 22px;
+            }
+            &:active {
+                border-color: rgba(#777,.9);
+            }
+        }
+        .next {
+            border-radius: 30px 0 0 30px;
+            right: 0;
+
+            &:after {
+                transform(scaleX(-1));
+            }
+            &:hover {
+                border-left-width: 15px;
+                border-right-width: 22px;
+            }
+        }
+        .prev {
+            left: 0;
+        }
+    }
+    #lightbox {
+        .next, .prev {
+            box-shadow: 0 0 4px #fff;
+        }
+    }
+}
+
+@media $retina {
+    .shots .next, .shots .prev {
+        &:after {
+            background: url(../img/icons/slider_arrow-2x.png) no-repeat;
+            background-size: 15px auto;
+        }
+    }
+}

--- a/src/media/css/tiles.styl
+++ b/src/media/css/tiles.styl
@@ -13,7 +13,8 @@ $app-title-size = 20px;
 // Currently used in author truncation.
 $greater-than-mobile = unquote('(min-width: 330px)');
 
-// base class
+
+// Base class.
 .mkt-tile {
     color: $castle-skull-gray;
     display: block;
@@ -85,6 +86,9 @@ $greater-than-mobile = unquote('(min-width: 330px)');
 
 // Detail page.
 .detail {
+    .mkt-tile {
+        padding-top: 10px;
+    }
     .mkt-tile h3 {
         font-size: $app-title-size;
         font-weight: 300;
@@ -100,7 +104,7 @@ $greater-than-mobile = unquote('(min-width: 330px)');
         margin-bottom: 2px;
     }
     .bad-app {
-        margin-top: 12px;
+        padding: 14px 0 10px;
     }
     .icon {
         height: $detail-icon-size;

--- a/src/media/css/typography.styl
+++ b/src/media/css/typography.styl
@@ -51,7 +51,7 @@
 
 body {
     color: $dark-gray;
-    font: 15px $open-stack;
+    font: 15px $primary-font-family;
 }
 
 body, h1, h2, h3, h4 {
@@ -154,9 +154,7 @@ dd {
 
 @media $base-desktop {
     h2 {
-        font-size: 40px;
-        font-weight: 300;
-        line-height: 50px;
+        desktop_mega();
     }
     article {
         border-radius: 10px;

--- a/src/media/js/apps.js
+++ b/src/media/js/apps.js
@@ -96,21 +96,19 @@ define('apps',
         var reasons = [];
         var device = capabilities.device_type();
         if (product.payment_required && !capabilities.navPay && !settings.simulate_nav_pay) {
-            reasons.push(gettext('Your device does not support payments.'));
+            reasons.push(gettext('Not available for your device'));
         } else if (product.payment_required && !product.price) {
-            reasons.push(gettext('This app is unavailable for purchase in your region.'));
+            reasons.push(gettext('Not available for your region'));
         }
-
-        if (!capabilities.webApps || (!capabilities.packagedWebApps && product.is_packaged)) {
-            reasons.push(gettext('Your browser or device is not web-app compatible.'));
-        } else if (!_.contains(product.device_types, device)) {
-            reasons.push(gettext('This app is unavailable for your platform.'));
+        if (!capabilities.webApps ||
+            (!capabilities.packagedWebApps && product.is_packaged) ||
+            !_.contains(product.device_types, device)) {
+            reasons.push(gettext('Not available for your platform'));
         }
 
         product[COMPAT_REASONS] = reasons.length ? reasons : undefined;
         return product[COMPAT_REASONS];
     }
-    nunjucks.require('globals').app_incompat = incompat;
 
     return {
         applyUpdate: applyUpdate,

--- a/src/media/js/helpers_local.js
+++ b/src/media/js/helpers_local.js
@@ -1,7 +1,7 @@
 define('helpers_local',
-    ['feed', 'compatibility_filtering', 'content-ratings', 'models',
+    ['apps', 'feed', 'compatibility_filtering', 'content-ratings', 'models',
      'nunjucks', 'regions', 'settings', 'urls', 'user_helpers', 'utils_local', 'z'],
-    function(feed, compatibility_filtering, iarc, models,
+    function(apps, feed, compatibility_filtering, iarc, models,
              nunjucks, regions, settings, urls, user_helpers, utils_local, z) {
     var filters = nunjucks.require('filters');
     var globals = nunjucks.require('globals');
@@ -68,7 +68,25 @@ define('helpers_local',
         return arr.indexOf(val);
     }
 
+    function app_notices(app) {
+        // App notices for the app detail page (e.g., not available,
+        // works offline). Returns an array of gettext/classes.
+        var notices = [];
+        // Positive notices.
+        if (app.is_offline) {
+            notices.push([gettext('Works offline'), 'positive']);
+        }
+        // Negative notices.
+        var incompat_notices = apps.incompat(app) || [];
+        incompat_notices.forEach(function(notice) {
+            notices.push([notice, 'negative']);
+        });
+        return notices;
+    }
+
     var helpers = {
+        app_incompat: apps.incompat,
+        app_notices: app_notices,
         cast_app: models('app').cast,
         has_installed: has_installed,
         indexOf: indexOf,

--- a/src/media/js/previews.js
+++ b/src/media/js/previews.js
@@ -1,27 +1,24 @@
 define('previews',
-    ['flipsnap', 'log', 'models', 'templates', 'capabilities', 'shothandles', 'underscore', 'z'],
-    function(Flipsnap, log, models, nunjucks, caps, handles, _, z) {
-
-    var console = log('previews');
-
-    // magic numbers!
+    ['flipsnap', 'log', 'models', 'templates', 'capabilities', 'shothandles',
+     'underscore', 'z'],
+    function(Flipsnap, log, models, nunjucks, caps, handles,
+             _, z) {
+    var logger = log('previews');
+    // Magic numbers!
     var THUMB_WIDTH = 150;
     var THUMB_PADDED = 165;
 
     var slider_pool = [];
 
     z.page.on('click', '.dot', function() {
-        console.log('Dot clicked, repositioning trays');
+        logger.log('Dot clicked, repositioning trays');
         var $this = $(this);
         $this.closest('.tray')[0].slider.moveToPoint($this.index());
     });
 
     function populateTray() {
-        // preview trays expect to immediately follow a .mkt-tile.
         var $tray = $(this);
-        if (!$tray.prev().hasClass('mkt-tile') ||
-            $tray.hasClass('single') ||
-            $tray.hasClass('init')) {
+        if ($tray.hasClass('single') || $tray.hasClass('init')) {
             return;
         }
 
@@ -85,8 +82,8 @@ define('previews',
     z.page.on('dragstart dragover', function(e) {
         e.preventDefault();
     }).on('populatetray', function() {
-        console.log('Populating trays');
-        $('.listing.expanded .mkt-tile + .tray').each(populateTray);
+        logger.log('Populating trays');
+        $('.expanded .tray').each(populateTray);
     });
 
 });

--- a/src/media/js/views/app.js
+++ b/src/media/js/views/app.js
@@ -1,8 +1,8 @@
 define('views/app',
-    ['content-ratings', 'l10n', 'log', 'settings', 'overflow', 'tracking',
-     'utils', 'z'],
-    function(iarc, l10n, log, settings, overflow, tracking,
-             utils, z) {
+    ['capabilities', 'content-ratings', 'l10n', 'log', 'overflow', 'settings',
+     'tracking', 'utils', 'z'],
+    function(caps, iarc, l10n, log, overflow, settings,
+             tracking, utils, z) {
     'use strict';
     var gettext = l10n.gettext;
     var logger = log('app');
@@ -47,19 +47,20 @@ define('views/app',
             }
         });
 
-        // tracking_events depends on navigation > views > views/app
-        // Prevents a dep loop, but deps resolved by now.
+        // tracking_events requires navigation > views > views/app
+        // All deps should have been resolved by the time this executes.
         require('tracking_events').track_search_term(true);
 
         var sync = true;
         builder.onload('app-data', function(app) {
+            /* Called after app defer block is finished loading. */
             builder.z('title', utils.translate(app.name));
 
             z.page.trigger('populatetray');
             overflow.init();
 
             $('.truncated-wrapper').each(function() {
-                // 'truncated' class applied by default, remove if not needed.
+                // 'truncated' class applied by default, remove if unneeded.
                 var $this = $(this);
                 if ($this.prop('scrollHeight') <= $this.prop('offsetHeight')) {
                     $this.removeClass('truncated').next('.show-toggle').hide();
@@ -74,12 +75,16 @@ define('views/app',
                 tracking.setPageVar(6, 'App name', app.name, 3);
                 tracking.setPageVar(7, 'App ID', app.id + '', 3);
                 tracking.setPageVar(8, 'App developer', app.author, 3);
-                tracking.setPageVar(9, 'App view source', utils.getVars().src || 'direct', 3);
+                tracking.setPageVar(9, 'App view source',
+                                    utils.getVars().src || 'direct', 3);
+                tracking.setPageVar(10, 'App price',
+                                    app.payment_required ? 'paid' : 'free', 3);
             } else {
                 logger.warn('App object is falsey and is not being tracked');
             }
-
-        }).onload('ratings', function() {
+        })
+        .onload('ratings', function() {
+            /* Called after ratings defer block is finished loading. */
             var reviews = $('.detail .reviews li');
             if (reviews.length >= 3) {
                 for (var i = 0; i < reviews.length - 2; i += 2) {

--- a/src/templates/_macros/app_tile.html
+++ b/src/templates/_macros/app_tile.html
@@ -3,29 +3,29 @@
 {% from "_macros/stars.html" import stars %}
 
 {% macro app_tile(app, feed_app=None, is_detail=False, tray=False, src=None) %}
-
   {#
       app -- app object
       feed_app - feed-app specific data
-      is_detail - is this tile a detail page tile?
+      is_detail - whether part of a detail page
       tray -- whether or not to attach a preview/screenshot tray
       src -- if tile is a link, attach a src param for analytics purposes
   #}
-
   {% set tag = 'div' if is_detail else 'a' %}
-
   <{{ tag }} class="product mkt-tile{{ ' feed-app' if feed_app }}"
-    {% if not is_detail %} href="{{ app.url or url('app', [app.slug])|urlparams(src=src) }}"{% endif %}
-    data-slug="{{ app.slug }}"
-    data-id="{{ app.id }}"
-    {{ 'itemscope itemtype="http://schema.org/SoftwareApplication"' if not is_detail }}>
+             data-slug="{{ app.slug }}" data-id="{{ app.id }}"
+             {% if not is_detail %}
+               href="{{ app.url or url('app', [app.slug])|urlparams(src=src) }}"
+             {% endif %}
+             {{ 'itemscope itemtype="http://schema.org/SoftwareApplication"' if not is_detail }}>
     <div class="heading">
-      {{ deferred_icon(app.icons['64']) }}
+      {# TODO: have backend deserialize a 128px icon. #}
+      {{ deferred_icon(app.icons['64']) if not is_detail else
+         deferred_icon(app.icons['64']|replace('64.png', '128.png'), '', 128) }}
       <div class="info">
         <h3 itemprop="name">{{ app.name|translate(app) }}</h3>
 
         {% if app.author %}
-          {# TODO: When we get user profiles, update this to be a proper Person itemprop #}
+          {# TODO: When we get user profiles, update to be Person itemprop. #}
           <div class="author elliflow vital subdetail" itemprop="creator">
             {% if is_detail -%}
               <a href="{{ url('search')|urlparams(author=app.author) }}">{{ app.author }}</a>
@@ -36,32 +36,29 @@
         {% endif %}
 
         {% if app.slug %}
-          {{ market_button(app,
-                           data_attrs={'manifest_url': app.manifest_url,
-                           'slug': app.slug}) }}
+          {{ market_button(app, data_attrs={'manifest_url': app.manifest_url,
+                                            'slug': app.slug}) }}
         {% endif %}
 
         {{ rating_link() if not is_detail }}
-
       </div>
     </div>
 
-    {% if is_detail %}
-      {{ rating_link(is_detail=True) }}
-    {% endif %}
-
-    {% for notice in app_incompat(app) %}
-      <div class="bad-app">{{ notice }}</div>
-    {% endfor %}
-
-    {% if app.is_offline %}
-      <div class="works-offline hidden">
-        {{ _('Works offline') }}
-      </div>
-    {% endif %}
-
+    {{ rating_link(is_detail=True) if is_detail }}
     {{ feed_app_tile(feed_app) if feed_app }}
   </{{ tag }}>
+
+  {% if is_detail %}
+    {% set notices = app_notices(app) %}
+    {% if notices.length %}
+      <div class="app-notices full">
+        {% for notice in notices %}
+          <span class="{{ notice[1] }}">{{ notice[0] }}</span>
+        {% endfor %}
+      </div>
+    {% endif %}
+  {% endif %}
+
   {% if tray and len(app.previews) %}
     <div class="tray previews full {{ 'single' if len(app.previews) == 1 }}">
       {{ preview_tray(app, src) }}
@@ -90,15 +87,15 @@
 {% endmacro %}
 
 
-{% macro deferred_icon(src, alt) %}
+{% macro deferred_icon(src, alt, width) %}
   {% if not imgAlreadyDeferred(src) %}
     {# Defer image loading. #}
     <img class="icon deferred" src="{{ PLACEHOLDER_ICON }}"
          data-src="{{ src }}" title="{{ alt or '' }}" alt="{{ alt or '' }}"
-         height="60" width="60" itemprop="image">
+         height="{{ width or 60 }}" width="{{ width or 60 }}" itemprop="image">
   {% else %}
     <img class="icon" src="{{ src }}" title="{{ alt or '' }}" alt="{{ alt or '' }}"
-         height="64" width="64" itemprop="image">
+         height="{{ width or 64 }}" width="{{ width or 64 }}" itemprop="image">
   {% endif %}
 {% endmacro %}
 
@@ -117,32 +114,23 @@
 
 
 {% macro rating_link(is_detail=False) %}
-  <div class="rating vital{{ ' unrated' if not app.ratings.count }}" itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating">
-
+  <div class="rating vital{{ ' unrated' if not app.ratings.count }}"
+       itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating">
     {# Detail page ratings link to the ratings list page. #}
     {% if is_detail %}
       <a href="{{ url('app/ratings', [app.slug]) }}" class="rating-link">
-
-        {{ stars(app.ratings.average) }}
-
         {% if app.ratings.count %}
-          <span class="cnt short">
-            {{ _('({n})', n='<span itemprop="reviewCount">' + app.ratings.count|numberfmt + '</span>') }}
-          </span>
+          {{ stars(app.ratings.average) }}
           <span class="cnt long">
             {{ app.ratings.count|numberfmt }} {{ _plural('Review', 'Reviews', n=app.ratings.count) }}
           </span>
         {% else %}
-          {# L10n: "(0)" means "0 reviews." #}
-          <span class="cnt short">{{ _('(0)') }}</span>
           <span class="cnt long">{{ _('Not yet reviewed') }}</span>
         {% endif %}
-
       </a>
     {% else %}
       {# Stars-only rating (member of an app listing). #}
       {{ stars(app.ratings.average) }}
     {% endif %}
-
   </div>
 {% endmacro %}

--- a/src/templates/detail/main.html
+++ b/src/templates/detail/main.html
@@ -5,40 +5,47 @@
 
 {% set endpoint = api('app', [slug]) %}
 
+<section class="main">
+  <div class="subheader">
+    <h1>&nbsp;</h1>
+  </div>
+</section>
+
 <div class="detail" itemscope itemtype="http://schema.org/SoftwareApplication"
      data-slug="{{ slug }}">
-<section class="main product-details listing expanded c">
-  {% defer (url=endpoint, as='app', key=slug, id='app-data') %}
-    {{ app_tile(this, is_detail=True, tray=True, src='detail') }}
-  {% placeholder %}
-    <div class="product mkt-tile">
-      <img class="icon deferred" src="{{ PLACEHOLDER_ICON }}" alt=""
-           data-src="{{ app.icons['64'] }}" height="64" width="64" itemprop="image">
-      <div class="info">
-        <h3>{{ _('Loading...') }}</h3>
-        <div class="price vital">{{ _('Loading...') }}</div>
-        <div class="rating vital unrated">
-          {{ stars(0) }}
+  <section class="main full app-header expanded">
+    {% defer (url=endpoint, as='app', key=slug, id='app-data') %}
+      {{ app_tile(this, is_detail=True, tray=True, src='detail') }}
+    {% placeholder %}
+      <div class="product mkt-tile">
+        <img class="icon deferred" src="{{ PLACEHOLDER_ICON }}" alt=""
+             data-src="{{ app.icons['64'] }}" height="64" width="64" itemprop="image">
+        <div class="info">
+          <h3>{{ _('Loading...') }}</h3>
+          <div class="price vital">{{ _('Loading...') }}</div>
+          <div class="rating vital unrated">
+            {{ stars(0) }}
+          </div>
         </div>
       </div>
-    </div>
-    <div class="tray previews full"></div>
-  {% except %}
-    <div class="detailed-error">
-      <h2>{{ _('Oh no!') }}</h2>
-      {% if error == 403 %}
-        <p>{{ _('The app requested is not public.') }}</p>
-      {% elif error == 404 %}
-        <p>{{ _('The app requested was not found.') }}</p>
-      {% elif error == 451 %}
-        <p>{{ _('The app requested is not available for your region.') }}</p>
-        <p>{{ _('You may wish to contact the developer if you would like to see a version of this app for your region.') }}</p>
-      {% else %}
-        <p>{{ _('A server error occurred. Please try again later.') }}</p>
-      {% endif %}
-    </div>
-  {% end %}
-</section>
+      <div class="tray previews full"></div>
+    {% except %}
+      <div class="detailed-error">
+        <h2>{{ _('Oh no!') }}</h2>
+        {% if error == 403 %}
+          <p>{{ _('The app requested is not public.') }}</p>
+        {% elif error == 404 %}
+          <p>{{ _('The app requested was not found.') }}</p>
+        {% elif error == 451 %}
+          <p>{{ _('The app requested is not available for your region.') }}</p>
+          <p>{{ _('You may wish to contact the developer if you would like to see a version of this app for your region.') }}</p>
+        {% else %}
+          <p>{{ _('A server error occurred. Please try again later.') }}</p>
+        {% endif %}
+      </div>
+    {% end %}
+  </section>
+</div>
 
 <section class="main" id="installed">
   <div>


### PR DESCRIPTION
Mock: https://www.dropbox.com/sh/7v0lv4rm70139o7/AACc_XBUl2TC5ALeR9ksdunQa

This focuses on the app tile portion of the app detail page, i.e., the top.

- button color definitions now using the common colors.styl palette
- preview CSS moved to diff file
- detail CSS now in css/detail, split off into different portions of the detail page
- copy for the app notices shortened
- some CSS selectors made less specific (e.g., remove ```.listing``` from detail page, have preview trays use ```.tray``` over ```.mkt-tile .tray```
- need to have the backend deserialize a 128px icon, but now i'm just using ```|replace('64.png', '128.png')```

![screen shot 2014-12-26 at 6 32 57 am](https://cloud.githubusercontent.com/assets/674727/5557974/5c16a10a-8cc9-11e4-8185-ab36cf3e320f.png)

![screen shot 2014-12-26 at 6 34 51 am](https://cloud.githubusercontent.com/assets/674727/5557975/5f737472-8cc9-11e4-8a90-98cc4b717d9d.png)
