### PR TITLE
updated preview trays

### DIFF
--- a/src/media/css/buttons-loadmore.styl
+++ b/src/media/css/buttons-loadmore.styl
@@ -69,9 +69,6 @@ $loadmore-desktop-width = 300px;
     .loadmore {
         padding: 25px 10px 0;
     }
-    .grid-if-desktop .loadmore {
-        padding-top: 18px;
-    }
     [data-page-type~=homepage],
     [data-page-type~=app-list] {
         padding-bottom: 0;

--- a/src/media/css/lightbox.styl
+++ b/src/media/css/lightbox.styl
@@ -112,3 +112,8 @@
         line-height: 60px;
     }
 }
+
+// Hide arrow buttons when overlay is up.
+.overlayed div:not(#lightbox) .arrow-button {
+    display: none;
+}

--- a/src/media/css/previews-tray.styl
+++ b/src/media/css/previews-tray.styl
@@ -2,42 +2,25 @@
 
 $bar-height = 3px;
 $tray-height = 170px;
-$desktop-tray-size = 540px;
-
-.listing.grid-if-desktop .tray,
-.listing.grid-if-desktop .tray img {
-    display: none;
-}
+$thumbnail-height = 150px;
+$full-shot-height = 520px;
+$desktop-tray-height = 560px;
 
 // Previews tray.
-.expanded .tray {
+.expanded .previews-tray {
     display: block;
 }
 
-.tray {
+.previews-tray {
     background: $filters-border;
     display: none;
-    height: $tray-height;
+    height: $tray-height + $bar-height;
     overflow: hidden;
-    padding: 10px 0 0;
     position: relative;
     top: 20px;
 
-    &.single {
-        height: $tray-height;
-    }
-    &.single .bars,
-    .desktop-content {
-        display: none;
-    }
-    .slider {
-        overflow: hidden;
-        user-select: none;
-        -webkit-user-select: none;
-        -moz-user-select: none;
-    }
     ul {
-        height: $tray-height - 20;
+        height: $thumbnail-height;
         list-style-type: none;
         margin: 0 auto;
         overflow: hidden;
@@ -48,7 +31,7 @@ $desktop-tray-size = 540px;
         float: left;
         margin-left: 10px;
         text-align: center;
-        width: 150px; // Max height/width of image.
+        width: $thumbnail-height;
 
         &:first-child {
             margin-left: 0;
@@ -64,34 +47,40 @@ $desktop-tray-size = 540px;
             width: 100%;
         }
     }
-}
-.tray img {
-    -moz-user-select: none;
-    bottom: 0;
-    display: block;
-    left: 0;
-    margin: auto;
-    max-height: 100%;
-    max-width: 100%;
-    position: absolute;
-    right: 0;
-    top: 0;
+    img {
+        bottom: 0;
+        disable-user-select();
+        display: block;
+        left: 0;
+        margin: auto;
+        max-height: 100%;
+        max-width: 100%;
+        position: absolute;
+        right: 0;
+        top: 0;
+    }
 }
 
-.mkt-tile + .single li {
+.previews-slider {
+    disable-user-select();
+    overflow: hidden;
+    padding-top: 10px;
+}
+
+.mkt-tile + .single-preview li {
     width: 100%;
 }
 
-.single .desktop-content > li {
+.single-preview .previews-desktop-content > li {
     width: 100%;
 
     .thumbnail {
-        height: 520px;
+        height: $full-shot-height;
         padding: 0;
     }
 }
 
-.single .content {
+.single-preview .previews-content {
     width: 100%;
 
     > li {
@@ -103,16 +92,15 @@ $desktop-tray-size = 540px;
     }
 }
 
-.tray {
-    .bars {
-        background: $white;
-        display: none;
-        margin-top: 7px;
-        height: $bar-height;
-        text-align: center;
-        width: 100%;
-    }
-    .bar {
+.previews-bars {
+    background: $white;
+    display-flex();
+    margin-top: 10px;
+    height: $bar-height;
+    text-align: center;
+    width: 100%;
+
+    b {
         flex-grow(1);
         height: $bar-height;
         margin: 0;
@@ -121,30 +109,38 @@ $desktop-tray-size = 540px;
             background: $action-positive;
         }
     }
-    .arrow-button {
-        display: none;
+}
+
+.previews-desktop-content,
+.previews-tray .arrow-button {
+    display: none;
+}
+
+.single-preview .previews-content {
+    width: 100%;
+
+    > li {
+        width: 100%;
+    }
+    .thumbnail {
+        height: 150px;
+        padding: 0;
     }
 }
 
-[data-page-type~="detail"] .tray {
-    // Offset div padding.
-    right: 10px;
-    top: 0;
-    width: unquote('calc(100% + 20px)');
+[data-page-type~="detail"] .previews-tray {
+    height: 193px;
+    margin-left: -10px;
+    width: unquote('calc(100% + 20px)')
 }
 
 @media $base-desktop {
-    .listing.app-header .mkt-tile {
-        + .tray:after,
-        + .tray:before {
-            background-image: none;
-        }
-    }
-    .shots {
+    .previews-slider {
         position: relative;
 
         .arrow-button {
-            margin-top: -15px;
+            display: block;
+            margin-top: -10px;
             outline: 0;
             position: absolute;
             top: 50%;
@@ -157,29 +153,23 @@ $desktop-tray-size = 540px;
             left: 20px;
         }
     }
-    [data-page-type~="detail"] .tray {
-        height: $desktop-tray-size;
+    [data-page-type~="detail"] .previews-tray {
+        height: $desktop-tray-height + $bar-height;
         position: relative;
-        width: 100%;
 
-        .content {
+        .previews-content {
             display: none;
         }
-        .desktop-content {
+        .previews-desktop-content {
             display: block;
         }
     }
-    .tray .desktop-content {
-        height: $desktop-tray-size - 20px;
+    .previews-tray .previews-desktop-content {
+        height: $full-shot-height;
     }
-    .desktop-content li {
-        width: $desktop-tray-size;
-    }
-    .tray .bars {
-        display-flex();
-    }
-    .tray .arrow-button {
-        display: block;
+    .previews-desktop-content li {
+        height: $full-shot-height;
+        width: $full-shot-height;
     }
 }
 

--- a/src/media/css/search.styl
+++ b/src/media/css/search.styl
@@ -37,18 +37,5 @@
 @media $base-desktop {
     #search-results {
         margin-top: 0;
-
-        .listing > li {
-            .shots .next,
-            .shots .prev {
-                opacity: 0;
-            }
-            &:hover {
-                .shots .next,
-                .shots .prev {
-                    opacity: 1;
-                }
-            }
-        }
     }
 }

--- a/src/media/css/site.styl
+++ b/src/media/css/site.styl
@@ -78,7 +78,12 @@ section.full + section.full {
     margin-top: 10px;
 }
 
-.js-hidden, .hidden {
+// Faster way to toggle show/hide than $.show()/$.hide()
+.js-hidden {
+    display: none !important;
+}
+
+.hidden {
     display: none;
 }
 

--- a/src/media/img/icons/placeholder.svg
+++ b/src/media/img/icons/placeholder.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 18.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 65 65" enable-background="new 0 0 65 65" xml:space="preserve">
+<g>
+	<g>
+		
+			<path fill="none" stroke="#CACACA" stroke-width="1.9375" stroke-linecap="round" stroke-miterlimit="10" stroke-dasharray="5.9611,7.9481" d="
+			M32.5,63.5L32.5,63.5c-17.1,0-31-13.9-31-31c0-17.1,13.9-31,31-31h0c17.1,0,31,13.9,31,31C63.5,49.6,49.6,63.5,32.5,63.5z"/>
+	</g>
+	<g>
+		<path fill="#CACACA" d="M33.8,43.7c0.2,0.5,0.3,1,0.3,1.6c0,1.5-1.2,2.8-1.6,2.8c-0.4,0-1.6-1.3-1.6-2.8c0-0.6,0.1-1.2,0.3-1.6
+			h-1.9c-0.2,0.8-0.3,1.7-0.3,2.6c0,3.4,2.6,6.2,3.5,6.2c0.9,0,3.5-2.8,3.5-6.2c0-0.9-0.1-1.8-0.3-2.6H33.8z"/>
+		<path fill="#CACACA" d="M40.6,27.3c-1.5-7.4-5.9-14.8-8.1-14.8c-2.2,0-6.6,7.4-8.1,14.8l-5.1,5.1v13.2h3.5l4.9-4.9
+			c0.5,0.5,1.1,1,1.6,1.3h6.2c0.6-0.3,1.2-0.8,1.7-1.3l4.9,4.9h3.5V32.3L40.6,27.3z M32.6,24.8c-1.1,0-2.1,0.1-3.1,0.3
+			c0.9-2.6,2.2-4.9,3-4.9c0.8,0,2.2,2.2,3,4.8C34.6,24.9,33.6,24.8,32.6,24.8z"/>
+	</g>
+</g>
+</svg>

--- a/src/media/js/helpers_local.js
+++ b/src/media/js/helpers_local.js
@@ -68,7 +68,7 @@ define('helpers_local',
     globals.NEWSLETTER_LANGUAGES = settings.NEWSLETTER_LANGUAGES;
     globals.REGIONS = regions.REGION_CHOICES_SLUG;
     globals.user_helpers = user_helpers;
-    globals.PLACEHOLDER_ICON = urls.media('fireplace/img/icons/placeholder.png');
+    globals.PLACEHOLDER_ICON = urls.media('fireplace/img/icons/placeholder.svg');
     globals.compatibility_filtering = compatibility_filtering;
 
     /* Helpers functions, provided in the default context. */

--- a/src/media/js/lightbox.js
+++ b/src/media/js/lightbox.js
@@ -16,7 +16,7 @@ define('lightbox',
     var previews;
     var slider;
 
-    $lightbox.addClass('shots');
+    $lightbox.addClass('shots previews-slider');
 
     function showLightbox() {
         logger.log('Opening lightbox');
@@ -24,7 +24,7 @@ define('lightbox',
 
         var $this = $(this);
         var which = $this.closest('li').index();
-        var $tray = $this.closest('.tray');
+        var $tray = $this.closest('.previews-tray');
         var $tile = $tray.siblings('.mkt-tile');
 
         if (!$tile.length) {
@@ -157,7 +157,7 @@ define('lightbox',
     z.win.on('resize', _.debounce(resize, 200));
 
     // If a tray thumbnail is clicked, load up our lightbox.
-    z.page.on('click', '.tray ul a', utils._pd(showLightbox));
+    z.page.on('click', '.previews-tray .screenshot', utils._pd(showLightbox));
 
     // Dismiss the lighbox when we click outside it or on the close button.
     $lightbox.on('click', function(e) {

--- a/src/templates/_macros/app_tile.html
+++ b/src/templates/_macros/app_tile.html
@@ -65,7 +65,7 @@
   {% endif %}
 
   {% if tray and len(app.previews) %}
-    <div class="tray previews full {{ 'single' if len(app.previews) == 1 }}">
+    <div class="previews-tray full {{ 'single-preview' if len(app.previews) == 1 }}">
       {{ preview_tray(app, src) }}
     </div>
   {% endif %}
@@ -73,8 +73,8 @@
 
 
 {% macro preview_tray(app, src) %}
-  <div class="slider shots">
-    <ul class="content">
+  <div class="previews-slider">
+    <ul class="previews-content">
       {% for preview in app.previews %}
         <li itemscope itemtype="http://schema.org/ImageObject">
           <a class="screenshot thumbnail" href="{{ preview.image_url }}">
@@ -84,9 +84,9 @@
       {% endfor %}
     </ul>
   </div>
-  <div class="bars">
+  <div class="previews-bars">
     {% for preview in app.previews %}
-      <b class="bar"></b>
+      <b></b>
     {% endfor %}
   </div>
 {% endmacro %}

--- a/tests/ui/app/index.js
+++ b/tests/ui/app/index.js
@@ -26,8 +26,8 @@ casper.test.begin('Test app detail', {
             test.assert(href.indexOf('/search?author') !== -1);
             test.assertSelectorHasText('.mkt-tile .install em', 'Free');
             test.assertVisible('.mkt-tile .install');
-            test.assertVisible('.previews');
-            test.assertExists('.previews img');
+            test.assertVisible('.previews-tray');
+            test.assertExists('.previews-tray img');
 
             // Test app info section.
             helpers.assertContainsText('[itemprop="description"]');
@@ -49,11 +49,11 @@ casper.test.begin('Test app detail previews', {
     test: function(test) {
         helpers.startCasper({path: '/app/abc'});
 
-        casper.waitForSelector('.previews img', function() {
-            casper.click('.previews');
-            casper.click('.previews li:first-child');
-            casper.click('.previews li:first-child .screenshot');
-            casper.click('.previews li:first-child .screenshot img');
+        casper.waitForSelector('.previews-tray img', function() {
+            casper.click('.previews-tray');
+            casper.click('.previews-tray li:first-child');
+            casper.click('.previews-tray li:first-child .screenshot');
+            casper.click('.previews-tray li:first-child .screenshot img');
         });
 
         casper.waitForSelector('#lightbox.show', function() {
@@ -234,10 +234,9 @@ casper.test.begin('Test app detail mobile previews', {
         helpers.startCasper({path: '/app/something'});
 
         helpers.waitForPageLoaded(function() {
-            test.assertVisible('.previews .content');
-            test.assertVisible('.content li:first-child img');
-            test.assertNotVisible('.tray .bars');
-            test.assertNotVisible('.tray .arrow-button');
+            test.assertVisible('.previews-content');
+            test.assertVisible('.previews-bars');
+            test.assertNotVisible('.previews-tray .arrow-button');
         });
 
         helpers.done(test);
@@ -249,10 +248,10 @@ casper.test.begin('Test app detail desktop previews', {
         helpers.startCasper({path: '/app/something', viewport: 'desktop'});
 
         helpers.waitForPageLoaded(function() {
-            test.assertVisible('.previews .desktop-content');
-            test.assertVisible('.desktop-content li:first-child img');
-            test.assertVisible('.tray .bars');
-            test.assertVisible('.tray .arrow-button');
+            test.assertVisible('.previews-tray .previews-desktop-content');
+            test.assertVisible('.previews-tray li:first-child img');
+            test.assertVisible('.previews-tray .previews-bars');
+            test.assertVisible('.previews-tray .arrow-button');
         });
 
         helpers.done(test);

--- a/tests/ui/app_list.js
+++ b/tests/ui/app_list.js
@@ -352,14 +352,14 @@ appListPages.forEach(function(appListPage) {
                 waitForAppListPage(appListPage, function() {
                     // Expand listings.
                     casper.click('.app-list-filters-expand-toggle');
-                    test.assertVisible('.previews li:first-child img');
-                    test.assertNotVisible('.tray .bars');
-                    test.assertNotVisible('.tray .arrow-button');
+                    test.assertVisible('.previews-tray li:first-child img');
+                    test.assertVisible('.previews-tray .previews-bars');
+                    test.assertNotVisible('.previews-tray .arrow-button');
 
                     // Collapse listings.
                     casper.click('.app-list-filters-expand-toggle');
                     test.assertExists('.app-list:not(.expanded)');
-                    test.assertNotVisible('.app-list-app .preview');
+                    test.assertNotVisible('.app-list-app .previews-tray');
                 });
 
                 helpers.done(test);
@@ -371,14 +371,14 @@ appListPages.forEach(function(appListPage) {
                 waitForAppListPage(appListPage, function() {
                     // Expand listings.
                     casper.click('.app-list-filters-expand-toggle');
-                    test.assertVisible('.previews li:first-child img');
-                    test.assertVisible('.tray .bars');
-                    test.assertVisible('.tray .arrow-button');
+                    test.assertVisible('.previews-tray li:first-child img');
+                    test.assertVisible('.previews-tray .previews-bars');
+                    test.assertVisible('.previews-tray .arrow-button');
 
                     // Collapse listings.
                     casper.click('.app-list-filters-expand-toggle');
                     test.assertExists('.app-list:not(.expanded)');
-                    test.assertNotVisible('.app-list-app .preview');
+                    test.assertNotVisible('.app-list-app .previews-tray');
                 }, {viewport: 'desktop'});
 
                 helpers.done(test);
@@ -418,7 +418,7 @@ casper.test.begin('Test collection detail page for app tile expanded state.', {
         casper.thenOpen(helpers.makeUrl('/feed/collection/top-games'), function() {
             helpers.waitForPageLoaded(function() {
                 test.assertDoesntExist('.app-list.expanded');
-                test.assertDoesntExist('.previews');
+                test.assertDoesntExist('.previews-tray');
             });
         });
         helpers.done(test);


### PR DESCRIPTION
Biggest change this offers is no longer recreating the trays on desktop on every resize. Some old and unnecessary CSS was removed (.listing ...) etc.

- JS logic should be a bit more readable.
- New breakpoint definition (1050px - this will play into the padding bug also).
- No initialization needed on single preview trays (except on desktop detail and there it's minimal).
- Better centering logic for preview images (I want to tweak this even more for when arrows are active).
- New placeholder icon.

![](http://i.imgur.com/NbPLVOb.png)

![](http://i.imgur.com/xuBxL5T.png)

![](http://i.imgur.com/kwmynSQ.png)