### PR TITLE
hide app ratings on 'new' page (bug 1126921)

### DIFF
--- a/src/media/css/app-list.styl
+++ b/src/media/css/app-list.styl
@@ -57,6 +57,11 @@ $desktop-tile-padding = 20px 50px;
     }
 }
 
+// Hide rating on the "new" page. Most apps there have no rating.
+[data-page-type~="new"] .mkt-tile .rating {
+    display: none;
+}
+
 @media $base-tablet {
     .app-list,
     .app-list.only-logged-in {

--- a/src/media/css/tiles.styl
+++ b/src/media/css/tiles.styl
@@ -148,16 +148,6 @@ $greater-than-mobile = unquote('(min-width: 330px)');
     }
 }
 
-.listing .mkt-tile {
-    .subdetail {
-        line-height: 18px;
-        max-height: 28px;
-    }
-    .price {
-        display: none;
-    }
-}
-
 .app-header {
     .works-offline {
         background: url(../img/pretty/no-connection.svg) 0 10px no-repeat;


### PR DESCRIPTION
Looks a bit awkward but here it is.

![](https://s3.amazonaws.com/f.cl.ly/items/3z471M0r1l351r2M1a2H/Image%202015-02-02%20at%201.21.33%20AM.png)

![](https://s3.amazonaws.com/f.cl.ly/items/2b2h42081V2S2F1v2b2D/Image%202015-02-02%20at%201.22.12%20AM.png)