### PR TITLE
Polish: fix typo and reword "Your Mac settings may only allow you to install apps from the Mac App Store." translation

### DIFF
--- a/locale/pl/LC_MESSAGES/messages.po
+++ b/locale/pl/LC_MESSAGES/messages.po
@@ -4,15 +4,15 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-02-11T17:58:58.145Z\n"
-"PO-Revision-Date: 2015-02-01 16:24+0100\n"
-"Last-Translator: Wojciech Szczęsny\n"
+"PO-Revision-Date: 2015-02-17 22:59+0100\n"
+"Last-Translator: Stefan Plewako <splewako@aviary.pl>\n"
 "Language-Team: Polish <team@aviary.pl>\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
-"X-Generator: Lokalize 1.4\n"
+"X-Generator: Poedit 1.7.4\n"
 
 #: /templates/app_list.html:7 /templates/category.html:17 /templates/search.html:26 /templates/purchases.html:7
 msgid "Expand"
@@ -571,7 +571,7 @@ msgstr "Uruchom tę aplikację z <b>panelu głównego</b>, <b>aktywatora aplikac
 
 #: /templates/_includes/os_x_banner.html:2
 msgid "Your Mac settings may only allow you to install apps from the Mac App Store."
-msgstr "Twoja ustawienia komputera Mac mogą pozwalać na instalację aplikacji tylko z Mac App Store.."
+msgstr "Ustawienie Twojego Maca mogą pozwalać na instalację aplikacji wyłącznie z Mac App Store."
 
 #: /templates/_includes/os_x_banner.html:5
 msgid "Learn how to change them."


### PR DESCRIPTION
"Your Mac settings may only allow you to install apps from the Mac App Store." has ugly and quote visible typo in Polish. This commit fixes the typo and improves whole sentence translation.