### PR TITLE
DRYify device detection code (bug 1083592)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "marketplace-constants": "0.4.0",
-    "marketplace-core-modules": "1.3.0",
+    "marketplace-core-modules": "1.4.1",
     "marketplace-elements": "0.1.3",
 
     "almond": "0.2.9",

--- a/src/media/js/compatibility_filtering.js
+++ b/src/media/js/compatibility_filtering.js
@@ -9,8 +9,8 @@ define('compatibility_filtering',
         'feed-items', 'feed-shelf', 'new_popular_search', 'search'
     ];
 
-    var actual_dev = '';
-    var actual_device = '';
+    var actual_platform = '';
+    var actual_formfactor = '';
     var limit = 25;
     var device_filter_name;
     var key = 'device_filtering_preferences';
@@ -36,27 +36,22 @@ define('compatibility_filtering',
     refresh_params();
     z.win.on('navigating', refresh_params);
 
-    // By default, filter by device everywhere but on desktop.
-    if (capabilities.firefoxOS) {
-        // Currently we don't distinguish between mobile & tablet on FirefoxOS,
-        // so don't set actual_device.
-        actual_dev = 'firefoxos';
-    } else if (capabilities.firefoxAndroid) {
-        actual_dev = 'android';
-        actual_device = capabilities.widescreen() ? 'tablet' : 'mobile';
-    }
+    // By default, filter by platform and form factor.
+    actual_platform = capabilities.device_platform();
+    actual_formfactor = capabilities.device_formfactor();
 
     // For mobile phones, set limit to 10, otherwise use the default, 25.
-    if (actual_device == 'mobile' || actual_dev == 'firefoxos') {
+    if (actual_formfactor == 'mobile' || actual_platform == 'firefoxos') {
         limit = 10;
     }
 
-    // Build the name of the filter combination we are currently using. It can
-    // even be '', which is fine, it's the default for desktop (no filtering).
-    if (actual_dev && actual_device) {
-        device_filter_name = actual_dev + '-' + actual_device;
-    } else {
-        device_filter_name = actual_dev;
+    // Build the name of the filter combination we are currently using.
+    device_filter_name = capabilities.device_type();
+
+    // On desktop, the default is no filtering.
+    if (actual_platform == 'desktop') {
+        actual_platform = '';
+        device_filter_name = '';
     }
 
     // Filtering preferences per page group. The default is to follow the
@@ -123,14 +118,14 @@ define('compatibility_filtering',
         else {
             // If device_filtering_preferences[endpoint_name] does not exist or
             // is an 'empty' value, then we use the default filtering behaviour
-            // with whatever dev and device are.
-            args.dev = actual_dev;
-            args.device = actual_device;
+            // with whatever actual_platform and actual_formfactor are.
+            args.dev = actual_platform;
+            args.device = actual_formfactor;
         }
         args.limit = limit;
-        if (actual_dev === 'firefoxos' &&
-            actual_dev === args.dev &&
-            actual_device === args.device &&
+        if (actual_platform === 'firefoxos' &&
+            actual_platform === args.dev &&
+            actual_formfactor === args.device &&
             _.indexOf(ENDPOINTS_WITH_FEATURE_PROFILE, endpoint_name) >= 0) {
             // Include feature profile, but only if specific conditions are met:
             // - We are using a Firefox OS device

--- a/src/tests/compatibility_filtering.js
+++ b/src/tests/compatibility_filtering.js
@@ -10,7 +10,11 @@ test('compatibility_filtering api_args desktop', function(done, fail) {
     mock(
         'compatibility_filtering',
         {
-            capabilities: {firefoxOS: false, firefoxAndroid: false},
+            capabilities: {
+                device_platform: function() { return 'desktop'; },
+                device_formfactor: function() { return ''; },
+                device_type: function() { return 'desktop'; },
+            },
             storage: {getItem: function() {}},
             utils: {getVars: function() { return {};}},
         },
@@ -54,7 +58,11 @@ test('compatibility_filtering api_args desktop override', function(done, fail) {
     mock(
         'compatibility_filtering',
         {
-            capabilities: {firefoxOS: false, firefoxAndroid: false},
+            capabilities: {
+                device_platform: function() { return 'desktop'; },
+                device_formfactor: function() { return ''; },
+                device_type: function() { return 'desktop'; },
+            },
             storage: {getItem: function() {}},
             utils: {getVars: function() { return {'device_override': 'desktop'};}},
         },
@@ -83,7 +91,11 @@ test('compatibility_filtering api_args desktop override firefoxos', function(don
     mock(
         'compatibility_filtering',
         {
-            capabilities: {firefoxOS: false, firefoxAndroid: false},
+            capabilities: {
+                device_platform: function() { return 'desktop'; },
+                device_formfactor: function() { return ''; },
+                device_type: function() { return 'desktop'; },
+            },
             storage: {getItem: function() {}},
             utils: {getVars: function() { return {'device_override': 'firefoxos'};}},
         },
@@ -116,7 +128,11 @@ test('compatibility_filtering api_args endpoint desktop w/ storage', function(do
     mock(
         'compatibility_filtering',
         {
-            capabilities: {firefoxOS: false, firefoxAndroid: false},
+            capabilities: {
+                device_platform: function() { return 'desktop'; },
+                device_formfactor: function() { return ''; },
+                device_type: function() { return 'desktop'; },
+            },
             storage: {getItem: function(key) { if (key == 'device_filtering_preferences') { return stored_prefs; }}},
         },
         function(compatibility_filtering) {
@@ -159,7 +175,11 @@ test('compatibility_filtering api_args endpoint android mobile', function(done, 
     mock(
         'compatibility_filtering',
         {
-            capabilities: {firefoxOS: false, firefoxAndroid: true, widescreen: function() { return false; }},
+            capabilities: {
+                device_platform: function() { return 'android'; },
+                device_formfactor: function() { return 'mobile'; },
+                device_type: function() { return 'android-mobile'; },
+            },
             storage: {getItem: function() {}},
         },
         function(compatibility_filtering) {
@@ -203,7 +223,11 @@ test('compatibility_filtering api_args endpoint android tablet', function(done, 
     mock(
         'compatibility_filtering',
         {
-            capabilities: {firefoxOS: false, firefoxAndroid: true, widescreen: function() { return true; }},
+            capabilities: {
+                device_platform: function() { return 'android'; },
+                device_formfactor: function() { return 'tablet'; },
+                device_type: function() { return 'android-tablet'; },
+            },
             storage: {getItem: function() {}},
         },
         function(compatibility_filtering) {
@@ -247,7 +271,11 @@ test('compatibility_filtering api_args endpoint firefoxos', function(done, fail)
     mock(
         'compatibility_filtering',
         {
-            capabilities: {firefoxOS: true, firefoxAndroid: false},
+            capabilities: {
+                device_platform: function() { return 'firefoxos'; },
+                device_formfactor: function() { return ''; },
+                device_type: function() { return 'firefoxos'; },
+            },
             storage: {getItem: function() {}},
         },
         function(compatibility_filtering) {
@@ -291,7 +319,11 @@ test('compatibility_filtering api_args endpoint firefoxos w/ profiled passed by 
     mock(
         'compatibility_filtering',
         {
-            capabilities: {firefoxOS: true, firefoxAndroid: false},
+            capabilities: {
+                device_platform: function() { return 'firefoxos'; },
+                device_formfactor: function() { return ''; },
+                device_type: function() { return 'firefoxos'; },
+            },
             storage: {getItem: function() {}},
             utils: {getVars: function() { return {'pro': 'dummy-profile'};}},
         },
@@ -345,7 +377,11 @@ test('compatibility_filtering api_args endpoint firefoxos w/ storage', function(
     mock(
         'compatibility_filtering',
         {
-            capabilities: {firefoxOS: true, firefoxAndroid: false},
+            capabilities: {
+                device_platform: function() { return 'firefoxos'; },
+                device_formfactor: function() { return ''; },
+                device_type: function() { return 'firefoxos'; },
+            },
             storage: {getItem: function(key) { if (key == 'device_filtering_preferences') { return stored_prefs; }}},
         },
         function(compatibility_filtering) {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1083592

Uses the new device_* methods introduced in m-c-m 1.4.0 to reduce code duplication.