### PR TITLE
use natural-sized images for desktop previews (bug 1122669)

### DIFF
--- a/src/media/css/previews-tray.styl
+++ b/src/media/css/previews-tray.styl
@@ -163,10 +163,6 @@ $desktop-tray-size = 540px;
         li {
             width: $desktop-tray-size;
         }
-        img {
-            height: $desktop-tray-size;
-            width: auto;
-        }
     }
 }
 


### PR DESCRIPTION
The containing `<li>` will restrict to a max of 540x540.

![](https://s3.amazonaws.com/f.cl.ly/items/3q2g3A1S1c3Q0W0z1L3P/Image%202015-01-23%20at%201.37.44%20PM.png)