### PR TITLE
Fix active/inactive states in category page toggles (bug 1123897).

### DIFF
--- a/src/media/css/app-list-filters.styl
+++ b/src/media/css/app-list-filters.styl
@@ -27,7 +27,7 @@ App listing filters.
     width: 100%;
 
     a {
-        color: $greyscale-black;
+        color: $action-positive;
         display: inline-block;
         ellipsis();
         font-size: 15px;
@@ -43,11 +43,12 @@ App listing filters.
         vertical-align: middle;
 
         &:hover {
-            border-bottom: 2px solid $greyscale-light-grey;
+            text-decoration: underline;
         }
         &.active {
-            border-bottom: 2px solid $filters-link;
+            color: $greyscale-black;
             pointer-events: none;
+            cursor: default;
         }
         &.active:before,
         &.active:after {

--- a/src/media/css/app-list-filters.styl
+++ b/src/media/css/app-list-filters.styl
@@ -66,7 +66,7 @@ App listing filters.
 }
 
 .app-list-filters-expand-toggle {
-    background: url(../img/pretty/list-toggle.svg) no-repeat 0 -40px / 82px auto;
+    background: url(../img/pretty/list-toggle.svg) no-repeat 0 0 / 82px auto;
     display: none;
     float: right;
     height: 40px;
@@ -75,7 +75,7 @@ App listing filters.
     width: 84px;
 
     &.active {
-        background-position: 0 0;
+        background-position: 0 -40px;
     }
     &:active {
         background: url(../img/pretty/list-toggle.svg) no-repeat 0 -40px / 82px auto;


### PR DESCRIPTION
After talking it over with @pwalm, he agreed with me that having the bright color be inactive and the underline indicate the active was a little bit awkward, as both could be used to indicate the active state. He asked me to remove the underline, and the active state be black and have the default cursor with no underline, while inactive be blue and underline on hover. This was hit in 35aac0b.

Additionally, we noticed that there was then an inconsistency between active/inactive colors between this toggle and the preview tray toggle. He indicated that the preview tray toggle was wrong, and asked me to switch it. That was in 6979b33.

r? @ngoke @spasovski 

# Before

![screen shot 2015-02-18 at 3 31 47 pm](https://cloud.githubusercontent.com/assets/23885/6258170/9aa98f56-b783-11e4-80c3-667594aa2bf4.png)

# After

![screen shot 2015-02-18 at 3 31 00 pm](https://cloud.githubusercontent.com/assets/23885/6258173/a2bde3fe-b783-11e4-984f-877f7a3e3936.png)
