### PR TITLE
remove focus/active outline/borders

### DIFF
--- a/src/media/css/site.styl
+++ b/src/media/css/site.styl
@@ -377,6 +377,16 @@ for region in $regions
     }
 }
 
+// Remove weird focus outlines and borders.
+body {
+    :focus,
+    :active,
+    ::-moz-focus-inner {
+        border: 0;
+        outline: none;
+    }
+}
+
 /* For Firefox for Android. */
 button:not([disabled]):active,
 input:not([disabled]):active,


### PR DESCRIPTION
In Firefox, if you click on something, you can a dotted border outline afterwards. Let's get rid of that.