### PR TITLE
Work around Firefox OS form validation issues in newsletter (bug 1120407)

### DIFF
--- a/src/media/css/newsletter.styl
+++ b/src/media/css/newsletter.styl
@@ -15,6 +15,10 @@
         max-width: 690px;
     }
 
+    .submitted-once input:invalid {
+        box-shadow: 0px 0px 2px 2px $action-error;
+    }
+
     .processing-hidden {
         visibility: hidden;
     }

--- a/src/media/js/newsletter.js
+++ b/src/media/js/newsletter.js
@@ -39,6 +39,11 @@ define('newsletter',
         var $processing = $form.siblings('.processing');
         var data = utils.getVars($form.serialize());
 
+        $form.addClass('submitted-once');
+        if ($form.find(':invalid').length) {
+            return;
+        }
+
         data.newsletter = 'marketplace-' + capabilities.device_platform();
 
         $form.addClass('processing-hidden');


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1120407

Firefox OS does not show error UI for invalid form elements and happily submits an invalid form, even though it does support the relevant "HTML5" attributes and API (bug 943869).

To work around this, style invalid inputs in newsletter form manually if the form has been submitted at least once, and abort submission early when there are invalid inputs remaining.