### PR TITLE
list toggle reload flash issue (bug 1130451)

### DIFF
--- a/src/media/css/app-list.styl
+++ b/src/media/css/app-list.styl
@@ -24,6 +24,7 @@ $desktop-tile-padding = 20px 50px;
 }
 
 .app-list {
+    display: none;
     list-style: none;
 
     // Masking element to cover the last row's bottom border.
@@ -40,6 +41,9 @@ $desktop-tile-padding = 20px 50px;
     }
     &.expanded .app-list-app {
         padding-bottom: 40px;
+    }
+    &.show {
+        display: block;
     }
 }
 
@@ -78,7 +82,7 @@ section.langpacks > div {
 @media $base-tablet {
     .app-list,
     .app-list.only-logged-in {
-        display-flex();
+        display: none;
     }
     .app-list {
         flex-wrap(wrap);
@@ -124,6 +128,10 @@ section.langpacks > div {
         section.full > div {
             padding-top: 30px;
         }
+    }
+    .app-list.show,
+    .app-list.only-logged-in.show {
+        display-flex();
     }
 }
 

--- a/src/media/css/app-list.styl
+++ b/src/media/css/app-list.styl
@@ -24,7 +24,7 @@ $desktop-tile-padding = 20px 50px;
 }
 
 .app-list {
-    display: none;
+    opacity: 0;
     list-style: none;
 
     // Masking element to cover the last row's bottom border.
@@ -43,7 +43,7 @@ $desktop-tile-padding = 20px 50px;
         padding-bottom: 40px;
     }
     &.show {
-        display: block;
+        opacity: 1;
     }
 }
 
@@ -82,7 +82,7 @@ section.langpacks > div {
 @media $base-tablet {
     .app-list,
     .app-list.only-logged-in {
-        display: none;
+        display-flex();
     }
     .app-list {
         flex-wrap(wrap);
@@ -128,10 +128,6 @@ section.langpacks > div {
         section.full > div {
             padding-top: 30px;
         }
-    }
-    .app-list.show,
-    .app-list.only-logged-in.show {
-        display-flex();
     }
 }
 

--- a/src/media/js/app_list.js
+++ b/src/media/js/app_list.js
@@ -17,7 +17,7 @@ define('app_list',
         if (expanded !== undefined) {
             expand = expanded;
         }
-        $('.app-list').toggleClass('expanded', expanded);
+        $('.app-list').toggleClass('expanded', expanded).addClass('show');
         $('.app-list-filters-expand-toggle')
             .toggleClass('active', expand)
             .addClass('show');


### PR DESCRIPTION
This fixes the problem where if all the compat filtered apps are cached and the page reloads immediately and the expand toggle was active....the list of apps would briefly flash as collapsed before expanding. 