### PR TITLE
Close popup on payment cancellation and success (bug 1130342)

### DIFF
--- a/src/media/js/apps_buttons.js
+++ b/src/media/js/apps_buttons.js
@@ -132,6 +132,13 @@ define('apps_buttons',
                 notification.notification({message: gettext('Payment cancelled.')});
                 logger.log('Purchase flow rejected for', product.name);
                 def.reject();
+            }).always(function() {
+                if (loginPopup) {
+                    // If we created the popup for a login and re-used it for a payment
+                    // we now need to close it.
+                    logger.log('Closing the popup window');
+                    loginPopup.close();
+                }
             });
         } else {
             // If a popup was kept open for payments we don't need it


### PR DESCRIPTION
As we're passing a window to fxpay, fxpay assumes we're managing it so we need to close it on cancellation or payment successes on the FP side.

r? @kumar303 