### PR TITLE
Rework date displaying and implement last updated on app details page (bug 1127055)

### DIFF
--- a/src/templates/app/index.html
+++ b/src/templates/app/index.html
@@ -84,11 +84,10 @@
           </section>
         {% endif %}
 
-        {% if this.is_packaged %}
-          <section class="prose package-version">
-            <h3>{{ _('Version') }}</h3>
-            <p>{{ _('Latest version: {version}',
-                    version=this.current_version) }}</p>
+        {% if this.is_packaged and this.last_updated %}
+          <section class="prose package-last-updated">
+            <h3>{{ _('Last updated') }}</h3>
+            <p>{{ this.last_updated|date }}</p>
           </section>
         {% endif %}
 

--- a/tests/ui/app/index.js
+++ b/tests/ui/app/index.js
@@ -116,7 +116,13 @@ casper.test.begin('Test app detail tests for packaged apps', {
         helpers.startCasper({path: '/app/packaged'});
         helpers.waitForPageLoaded(function() {
             test.assertUrlMatch(/\/app\/packaged/);
-            test.assertSelectorHasText('.package-version', 'Latest version: 1.0');
+            test.assertExists('.package-last-updated h3');
+            // Date is either in Y-m-d format or in Month, Day, Year
+            // format depending on what is available. We simply try to parse it
+            // to see if it's a valid date.
+            test.assertTruthy(
+                Date.parse(casper.fetchText('.package-last-updated p')),
+               'Last updated text is a valid date');
         });
         helpers.done(test);
     }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1127055

`toLocaleDateString()` is unreliable on Firefox OS and Android, so we use `Intl.DateTimeFormat()` instead if available, and fall back to `Y-m-d` formatting if absent. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString compatibility notes and https://bugzilla.mozilla.org/show_bug.cgi?id=864843.

Note: `|date` filter was already used on reviews and had the same issue, so this will affect reviews, but in a good way IMHO. 