### PR TITLE
Restore utils

### DIFF
--- a/src/media/js/apps_buttons.js
+++ b/src/media/js/apps_buttons.js
@@ -1,10 +1,10 @@
 define('apps_buttons',
     ['apps', 'cache', 'capabilities', 'defer', 'l10n', 'log', 'login',
      'models', 'notification', 'payments', 'requests', 'settings',
-     'tracking_events', 'urls', 'user', 'views', 'z'],
+     'tracking_events', 'urls', 'user', 'utils', 'views', 'z'],
     function(apps, cache, capabilities, defer, l10n, log, login, models,
              notification, payments, requests, settings,
-             tracking_events, urls, user, views, z) {
+             tracking_events, urls, user, utils, views, z) {
     var console = log('buttons');
     var gettext = l10n.gettext;
     var apps_model = models('app');


### PR DESCRIPTION
Looks like it was erroneously removed here [1] but it's needed for the popup utils [2]

[1] https://github.com/mozilla/fireplace/commit/821d13f64cc012fb9a90bf1dd99a2d98772cce4a
[2] https://github.com/mozilla/fireplace/blob/master/src/media/js/apps_buttons.js#L54