### PR TITLE
fix app detail loading offset, clean up some previews code (bug 1126504)

### DIFF
--- a/src/media/css/detail/base.styl
+++ b/src/media/css/detail/base.styl
@@ -60,6 +60,10 @@
 }
 
 @media $base-tablet {
+    [data-page-type~="detail"] .detail > .placeholder > .loading {
+        // Fix offset caused by not all elements being loaded.
+        margin-top: 82px;
+    }
     .detail-flex-wrap {
         display: flex;
         justify-content: center;

--- a/src/media/css/detail/header.styl
+++ b/src/media/css/detail/header.styl
@@ -5,6 +5,7 @@
 @import '../lib';
 
 .app-header.full {
+    margin-bottom: -10px;
     padding-bottom: 0;
 
     > div {

--- a/src/media/css/previews-tray.styl
+++ b/src/media/css/previews-tray.styl
@@ -139,16 +139,10 @@ $desktop-tray-size = 540px;
         }
     }
     [data-page-type~="detail"] .tray {
-        height: $desktop-tray-size + 23px;
-        left: 0;
-        position: absolute;
-        right: inherit;
-        top: 225px;
+        height: $desktop-tray-size;
+        position: relative;
         width: 100%;
 
-        .bars {
-            margin-top: 10px;
-        }
         .content {
             display: none;
         }
@@ -157,12 +151,10 @@ $desktop-tray-size = 540px;
         }
     }
     .tray .desktop-content {
-        height: $desktop-tray-size;
+        height: $desktop-tray-size - 20px;
     }
-    .desktop-content {
-        li {
-            width: $desktop-tray-size;
-        }
+    .desktop-content li {
+        width: $desktop-tray-size;
     }
 }
 

--- a/src/media/js/previews.js
+++ b/src/media/js/previews.js
@@ -1,9 +1,15 @@
+/*
+    Preview trays which holds previews and screenshots.
+    On mobile, uses Flipsnap which enables touch-drag.
+    On desktop, adds prev/next buttons to navigate images.
+*/
 define('previews',
     ['flipsnap', 'log', 'models', 'templates', 'capabilities', 'shothandles',
      'underscore', 'z'],
     function(Flipsnap, log, models, nunjucks, caps, handles,
              _, z) {
     var logger = log('previews');
+
     // Magic numbers!
     var THUMB_WIDTH = 150;
     var THUMB_PADDED = 165;
@@ -12,28 +18,16 @@ define('previews',
 
     var slider_pool = [];
 
-    function adjustOffset() {
-        var trayOffset = 0;
-        // If the app shows notices we need to increase the container height.
-        // TODO: Clean this up better once we have an idea
-        // of whether we're happy with the desktop trays.
+    function adjustWidth() {
+        // Full width of window on desktop.
+        // Width of page on mobile.
+        var $previews = $('.previews');
         if (window.matchMedia('(min-width:1070px)').matches) {
-            if ($('.app-notices').children().length) {
-                trayOffset += 90;
-            }
-            if ($('#installed').css('display') !== 'none') {
-                trayOffset += 90;
-            }
-
-            $('.app-header.expanded > div')
-               .css('height', 778 + trayOffset + 'px')
-               .find('.previews')
-               .css('top', 225 + trayOffset + 'px');
+            var winWidth = z.win.width();
+            $previews.css('width', winWidth + 'px');
+            $previews.css('right', (winWidth - 1070) / 2 + 'px');
         } else {
-            $('.app-header.expanded > div')
-                .css('height', 'inherit')
-                .find('.previews')
-                .css('top', 0);
+            $previews.attr('style', '');
         }
     }
 
@@ -45,7 +39,7 @@ define('previews',
 
         // Init desktop detail screenshot tray.
         if (caps.device_type() === 'desktop' &&
-            $('[data-page-type~="detail"] .detail').length &&
+            $('[data-page-type~="detail"]').length &&
             window.matchMedia('(min-width:1070px)').matches) {
 
             if ($tray.find('.desktop-content').length) {
@@ -61,7 +55,7 @@ define('previews',
                 $desktopShots.append($newShot);
             });
 
-            adjustOffset();
+            adjustWidth();
             $tray.find('.slider').append($desktopShots);
 
             $desktopShots.css({
@@ -137,7 +131,7 @@ define('previews',
             e.refresh();
         }
         z.page.trigger('populatetray');
-        adjustOffset();
+        adjustWidth();
     });
 
     // We're leaving the page, so destroy Flipsnap.

--- a/src/media/js/views/app.js
+++ b/src/media/js/views/app.js
@@ -31,6 +31,10 @@ define('views/app',
             placeholder_app: {
                 author: gettext('Loading...'),
                 name: gettext('Loading...'),
+                previews: [{
+                    image_url: '',
+                    thumbnail_url: ''
+                }],
                 price: gettext('Loading...'),
                 price_locale: gettext('Loading...'),
                 ratings: {

--- a/src/templates/app/index.html
+++ b/src/templates/app/index.html
@@ -41,7 +41,7 @@
   </div></section>
 {% placeholder %}
   <section class="main full app-header expanded"><div>
-    {{ app_tile(placeholder_app, is_detail=True) }}
+    {{ app_tile(placeholder_app, is_detail=True, tray=True) }}
   </div></section>
 {% except %}
 {% end %}


### PR DESCRIPTION
- add 83px to top of loading div on apps detail page. didn't investigate the cause, but just when more stuff is rendered, it pulls the page back down
- not making the preview trays abs position on detail page simplifies some calculations