### PR TITLE
Don't stack the Mac banner on login/logout (bug 1125168)

### DIFF
--- a/src/media/js/main.js
+++ b/src/media/js/main.js
@@ -232,7 +232,10 @@ function(_) {
                 $('#site-nav').after(nunjucks.env.render('incompatible.html'));
             }
         } else if (capabilities.osXInstallIssues) {
-            $('#site-nav').after(nunjucks.env.render('_includes/os_x_banner.html'));
+            if ($('mkt-banner[name="mac-banner"]').length === 0) {
+                $('#site-nav').after(
+                    nunjucks.env.render('_includes/os_x_banner.html'));
+            }
         }
 
         var logged_in = user.logged_in();

--- a/src/templates/_includes/os_x_banner.html
+++ b/src/templates/_includes/os_x_banner.html
@@ -1,4 +1,4 @@
-<mkt-banner>
+<mkt-banner dismiss="session" name="mac-banner">
   <span>
     {{ _('Your Mac settings may only allow you to install apps from the Mac App Store.') }}
   </span>


### PR DESCRIPTION
Remember the dismissal per session, only add the banner if it isn't on the page already.

Depends on https://github.com/mozilla/marketplace-elements/pull/8.