### PR TITLE
Upload test failure captures for viewing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ before_script:
   - "pushd /tmp/flue"
   - "pip install --user --exists-action=w --download-cache=/tmp/pip-cache -r requirements.txt"
   - "popd"
+# Install gist gem.
+  - "gem install gist"
 # Create an installation.
   - "make install"
 script:
@@ -39,6 +41,8 @@ script:
   - "sleep 5"
 # Run UI tests.
   - "make test"
+# Upload captures.
+  - "sh tests/upload-captures.sh"
 # Test package.
   - "make package"
   - "test -f package/builds/_prod/media/js/include.js"

--- a/tests/upload-captures.sh
+++ b/tests/upload-captures.sh
@@ -1,0 +1,5 @@
+for file in $(find tests/captures -name '*.png')
+do
+    raw_url=$(cat $file | base64 | gist --raw)
+    echo "https://base64service.herokuapp.com/decode?url=$raw_url&filename=$file"
+done


### PR DESCRIPTION
This converts the failure screenshots to base64, uploads them to GitHub in anonymous gists and provides links to view the image by proxying it through [base64service](https://github.com/mstriemer/base64) which decodes the base64 and sets the `Content-type: image/png` header.