### PR TITLE
Fix install button :active style (bug 1123352)

### DIFF
--- a/src/media/css/buttons.styl
+++ b/src/media/css/buttons.styl
@@ -271,6 +271,10 @@ commonprops($colour, $shadow) {
             }
         }
     }
+    &:active {
+        // Fix for bug 1123352.
+        background: transparent;
+    }
     &:hover em {
         background: $btn-hvr;
     }

--- a/src/media/css/buttons.styl
+++ b/src/media/css/buttons.styl
@@ -283,7 +283,7 @@ commonprops($colour, $shadow) {
     }
     &.spinning, &.purchasing {
         background: $btn-act;
-        bottom: 1px;
+        bottom: 2px;
         height: $tiny;
 
         em {


### PR DESCRIPTION
Before:

![test___firefox_marketplace](https://cloud.githubusercontent.com/assets/1514/5807558/69222930-a01c-11e4-8796-566116c41ddb.png)


After:

![test___firefox_marketplace](https://cloud.githubusercontent.com/assets/1514/5807559/703ca25e-a01c-11e4-9c39-d740861d39b4.png)

I've added a second commit to fix a small 1px movement downwards when the install button has a spinner.
