### PR TITLE
Show skipped unittest status

### DIFF
--- a/tests/ui/unittests.js
+++ b/tests/ui/unittests.js
@@ -44,12 +44,16 @@ casper.test.begin('Unit tests', {
         var passCount = 0;
         var failCount = 0;
         var stallCount = 0;
+        var skipCount = 0;
         var initCount = 0;
 
         testResults.forEach(function(testResult) {
             if (testResult.status === 'fail') {
                 failCount++;
                 logError('FAIL', testResult.name);
+            } else if (testResult.status === 'skip') {
+                skipCount++;
+                logError('SKIP', testResult.name, 'COMMENT');
             } else if (testResult.status === 'stall') {
                 stallCount++;
                 logError('STALL', testResult.name);
@@ -62,7 +66,7 @@ casper.test.begin('Unit tests', {
         });
 
         var status, style;
-        if (passCount === testCount) {
+        if (passCount + skipCount === testCount) {
             status = 'PASS';
             style = 'GREEN_BAR';
         } else {
@@ -74,7 +78,8 @@ casper.test.begin('Unit tests', {
             passCount + ' passed',
             failCount + ' failed',
             stallCount + ' stalled',
-            initCount + ' errored'
+            initCount + ' errored',
+            skipCount + ' skipped',
         ].join(', ') + '.', style);
     },
 });


### PR DESCRIPTION
Show the skipped test results in casperjs output. Depends on https://github.com/mozilla/marketplace-core-modules/pull/16.

![screenshot 2015-01-21 15 45 55](https://cloud.githubusercontent.com/assets/211578/5845795/9b832154-a184-11e4-8130-9ff372366275.png)
