### PR TITLE
Fix the intermittent offline test failures

### DIFF
--- a/tests/ui/offline.js
+++ b/tests/ui/offline.js
@@ -27,8 +27,7 @@ casper.test.begin('Check offline dialogue', {
     },
 
     test: function(test) {
-
-        casper.waitUntilVisible('#error-overlay.offline', function() {
+        casper.waitForSelector('#splash-overlay.hide', function() {
             test.assertVisible('#error-overlay.offline', 'Check offline error message is shown');
         });
 
@@ -38,9 +37,11 @@ casper.test.begin('Check offline dialogue', {
         });
 
         casper.waitForSelector('#splash-overlay:not(.hide)', function() {
-            casper.waitForSelector('#splash-overlay.hide', function() {
+            // Wait for the splash to show up again before continuing.
+        });
+
+        casper.waitForSelector('#splash-overlay.hide', function() {
             test.assertNotVisible('#error-overlay.offline', 'Check offline error message is removed');
-            });
         });
 
         casper.run(function() {


### PR DESCRIPTION
It would occasionally fail because the splash hadn't been hidden yet when the error overlay appeared. This forces it to wait for the splash to go away so that we can verify that the page is reloading before the second assertion.