### PR TITLE
Re-use the login popup for payments (122792, 1122790)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "marketplace-constants": "0.4.0",
-    "marketplace-core-modules": "1.4.1",
+    "marketplace-core-modules": "1.5.0",
     "marketplace-elements": "0.1.3",
 
     "almond": "0.2.9",

--- a/src/media/js/main.js
+++ b/src/media/js/main.js
@@ -134,14 +134,17 @@ function(_) {
     }
 
     z.page.one('loaded', function() {
-        // Remove the splash screen.
-        console.log('Hiding splash screen (' + ((performance.now() - start_time) / 1000).toFixed(6) + 's)');
-        var splash = $('#splash-overlay').addClass('hide');
-        z.body.removeClass('overlayed').addClass('loaded');
-
-        setTimeout(function() {
-            z.page.trigger('splash_removed');
-        }, 1500);
+        if (z.context.hide_splash !== false) {
+            // Remove the splash screen.
+            console.log('Hiding splash screen (' + ((performance.now() - start_time) / 1000).toFixed(6) + 's)');
+            var splash = $('#splash-overlay').addClass('hide');
+            z.body.removeClass('overlayed').addClass('loaded');
+            setTimeout(function() {
+                z.page.trigger('splash_removed');
+            }, 1500);
+        } else {
+            console.log('Retaining the splash screen for this view');
+        }
     });
 
     // This lets you refresh within the app by holding down command + R.

--- a/src/media/js/payments.js
+++ b/src/media/js/payments.js
@@ -132,7 +132,7 @@ define('payments',
                         break;
                     case 'MKT_SERVER_ERROR':
                         // L10n: This error is raised when we are unable to fetch a JWT from the payments API.
-                        msg = gettext('Error while communicating with server. Try again later.')
+                        msg = gettext('Error while communicating with server. Try again later.');
                         break;
                     default:
                         msg = gettext('Payment failed. Try again later.');
@@ -150,7 +150,7 @@ define('payments',
                 logger.log('payment completed successfully');
                 purchase.resolve(product);
             }
-        });
+        }, {paymentWindow: opt.paymentWindow});
 
         return purchase.promise();
     }


### PR DESCRIPTION
* Popup is created when login is required prior to a purchase. 
* This window is passed to the payments code so it can be re-used for payments.
* Adds feature to retain the splash screen in the fxa_authorize view.

See also: https://github.com/mozilla/marketplace-core-modules/pull/15 (which this branch depends on)