### PR TITLE
refresh tracking events (bug 1126625)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "marketplace-constants": "0.4.0",
     "marketplace-core-modules": "1.6.3",
-    "marketplace-elements": "0.5.1",
+    "marketplace-elements": "0.5.3",
 
     "almond": "0.2.9",
     "jquery": "2.0.2",

--- a/src/media/js/lightbox.js
+++ b/src/media/js/lightbox.js
@@ -1,9 +1,13 @@
+/*
+    Previews and screenshots modal, triggered on click of a preview
+    within a preview tray on an app detail page.
+*/
 define('lightbox',
     ['keys', 'log', 'models', 'navigation', 'utils', 'shothandles', 'tracking',
      'underscore', 'z'],
     function(keys, log, models, navigation, utils, handles, tracking,
              _, z) {
-    var console = log('lightbox');
+    var logger = log('lightbox');
 
     var $lightbox = $(document.getElementById('lightbox'));
     var $section = $lightbox.find('section');
@@ -15,18 +19,8 @@ define('lightbox',
     $lightbox.addClass('shots');
 
     function showLightbox() {
-        console.log('Opening lightbox');
-
-        if (z.context.type === 'leaf') {
-            tracking.trackEvent('App view interactions', 'click',
-                                'Screenshot view');
-        } else if (z.context.type === 'search') {
-            tracking.trackEvent(
-                'Category view interactions',
-                'click',
-                'Screenshot view'
-            );
-        }
+        logger.log('Opening lightbox');
+        z.body.trigger('lightbox-open');
 
         var $this = $(this);
         var which = $this.closest('li').index();
@@ -34,7 +28,7 @@ define('lightbox',
         var $tile = $tray.siblings('.mkt-tile');
 
         if (!$tile.length) {
-            console.log('[WARN] could not find .mkt-tile near .previews.');
+            logger.log('[WARN] could not find .mkt-tile near .previews.');
             return;
         }
 

--- a/src/media/js/mobilenetwork.js
+++ b/src/media/js/mobilenetwork.js
@@ -1,6 +1,6 @@
 define('mobilenetwork',
-       ['l10n', 'log', 'regions', 'tracking', 'user', 'utils'],
-       function(l10n, log, regions, tracking, user, utils) {
+    ['l10n', 'log', 'regions', 'tracking', 'user', 'utils'],
+    function(l10n, log, regions, tracking, user, utils) {
     var console = log('mobilenetwork');
     var persistent_console = log.persistent('mobilenetwork', 'change');
     var gettext = l10n.gettext;

--- a/src/media/js/reviews.js
+++ b/src/media/js/reviews.js
@@ -1,10 +1,10 @@
 define('reviews',
     ['cache', 'capabilities', 'forms', 'jquery', 'l10n', 'login', 'models',
      'notification', 'nunjucks', 'ratingwidget', 'requests', 'settings',
-     'tracking', 'underscore', 'utils', 'urls', 'user', 'z'],
+     'underscore', 'utils', 'urls', 'user', 'z'],
     function(cache, caps, forms, $, l10n, login, models,
              notification, nunjucks, ratingwidget, requests, settings,
-             tracking, _, utils, urls, user, z) {
+             _, utils, urls, user, z) {
     var gettext = l10n.gettext;
     var notify = notification.notification;
     var open_rating = false;
@@ -224,11 +224,6 @@ define('reviews',
             notify({message: gettext('Your review was successfully posted. Thanks!')});
 
             z.page.trigger('navigate', urls.reverse('app', [slug]));
-
-            tracking.trackEvent('App view interactions', 'click',
-                                'Successful review');
-            tracking.setVar(12, 'Reviewer', 'Reviewer', 1);
-            tracking.trackEvent('Write a Review', 'click', slug, data.rating);
 
         }).fail(function() {
             forms.toggleSubmitFormState($this, true);

--- a/src/media/js/settings.js
+++ b/src/media/js/settings.js
@@ -78,7 +78,7 @@ define('settings', ['l10n', 'settings_local', 'underscore'], function(l10n, sett
 
         // Switches for features.
         payments_enabled: true,
-        tracking_enabled: false,
+        tracking_enabled: true,
         action_tracking_enabled: true,
         upsell_enabled: true,
         cache_rewriting_enabled: true,

--- a/src/templates/_macros/feed_item.html
+++ b/src/templates/_macros/feed_item.html
@@ -18,7 +18,7 @@
   {% set desc = feed_app.description|translate(feed_app) %}
 
   <a href="{{ url('app', [feed_app.app.slug])|urlparams(src='featured-app') }}"
-     class="featured-app app-link" data-tracking-slug="{{ feed_app.app.slug }}">
+     class="featured-app app-link" data-tracking="{{ feed_app.app.slug }}">
     {% if indexOf([feed.FEEDAPP_ICON, feed.FEEDAPP_IMAGE], feed_app.type) != -1 %}
       <section class="feed-item {{ 'deferred-background' if feed_app.background_image }}"
                {% if feed_app.type == feed.FEEDAPP_ICON %}
@@ -92,7 +92,7 @@
   {% set max_apps = 4 %}
 
   <section class="feed-brand feed-layout-{{ brand.layout }} multi-app-tile c"
-           data-tracking-slug="{{ brand.slug }}">
+           data-tracking="{{ brand.slug }}">
     {{ brand_header(brand) }}
     <ul>
       {% for app in brand.apps %}
@@ -128,7 +128,7 @@
   <section class="feed-item feed-collection full {{ 'mega' if desc }}
                   {{ 'has-desc' if desc }}
                   {{ 'has-background deferred-background' if coll.background_image }}"
-           data-tracking-slug="{{ coll.slug }}"
+           data-tracking="{{ coll.slug }}"
        {% if coll.background_image %}
            style="background-image: url({{ PLACEHOLDER_ICON }})"
            data-src="{{ coll.background_image }}"
@@ -166,7 +166,7 @@
 
   <section class="feed-collection feed-collection-listing feed-layout-list
                   multi-app-tile mkt-tile c"
-           data-tracking-slug="{{ coll.slug }}">
+           data-tracking="{{ coll.slug }}">
     {{ collection_listing_header(coll) }}
     {% if coll.description %}
       <p class="desc">{{ coll.description|translate(coll)|safe }}</p>
@@ -192,7 +192,7 @@
   {# Used both for collections and shelves. Reduce, reuse, recycle. #}
   {% set src = 'operator-shelf-element' if coll.carrier else 'collection-element' %}
 
-  <div class="collection-landing-wrapper"
+  <div class="collection-landing-wrapper" data-tracking="{{ coll.slug }}"
        {% if not coll.carrier %}
          data-collection-landing-color="{{ coll.color or 'sapphire' }}"
        {% endif %}
@@ -294,7 +294,7 @@
   {% elif obj.item_type == 'shelf' %}
     <a href="{{ url('feed/feed_shelf', [obj.shelf.slug])|
                 urlparams(src='operator-shelf-element') }}"
-       class="op-shelf" data-tracking-slug="{{ obj.shelf.slug }}">
+       class="op-shelf" data-tracking="{{ obj.shelf.slug }}">
       {{ shelf(obj.shelf) }}
     </a>
   {% endif %}

--- a/tests/ui/app/index.js
+++ b/tests/ui/app/index.js
@@ -3,7 +3,7 @@
 */
 var helpers = require('../lib/helpers');
 
-casper.test.begin('App detail tests', {
+casper.test.begin('Test app detail', {
     test: function(test) {
         helpers.startCasper({path: '/app/free'});
 
@@ -42,7 +42,7 @@ casper.test.begin('App detail tests', {
 });
 
 
-casper.test.begin('App detail previews tests', {
+casper.test.begin('Test app detail previews', {
     test: function(test) {
         helpers.startCasper({path: '/app/abc'});
 
@@ -60,6 +60,12 @@ casper.test.begin('App detail previews tests', {
 
         casper.waitWhileVisible('#lightbox', function() {
             test.assertNotVisible('#lightbox', 'Lightbox should be invisible');
+
+            helpers.assertUATracking(test, [
+                'App view interactions',
+                'click',
+                'Screenshot view'
+            ]);
         });
 
         helpers.done(test);
@@ -67,8 +73,28 @@ casper.test.begin('App detail previews tests', {
 });
 
 
+casper.test.begin('Test app detail description toggle', {
+    test: function(test) {
+        helpers.startCasper({path: '/app/abc'});
 
-casper.test.begin('App detail tests for packaged apps', {
+        casper.waitForSelector('.description-wrapper.truncated', function() {
+            casper.click('.description-wrapper + .truncate-toggle');
+
+            test.assertNotExists('.description-wrapper.truncated');
+
+            helpers.assertUATracking(test, [
+                'App view interactions',
+                'click',
+                'Toggle description'
+            ]);
+        });
+
+        helpers.done(test);
+    }
+});
+
+
+casper.test.begin('Test app detail tests for packaged apps', {
     test: function(test) {
         helpers.startCasper({path: '/app/packaged'});
         helpers.waitForPageLoaded(function() {
@@ -80,7 +106,7 @@ casper.test.begin('App detail tests for packaged apps', {
 });
 
 
-casper.test.begin('App detail tests for paid apps', {
+casper.test.begin('Test app detail for paid apps', {
     test: function(test) {
         helpers.startCasper({path: '/app/paid'});
         helpers.waitForPageLoaded(function() {
@@ -91,7 +117,7 @@ casper.test.begin('App detail tests for paid apps', {
 });
 
 
-casper.test.begin('App detail tests as a developer', {
+casper.test.begin('Test app detail as a developer', {
     test: function(test) {
         helpers.startCasper({path: '/app/developed'});
 
@@ -110,7 +136,7 @@ casper.test.begin('App detail tests as a developer', {
 });
 
 
-casper.test.begin('App detail tests as a reviewer', {
+casper.test.begin('Test app detail as a reviewer', {
     test: function(test) {
         helpers.startCasper({path: '/app/developed'});
 
@@ -130,7 +156,7 @@ casper.test.begin('App detail tests as a reviewer', {
 });
 
 
-casper.test.begin('App detail reviews tests if user has not rated', {
+casper.test.begin('Test app detail reviews if user has not rated', {
     setUp: helpers.setUpDesktop,
     tearDown: helpers.tearDown,
     test: function(test) {
@@ -149,7 +175,7 @@ casper.test.begin('App detail reviews tests if user has not rated', {
 });
 
 
-casper.test.begin('App detail reviews tests if user has rated', {
+casper.test.begin('Test app detail reviews if user has rated', {
     setUp: helpers.setUpDesktop,
     tearDown: helpers.tearDown,
     test: function(test) {

--- a/tests/ui/app/reviews.js
+++ b/tests/ui/app/reviews.js
@@ -4,18 +4,31 @@
 var helpers = require('../lib/helpers');
 
 function testAddReviewModal(test) {
-    casper.waitForSelector('.mkt-prompt .add-review-form', function() {
+    casper.waitForSelector('.add-review-form', function() {
         test.assertSelectorHasText('.char-count b', '150');
         test.assert(!helpers.checkValidity('.mkt-prompt form'));
         casper.fill('.add-review-form', {'body': 'test'});
     });
 
     casper.waitForText('146', function() {
+        // Test form validity.
         test.assert(!helpers.checkValidity('.mkt-prompt form'));
+
         casper.click('.stars input[value="3"]');
         test.assert(helpers.checkValidity('.mkt-prompt form'));
+        casper.click('.add-review-form [type="submit"]');
+    });
+
+    casper.waitWhileVisible('.add-review-form', function() {
+        // Post review stuff.
+        helpers.assertUATracking(test, [
+            'App view interactions',
+            'click',
+            'Successful review'
+        ]);
     });
 }
+
 
 casper.test.begin('Test app review page', {
     test: function(test) {
@@ -31,6 +44,7 @@ casper.test.begin('Test app review page', {
         helpers.done(test);
     }
 });
+
 
 casper.test.begin('Test flag review on app review page', {
     test: function(test) {

--- a/tests/ui/app_list.js
+++ b/tests/ui/app_list.js
@@ -142,12 +142,26 @@ appListPages.forEach(function(appListPage) {
                 if (!appListPage.collection) {
                     var toggleLink = '.app-list-filters-expand-toggle';
                     test.assertVisible(toggleLink);
+
+                    // Expanded view.
                     casper.click(toggleLink);
                     test.assertExists(toggleLink + '.active');
                     test.assertExists('.app-list.expanded');
+                    helpers.assertUATracking(test, [
+                        'View type interactions',
+                        'click',
+                        'Expanded view'
+                    ]);
+
+                    // List view.
                     casper.click(toggleLink);
                     test.assertExists(toggleLink + ':not(.active)');
                     test.assertExists('.app-list:not(.expanded)');
+                    helpers.assertUATracking(test, [
+                        'View type interactions',
+                        'click',
+                        'List view'
+                    ]);
                 }
 
                 // Test authors are not a link.

--- a/tests/ui/feedback.js
+++ b/tests/ui/feedback.js
@@ -15,9 +15,11 @@ function testFeedbackForm(test) {
     test.assertVisible('[name="feedback"]');
 
     test.assert(!helpers.checkValidity('.feedback-form'));
+
     casper.fill('.feedback-form', {'feedback': 'test'});
     test.assert(helpers.checkValidity('.feedback-form'));
 }
+
 
 casper.test.begin('Test feedback page', {
     test: function(test) {

--- a/tests/ui/index.js
+++ b/tests/ui/index.js
@@ -1,10 +1,10 @@
 var helpers = require('../lib/helpers');
 
-helpers.startCasper();
-
-casper.test.begin('"Home" page tests', {
+casper.test.begin('Test homepage', {
     test: function(test) {
-        casper.waitForSelector('#splash-overlay.hide', function() {
+        helpers.startCasper();
+
+        helpers.waitForPageLoaded(function() {
             test.assertTitle('Firefox Marketplace');
             test.assertVisible('.wordmark');
             test.assertVisible('.header-button.settings');
@@ -14,8 +14,89 @@ casper.test.begin('"Home" page tests', {
             test.assertNotVisible('.app-list-filters-expand-toggle');
         });
 
-        casper.run(function() {
-            test.done();
+        helpers.done(test);
+    }
+});
+
+casper.test.begin('Test Feed navigation and tracking events', {
+    test: function(test) {
+        casper.waitForSelector('.home-feed', function() {
+            helpers.assertUATracking(test, [
+                15,
+                'Package Version',
+                0
+            ]);
+
+            casper.click('.feed-collection[data-tracking="coll-listing"] .view-all-tab');
+            helpers.assertWaitForSelector(test, '.app-list');
+            helpers.assertUATracking(test, [
+                'View Collection',
+                'click',
+                'coll-listing'
+            ]);
+
+            casper.back();
         });
+
+        casper.waitForSelector('.home-feed', function() {
+            casper.click('.feed-collection[data-tracking="coll-listing"] .mkt-tile');
+            helpers.assertWaitForSelector(test, '[data-page-type~="detail"]');
+            helpers.assertUATracking(test, [
+                'View App from Collection Element',
+                'click',
+                'coll-listing'
+            ]);
+
+            casper.back();
+        });
+
+        casper.waitForSelector('.home-feed', function() {
+            casper.click('.featured-app');
+            helpers.assertUATracking(test, 'View App from Featured App Element');
+
+            casper.back();
+        });
+
+        casper.waitForSelector('.home-feed', function() {
+            casper.click('[data-tracking="brand-grid"] .view-all-tab');
+            helpers.assertWaitForSelector(test, '.app-list');
+            helpers.assertUATracking(test, [
+                'View Branded Editorial Element',
+                'click',
+                'brand-grid',
+            ]);
+
+            casper.back();
+        });
+
+        casper.waitForSelector('.home-feed', function() {
+            casper.click('.feed-brand .mkt-tile');
+            helpers.assertWaitForSelector(test, '[data-page-type~="detail"]');
+            helpers.assertUATracking(test, 'View App from Branded Editorial Element');
+
+            casper.back();
+        });
+
+        casper.waitForSelector('.home-feed', function() {
+            casper.click('.feed-brand .mkt-tile');
+            helpers.assertWaitForSelector(test, '[data-page-type~="detail"]');
+            helpers.assertUATracking(test, 'View App from Branded Editorial Element');
+
+            casper.back();
+        });
+
+        casper.waitForSelector('.home-feed', function() {
+            casper.click('.op-shelf');
+            casper.waitForSelector('.app-list');
+            helpers.assertUATracking(test, 'View Operator Shelf Element');
+
+            casper.waitForSelector('[data-page-type~="shelf-landing"] .mkt-tile', function() {
+                casper.click('.mkt-tile');
+                helpers.assertWaitForSelector(test, '[data-page-type~="detail"]');
+                helpers.assertUATracking(test, 'View App from Operator Shelf Element');
+            });
+        });
+
+        helpers.done(test);
     }
 });

--- a/tests/ui/navbar.js
+++ b/tests/ui/navbar.js
@@ -47,3 +47,18 @@ casper.test.begin('Test navbar', {
         helpers.done(test);
     }
 });
+
+casper.test.begin('Test navbar tracking events', {
+    test: function(test) {
+        helpers.waitForPageLoaded(function() {
+            casper.click('.navbar [data-tab="popular"] a');
+            helpers.assertUATracking(test, [
+                'Nav Click',
+                'click',
+                'popular'
+            ]);
+        });
+
+        helpers.done(test);
+    }
+});

--- a/tests/ui/offline.js
+++ b/tests/ui/offline.js
@@ -1,8 +1,5 @@
 var helpers = require('../lib/helpers');
 
-helpers.startCasper();
-
-
 function restoreOnlineState() {
     casper.echo('Changing window.__mockOffLine -> false', 'INFO');
     casper.evaluate(function() {
@@ -10,9 +7,7 @@ function restoreOnlineState() {
     });
 }
 
-
 casper.test.begin('Check offline dialogue', {
-
     setUp: function() {
         casper.once('page.initialized', function() {
             casper.echo('Setting window.__mockOffLine -> true', 'INFO');
@@ -21,14 +16,15 @@ casper.test.begin('Check offline dialogue', {
             });
         });
     },
-
     tearDown: function() {
         restoreOnlineState();
     },
-
     test: function(test) {
-        casper.waitForSelector('#splash-overlay.hide', function() {
-            test.assertVisible('#error-overlay.offline', 'Check offline error message is shown');
+        helpers.startCasper();
+
+        helpers.waitForPageLoaded(function() {
+            test.assertVisible('#error-overlay.offline',
+                               'Check offline error message is shown');
         });
 
         casper.then(function() {
@@ -41,11 +37,10 @@ casper.test.begin('Check offline dialogue', {
         });
 
         casper.waitForSelector('#splash-overlay.hide', function() {
-            test.assertNotVisible('#error-overlay.offline', 'Check offline error message is removed');
+            test.assertNotVisible('#error-overlay.offline',
+                                  'Check offline error message is removed');
         });
 
-        casper.run(function() {
-            test.done();
-        });
+        helpers.done(test);
     },
 });


### PR DESCRIPTION
PR:

- move some more tracking events into tracking_events.js
- move the tracking logging duties into tracking.js
- fix lightbox events
- pull in modal update that lets it work better on phantom
- remove rickfant rolled egg
- test most tracking events besides app install/launch ones
- enable tracking by default
- test for description toggle and feed navigations

Depends on https://github.com/mozilla/marketplace-api-mock/commit/6ad63d445123deacdc4ba321984db5e451d83b70 which has been committed