### PR TITLE
better starting point for trays (bug 1122676)

### DIFF
--- a/src/media/js/previews.js
+++ b/src/media/js/previews.js
@@ -86,11 +86,7 @@ define('previews',
             slider.element.addEventListener('fsmoveend', setActiveBar, false);
 
             // Show as many thumbs as possible to start (zero-indexed).
-            if (numPreviews === 3) {
-                slider.moveToPoint(1);
-            } else {
-                slider.moveToPoint(~~($tray.width() / DESKTOP_PADDED / 2) - 1);
-            }
+            slider.moveToPoint(~~($tray.width() / DESKTOP_PADDED / 2));
 
             slider_pool.push(slider);
         } else {


### PR DESCRIPTION
This should accommodate the desktop init state better.

![](https://s3.amazonaws.com/f.cl.ly/items/413x3f0W41353C1f1O28/Image%202015-01-23%20at%201.55.03%20PM.png)