### PR TITLE
refresh UA tracking code (bug 1103180)

### DIFF
--- a/src/media/js/app_list.js
+++ b/src/media/js/app_list.js
@@ -26,7 +26,7 @@ define('app_list',
     z.body.on('click', '.app-list-filters-expand-toggle', utils._pd(function() {
         expand = !expand;
         initTileState();
-        z.doc.trigger('scroll');  // For defer image loading.
+        z.doc.trigger('image-deferrer--load');
     }));
 
     z.page.on('loaded reloaded_chrome', function() {

--- a/src/media/js/apps_buttons.js
+++ b/src/media/js/apps_buttons.js
@@ -99,7 +99,7 @@ define('apps_buttons',
         var def = defer.Deferred();
 
         // Create a reference to the button.
-        var $this = $button || $(this);
+        $button = $button || $(this);
         var _timeout;
 
         // If the user has already purchased the app, we do need to generate
@@ -111,9 +111,10 @@ define('apps_buttons',
         if (product.payment_required) {
             // The app requires a payment.
             logger.log('Starting payment flow for', product.name);
+
             // Save the old text of the button.
             $this.data('old-text', $this.find('em').text());
-            setInstallBtnState($this, gettext('Purchasing'), 'purchasing');
+            setInstallBtnState($button, gettext('Purchasing'), 'purchasing');
 
             var purchaseOpts = {
                 // This will be undefined unless a window was created
@@ -124,9 +125,9 @@ define('apps_buttons',
                 logger.log('Purchase flow completed for', product.name);
 
                 // Update the button to say Install.
-                setInstallBtnState($this, gettext('Install'), 'purchased');
+                setInstallBtnState($button, gettext('Install'), 'purchased');
                 // Save the old text of the button.
-                $this.data('old-text', $this.find('em').text());
+                $this.data('old-text', $button.find('em').text());
 
                 // Update the cache to show that the app was purchased.
                 user.update_purchased(product.id);
@@ -176,19 +177,19 @@ define('apps_buttons',
         function start_install() {
             // Track the search term used to find this app, if applicable.
             tracking_events.track_search_term();
-            tracking_events.track_app_install_begin(product, $this);
+            tracking_events.trackAppInstallBegin($button);
 
             // Make the button a spinner.
-            $this.data('old-text', $this.find('em').text())
+            $button.data('old-text', $button.find('em').text())
                  .addClass('spinning');
 
             // Temporary timeout for hosted apps until we catch the appropriate
             // download error event for hosted apps (in iframe).
             if (!product.is_packaged && !product.payment_required) {
                 _timeout = setTimeout(function() {
-                    if ($this.hasClass('spinning')) {
+                    if ($button.hasClass('spinning')) {
                         logger.log('Spinner timeout for ', product.name);
-                        revertButton($this);
+                        revertButton($button);
                         notification.notification({
                             message: gettext('Sorry, we had trouble fetching this app\'s data. Please try again later.')
                         });
@@ -253,7 +254,7 @@ define('apps_buttons',
                     cache.bust(urls.api.url('installed'));
                 }
 
-                def.resolve(installer, product, $this);
+                def.resolve(installer, product, $button);
             }).fail(function(error) {
                 if (error) {
                     notification.notification({message: error});
@@ -285,11 +286,11 @@ define('apps_buttons',
                 // multiple instances of the same button on the page.
                 mark_installed(product.manifest_url);
             });
-            tracking_events.track_app_install_success(product, $this);
+            tracking_events.trackAppInstallSuccess($button);
             logger.log('Successful install for', product.name);
         }, function() {
-            revertButton($this);
-            tracking_events.track_app_install_fail(product, $this);
+            revertButton($button);
+            tracking_events.trackAppInstallFail($button);
             logger.log('Unsuccessful install for', product.name);
         });
 

--- a/src/media/js/apps_buttons.js
+++ b/src/media/js/apps_buttons.js
@@ -5,11 +5,11 @@ define('apps_buttons',
      'core/user', 'core/utils', 'core/views', 'core/z'],
     function(apps, cache, caps, defer, l10n,
              log, login, models, notification, payments,
-             requests, settings, tracking_events, urls, user, utils,
+             requests, settings, trackingEvents, urls, user, utils,
              views, z) {
     var logger = log('buttons');
     var gettext = l10n.gettext;
-    var apps_model = models('app');
+    var appModel = models('app');
 
     z.page.one('iframe-install-loaded', function() {
         markBtnsAsInstalled();
@@ -45,7 +45,7 @@ define('apps_buttons',
 
             // Fetch the product from either model cache or data attr.
             var $btn = $(this);
-            var product = apps_model.lookup($btn.closest('[data-slug]').data('slug')) ||
+            var product = appModel.lookup($btn.closest('[data-slug]').data('slug')) ||
                           $btn.data('product');
             func.call(this, product);
         };
@@ -53,7 +53,7 @@ define('apps_buttons',
 
     var launchHandler = _handler(function(product) {
         apps.launch(product.manifest_url);
-        tracking_events.track_app_launch(product);
+        trackingEvents.trackAppLaunch(product);
     });
 
     function install(product, $button, loginPopup) {
@@ -175,9 +175,7 @@ define('apps_buttons',
         }
 
         function start_install() {
-            // Track the search term used to find this app, if applicable.
-            tracking_events.track_search_term();
-            tracking_events.trackAppInstallBegin($button);
+            trackingEvents.trackAppInstallBegin($button);
 
             // Make the button a spinner.
             $button.data('old-text', $button.find('em').text())
@@ -286,11 +284,11 @@ define('apps_buttons',
                 // multiple instances of the same button on the page.
                 mark_installed(product.manifest_url);
             });
-            tracking_events.trackAppInstallSuccess($button);
+            trackingEvents.trackAppInstallSuccess($button);
             logger.log('Successful install for', product.name);
         }, function() {
             revertButton($button);
-            tracking_events.trackAppInstallFail($button);
+            trackingEvents.trackAppInstallFail($button);
             logger.log('Unsuccessful install for', product.name);
         });
 

--- a/src/media/js/desktop_promo.js
+++ b/src/media/js/desktop_promo.js
@@ -2,8 +2,9 @@
     Content for the desktop promo carousel.
 */
 define('desktop_promo',
-    ['core/capabilities', 'core/l10n', 'core/urls', 'core/utils',],
-    function(caps, l10n, urls, utils) {
+    ['core/capabilities', 'core/l10n', 'core/urls', 'core/utils',
+     'tracking_events'],
+    function(caps, l10n, urls, utils, trackingEvents) {
     'use strict';
     var gettext = l10n.gettext;
 
@@ -40,8 +41,10 @@ define('desktop_promo',
                 text: gettext('Store and share any type of file with Box.'),
             },
         ].map(function(item) {
-          item.url = utils.urlparams(item.url, {src: 'desktop-promo'});
-          return item;
+            item.url = utils.urlparams(item.url, {
+                src: trackingEvents.SRCS.desktopPromo
+            });
+            return item;
         })
     };
 });

--- a/src/media/js/feed.js
+++ b/src/media/js/feed.js
@@ -3,9 +3,11 @@
 */
 define('feed',
     ['collection_colors', 'edbrands', 'core/l10n', 'core/nunjucks',
-     'core/urls', 'core/utils', 'underscore', 'utils_local'],
+     'core/urls', 'core/utils', 'tracking_events', 'underscore',
+     'utils_local'],
     function(colors, brands, l10n, nunjucks,
-             urls, utils, _, utils_local) {
+             urls, utils, trackingEvents, _,
+             utils_local) {
     'use strict';
     var gettext = l10n.gettext;
 
@@ -47,12 +49,12 @@ define('feed',
                         feedItem.isPreview = true;
                         break;
                 }
-                feedItem.src = 'featured-app';
+                feedItem.src = trackingEvents.SRCS.featuredApp;
                 break;
             case 'brand':
                 feedItem.color = get_brand_color_class(feedItem);
                 feedItem.name = brands.get_brand_type(feedItem.type, feedItem.apps.length);
-                feedItem.src = 'branded-editorial-element';
+                feedItem.src = trackingEvents.SRCS.brand;
                 break;
             case 'collection':
                 if (feedItem.type == 'promo') {
@@ -60,10 +62,10 @@ define('feed',
                 } else {
                     feedItem.isCollListing = true;
                 }
-                feedItem.src = 'collection-element';
+                feedItem.src = trackingEvents.SRCS.collection;
                 break;
             case 'shelf':
-                feedItem.src = 'operator-shelf-element';
+                feedItem.src = trackingEvents.SRCS.shelf;
                 break;
         }
 

--- a/src/media/js/feed.js
+++ b/src/media/js/feed.js
@@ -69,6 +69,11 @@ define('feed',
                 break;
         }
 
+        // Some cases, we want to persist the previous src, like Desktop Promo.
+        if (utils.getVars().src in trackingEvents.PERSISTENT_SRCS) {
+            feedItem.src = utils.getVars().src;
+        }
+
         // Get the Feed detail page URL for the item.
         if (feedItem.isApp) {
             feedItem.landingUrl = urls.reverse('app', [feedItem.app.slug]);

--- a/src/media/js/helpers_local.js
+++ b/src/media/js/helpers_local.js
@@ -2,23 +2,21 @@ define('helpers_local',
     ['apps', 'categories', 'compat_filter', 'content-ratings',
      'core/format', 'core/helpers', 'core/models', 'core/nunjucks',
      'core/settings', 'core/urls', 'core/utils', 'core/z', 'feed', 'regions',
-     'user_helpers', 'utils_local'],
-    function(apps, categories, compat_filter, iarc,
+     'tracking_events', 'user_helpers', 'utils_local'],
+    function(apps, categories, compatFilter, iarc,
              format, base_helpers, models, nunjucks,
              settings, urls, utils, z, feed, regions,
-             user_helpers, utils_local) {
+             trackingEvents, user_helpers, utils_local) {
     var filters = nunjucks.require('filters');
     var globals = nunjucks.require('globals');
 
     // developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString
-    // toLocaleDateString() is unreliable ; on Firefox Android and FxOS, it
-    // will return the date in m/d/Y format, even if you try to pass custom
-    // locale and/or options!.
-    // To avoid having to ship a full re-implementation, we use
-    // Intl.DateTimeFormat(), which is equivalent but only present if the
-    // underlying platform has a full implementation, and fall back to Y-m-d.
-    // This gives us a pretty date format (e.g. Saturday, February 15, 2014) on
-    // desktop, and leaves something somewhat universal on phones (2014-02-15).
+    // toLocaleDateString() on FxAndroid and FxOS returns m/d/Y even if passing
+    // custom locale + options! To not ship full re-implementation, use
+    // Intl.DateTimeFormat(), which is equivalent, but only present if
+    // underlying platform has full implementation. Else fall back to Y-m-d.
+    // Pretty date format (e.g. Saturday, February 15, 2014) on desktop
+    // Something more universal (2014-02-15) on phones.
     var dateFormat;
     if (typeof Intl !== 'undefined' &&
         typeof Intl.DateTimeFormat !== 'undefined') {
@@ -94,14 +92,15 @@ define('helpers_local',
 
     /* Global variables, provided in default context. */
     globals.CATEGORIES = categories;
-    globals.DEVICE_CHOICES = compat_filter.DEVICE_CHOICES;
+    globals.DEVICE_CHOICES = compatFilter.DEVICE_CHOICES;
     globals.feed = feed;
     globals.iarc_names = iarc.names;
     globals.NEWSLETTER_LANGUAGES = settings.NEWSLETTER_LANGUAGES;
     globals.REGIONS = regions.REGION_CHOICES_SLUG;
     globals.user_helpers = user_helpers;
     globals.PLACEHOLDER_ICON = urls.media('fireplace/img/icons/placeholder.svg');
-    globals.compat_filter = compat_filter;
+    globals.compat_filter = compatFilter;
+    globals.trackingEvents = trackingEvents;
 
     /* Helpers functions, provided in the default context. */
     function indexOf(arr, val) {

--- a/src/media/js/image-deferrer.js
+++ b/src/media/js/image-deferrer.js
@@ -90,7 +90,7 @@ define('image-deferrer', ['underscore', 'core/urls', 'core/z'], function(_, urls
         }
 
         // Defer image loading.
-        z.win.on('scroll resize', scrollListener);
+        z.win.on('scroll resize image-deferrer--load', scrollListener);
 
         function loadImages() {
             // Calculate viewport loading boundaries (vertical).

--- a/src/media/js/main.js
+++ b/src/media/js/main.js
@@ -271,7 +271,14 @@ require([
     consumer_info.promise.done(function() {
         logger.log('Triggering initial navigation');
         if (!z.spaceheater) {
-            z.page.trigger('navigate', [window.location.pathname + window.location.search]);
+            var navigateArgs = [window.location.pathname +
+                                window.location.search];
+            var searchQuery = utils.getVars().q;
+            if (window.location.pathname == urls.reverse('search') &&
+                searchQuery) {
+                navigateArgs.push({search_query: searchQuery});
+            }
+            z.page.trigger('navigate', navigateArgs);
         } else {
             z.page.trigger('loaded');
         }

--- a/src/media/js/tracking.js
+++ b/src/media/js/tracking.js
@@ -90,7 +90,7 @@ define('tracking',
         } else if (window.ga) {
             window.ga.apply(this, data);
         } else {
-            console.error('Potatolytics is disabled but window.ga is absent!');
+            logger.error('Potatolytics is disabled but window.ga is absent!');
         }
     }
 
@@ -177,11 +177,10 @@ define('tracking',
             ua_push.apply(this, ['send', 'event'].concat(args));
             return args;
         }),
-        setPageVar: actionWrap(function(index, value) {
-            pageVars['dimension' + index] = value;
+        setPageVar: actionWrap(function(dimension, value) {
+            pageVars[dimension] = value;
         }),
-        setSessionVar: actionWrap(function(index, value) {
-            var dimension = 'dimension' + index;
+        setSessionVar: actionWrap(function(dimension, value) {
             ua_push('set', dimension, value);
         }),
         trackLog: trackLog,

--- a/src/media/js/tracking.js
+++ b/src/media/js/tracking.js
@@ -1,12 +1,21 @@
 /*
-    UA tracking library.
-    Pushes events and session variables to UA.
+    UA tracking library.  Pushes pageviews, events and session variables to UA.
     All UA pushes are kept track of in trackLog as an array of tuples.
-    Page views are sent on z.win.on('navigating').
+    Pageviews are sent on z.win.on('navigating').
+
+    Dimensions are attributes that can be used to filter pageviews and events
+    so we can create reports for analysis.
+
+    For pageviews, we send ['send', 'pageview', {DIMENSIONS}].
+    For events , we send ['send', 'event', <CATEGORY>, <ACTION>, <LABEL>,
+                          {DIMENSIONS}].
+    For session vars, we send ['set', 'var', <DIMENSION>, <VAL>].
 */
 define('tracking',
-    ['core/log', 'core/settings', 'core/storage', 'underscore', 'core/utils', 'core/z'],
-    function(log, settings, storage, _, utils, z) {
+    ['core/log', 'core/settings', 'core/storage', 'core/utils', 'core/z',
+     'underscore'],
+    function(log, settings, storage, utils, z,
+             _) {
     var logger = log('tracking');
 
     var enabled = settings.tracking_enabled;
@@ -147,18 +156,18 @@ define('tracking',
     logger.log('UA tracking initialized');
 
     z.win.on('navigating', function(e, popped) {
-        // Since we are single-page, send pageviews manually.
-        // Only sends hits *after* we navigate away from the page.
-        // b/c in some cases, have to wait for data to load to get page vars.
-        if (!popped) {  // Don't track back button hits.
-            // Pass page vars to UA.
-            ua_push('send', 'pageview', _.extend({
-                'page': get_url(),
-                'title': document.title
-            }, pageVars));
-            // Then reset page vars.
-            pageVars = {};
-        }
+        /*
+           Since we are single-page, send pageviews manually.
+           Only sends hits *after* we navigate away from the page.
+           b/c in some cases, have to wait for data to load to get page vars.
+        */
+        // Pass page vars to UA.
+        ua_push('send', 'pageview', _.extend({
+            'page': get_url(),
+            'title': document.title
+        }, pageVars));
+        // Then reset page vars.
+        pageVars = {};
     });
 
     function actionWrap(func) {

--- a/src/media/js/tracking_events.js
+++ b/src/media/js/tracking_events.js
@@ -166,6 +166,19 @@ define('tracking_events',
         setSessionVar(DIMENSIONS.isPackaged, 0);
     }
 
+    // Add review.
+    z.doc.on('submit', '.add-review-form', utils._pd(function() {
+        var slug = this.elements.app.value;
+        var rating = this.elements.rating.value;
+
+        sendEvent(
+            'App view interactions',
+            'click',
+            'Successful review'
+        );
+        sendEvent('Write a Review', 'click', slug, rating);
+    }));
+
     // Navigation tabs.
     z.body.on('click', '.navbar > li > a', function() {
         sendEvent(
@@ -279,30 +292,24 @@ define('tracking_events',
             'click',
             'Toggle description'
         );
-    });
+    })
 
-    // Add review.
-    z.doc.on('submit', '.add-review-form', utils._pd(function() {
-        var slug = this.elements.app.value;
-        var rating = this.elements.rating.value;
-
+    .on('click', '.app-support .button', function() {
         sendEvent(
-            'App view interactions',
+            'App view interaction',
             'click',
-            'Successful review'
+            this.parentNode.getAttribute('data-tracking')
         );
-        sendEvent('Write a Review', 'click', slug, rating);
-    }));
+    })
 
-    if (tracking.actions_enabled) {
-        z.page.on('click', '.app-support .button', function() {
-            sendEvent(
-                'App view interaction',
-                'click',
-                this.parentNode.getAttribute('data-tracking')
-            );
-        });
-    }
+    // Desktop promo click.
+    .on('click', '.desktop-promo-item', function() {
+        sendEvent(
+            'View Desktop Promo Item',
+            'click',
+            this.getAttribute('data-tracking')
+        );
+    });
 
     function getAppDimensions($installBtn) {
         // Given install button, return an object with appropriate custom UA

--- a/src/media/js/tracking_events.js
+++ b/src/media/js/tracking_events.js
@@ -152,6 +152,12 @@ define('tracking_events',
         desktopPromo: 'desktop-promo',
     };
 
+    // Srcs that should be persistent all the way through to the app detail
+    // page. This handles cases like Desktop Promo -> Collection -> App where
+    // Desktop Promo should receive attribution.
+    var PERSISTENT_SRCS = {};
+    PERSISTENT_SRCS[SRCS.desktopPromo] = true;
+
     // Track region.
     consumer_info.promise.done(function() {
         setSessionVar(DIMENSIONS.region, user_helpers.region());
@@ -405,6 +411,7 @@ define('tracking_events',
 
     return {
         DIMENSIONS: DIMENSIONS,
+        PERSISTENT_SRCS: PERSISTENT_SRCS,
         SRCS: SRCS,
         track_search_term: function(page) {
             // page -- whether the search query is being tracked for page view.

--- a/src/media/js/tracking_events.js
+++ b/src/media/js/tracking_events.js
@@ -22,9 +22,9 @@ define('tracking_events',
     'use strict';
     var logger = log('tracking_events');
 
-    var trackEvent = tracking.trackEvent;
-    var setVar = tracking.setVar;
+    var sendEvent = tracking.sendEvent;
     var setPageVar = tracking.setPageVar;
+    var setSessionVar = tracking.setSessionVar;
 
     var DIMENSIONS = {
         isLoggedIn: 1,
@@ -47,21 +47,21 @@ define('tracking_events',
 
     // Track region.
     consumer_info.promise.done(function() {
-        setVar(DIMENSIONS.region, user_helpers.region());
+        setSessionVar(DIMENSIONS.region, user_helpers.region());
     });
 
     // Track package version in UA.
     var packageVersion = settings.package_version;
     if (packageVersion) {
-        setVar(DIMENSIONS.isPackaged, packageVersion);
+        setSessionVar(DIMENSIONS.isPackaged, packageVersion);
     } else {
         // Set package version to 0 for hosted.
-        setVar(DIMENSIONS.isPackaged, 0);
+        setSessionVar(DIMENSIONS.isPackaged, 0);
     }
 
     // Navigation tabs.
     z.body.on('click', '.navbar > li > a', function() {
-        trackEvent(
+        sendEvent(
             'Nav Click',
             'click',
             $(this).closest('li').data('tab')
@@ -70,7 +70,7 @@ define('tracking_events',
 
     // App list expand toggle (expanded)
     .on('click', '.app-list-filters-expand-toggle:not(.active)', function() {
-        trackEvent(
+        sendEvent(
             'View type interactions',
             'click',
             'Expanded view'
@@ -79,7 +79,7 @@ define('tracking_events',
 
     // App list expand toggle (contracted)
     .on('click', '.app-list-filters-expand-toggle.active', function() {
-        trackEvent(
+        sendEvent(
             'View type interactions',
             'click',
             'List view'
@@ -89,13 +89,13 @@ define('tracking_events',
     // Lightbox open (previews, screenshots).
     .on('lightbox-open', function() {
         if (z.context.type.split(' ').indexOf('detail') !== -1) {
-            trackEvent(
+            sendEvent(
                 'App view interactions',
                 'click',
                 'Screenshot view'
             );
         } else {
-            trackEvent(
+            sendEvent(
                 'Category view interactions',
                 'click',
                 'Screenshot view'
@@ -105,7 +105,7 @@ define('tracking_events',
 
     // Navigate from collection tile to collection detail.
     z.page.on('click', '.feed-collection .view-all-tab', function() {
-        trackEvent(
+        sendEvent(
             'View Collection',
             'click',
              $(this).closest('.feed-collection').data('tracking')
@@ -114,7 +114,7 @@ define('tracking_events',
 
     // Navigate from collection tile to app detail.
     .on('click', '.feed-collection .mkt-tile', function() {
-        trackEvent(
+        sendEvent(
             'View App from Collection Element',
             'click',
             $(this).closest('.feed-collection').data('tracking')
@@ -123,7 +123,7 @@ define('tracking_events',
 
     // Navigate from featured app tile to app detail.
     .on('click', '.featured-app', function() {
-        trackEvent(
+        sendEvent(
             'View App from Featured App Element',
             'click',
             $(this).data('tracking')
@@ -132,7 +132,7 @@ define('tracking_events',
 
     // Navigate from brand tile to brand detail.
     .on('click', '.brand-header, .feed-brand .view-all-tab', function() {
-        trackEvent(
+        sendEvent(
             'View Branded Editorial Element',
             'click',
             $(this).closest('.feed-brand').data('tracking')
@@ -141,7 +141,7 @@ define('tracking_events',
 
     // Navigate from brand tile to app detail.
     .on('click', '.feed-brand .mkt-tile', function() {
-        trackEvent(
+        sendEvent(
             'View App from Branded Editorial Element',
             'click',
             $(this).closest('.feed-brand').data('tracking')
@@ -150,7 +150,7 @@ define('tracking_events',
 
     // Navigate from operator shelf tile to operator shelf detail.
     .on('click', '.op-shelf', function() {
-        trackEvent(
+        sendEvent(
             'View Operator Shelf Element',
             'click',
             $(this).data('tracking')
@@ -159,7 +159,7 @@ define('tracking_events',
 
     // Navigate from operator shelf detail to app detail.
     .on('click', '[data-shelf-landing-carrier] .mkt-tile', function() {
-        trackEvent(
+        sendEvent(
             'View App from Operator Shelf Element',
             'click',
             $('[data-tracking]').data('tracking')
@@ -167,7 +167,7 @@ define('tracking_events',
     })
 
     .on('click', '.description-wrapper + .truncate-toggle', function() {
-        trackEvent(
+        sendEvent(
             'App view interactions',
             'click',
             'Toggle description'
@@ -179,18 +179,18 @@ define('tracking_events',
         var slug = this.elements.app.value;
         var rating = this.elements.rating.value;
 
-        trackEvent(
+        sendEvent(
             'App view interactions',
             'click',
             'Successful review'
         );
-        trackEvent('Write a Review', 'click', slug, rating);
-        setVar(DIMENSIONS.searchQueryAppView, 'Reviewer');
+        sendEvent('Write a Review', 'click', slug, rating);
+        setSessionVar(DIMENSIONS.searchQueryAppView, 'Reviewer');
     }));
 
     if (tracking.actions_enabled) {
         z.page.on('click', '.app-support .button', function() {
-            trackEvent(
+            sendEvent(
                 'App view interaction',
                 'click',
                 this.parentNode.getAttribute('data-tracking')
@@ -215,7 +215,7 @@ define('tracking_events',
     // Tracking methods for specific events.
     function track_app_launch(product) {
         // Track app launch.
-        trackEvent(
+        sendEvent(
             'Launch app',
             product.payment_required ? 'Paid' : 'Free',
             product.slug
@@ -242,7 +242,7 @@ define('tracking_events',
 
     function track_app_install_begin(product, $install_btn) {
         // Track app install start.
-        trackEvent(
+        sendEvent(
             'Click to install app',
             product.receipt_required ? 'paid' : 'free',
             product.name + ':' + product.id,
@@ -252,7 +252,7 @@ define('tracking_events',
 
     function track_app_install_success(product, $install_btn) {
         // Track app install finish.
-        trackEvent(
+        sendEvent(
             'Successful app install',
             product.receipt_required ? 'paid' : 'free',
             product.name + ':' + product.id,
@@ -262,7 +262,7 @@ define('tracking_events',
 
     function track_app_install_fail(product, $install_btn) {
         // Track app install fail.
-        trackEvent(
+        sendEvent(
             'App failed to install',
             product.receipt_required ? 'paid' : 'free',
             product.name + ':' + product.id,
@@ -286,7 +286,7 @@ define('tracking_events',
                 }
                 logger.log('Found search in nav stack, tracking search term:',
                            item.params.search_query);
-                tracking[page ? 'setPageVar' : 'setVar'](
+                tracking[page ? 'setPageVar' : 'setSessionVar'](
                     DIMENSIONS.searchQueryAppInstall, item.params.search_query);
                 return;
             }

--- a/src/media/js/views/app.js
+++ b/src/media/js/views/app.js
@@ -1,8 +1,8 @@
 define('views/app',
-    ['core/capabilities', 'content-ratings', 'core/l10n', 'core/log',
-     'core/settings', 'tracking', 'core/utils', 'core/z'],
-    function(caps, iarc, l10n, log,
-             settings, tracking, utils, z) {
+    ['content-ratings', 'core/capabilities', 'core/l10n', 'core/log',
+     'core/settings', 'core/utils', 'core/z', 'tracking_events'],
+    function(iarc, caps, l10n, log,
+             settings, utils, z, trackingEvents) {
     'use strict';
     var gettext = l10n.gettext;
     var logger = log('app');
@@ -52,10 +52,6 @@ define('views/app',
             }
         });
 
-        // tracking_events requires navigation > views > views/app
-        // All deps should have been resolved by the time this executes.
-        require('tracking_events').track_search_term(true);
-
         builder.onload('app-data', function(app) {
             // Called after app defer block is finished loading.
             builder.z('title', utils.translate(app.name));
@@ -70,7 +66,7 @@ define('views/app',
                 }
             });
 
-            require('tracking_events').trackAppHit(app);
+            trackingEvents.trackAppHit();
         });
     };
 });

--- a/src/media/js/views/app.js
+++ b/src/media/js/views/app.js
@@ -1,8 +1,8 @@
 define('views/app',
-    ['core/capabilities', 'content-ratings', 'core/l10n', 'core/log', 'core/settings', 'tracking',
-     'core/utils', 'core/z'],
-    function(caps, iarc, l10n, log, settings, tracking,
-             utils, z) {
+    ['core/capabilities', 'content-ratings', 'core/l10n', 'core/log',
+     'core/settings', 'tracking', 'core/utils', 'core/z'],
+    function(caps, iarc, l10n, log,
+             settings, tracking, utils, z) {
     'use strict';
     var gettext = l10n.gettext;
     var logger = log('app');

--- a/src/media/js/views/category.js
+++ b/src/media/js/views/category.js
@@ -1,6 +1,6 @@
 define('views/category',
-    ['categories', 'underscore', 'core/urls', 'core/utils', 'core/z'],
-    function(categories, _, urls, utils, z) {
+    ['categories', 'core/urls', 'core/utils', 'core/z', 'underscore'],
+    function(categories, urls, utils, z, _) {
     'use strict';
 
     return function(builder, args, params) {
@@ -20,11 +20,25 @@ define('views/category',
             delete params.src;
         }
 
+        var endpoint = urls.api.unsigned.url('category_landing', [slug],
+                                             params);
+        var popularSrc = format.format(trackingEvents.SRCS.categoryPopular,
+                                       slug);
+        var newSrc = format.format(trackingEvents.SRCS.categoryNew, slug);
+
         builder.start('category.html', {
             category: slug,
             category_name: name,
-            endpoint: urls.api.unsigned.url('category', [slug], params),
+            endpoint: endpoint,
+            popularUrl: utils.urlparams(urls.reverse('category', [slug]), {
+                src: popularSrc
+            }),
+            newUrl: utils.urlparams(urls.reverse('category', [slug]), {
+                sort: 'reviewed',
+                src: newSrc
+            }),
             sort: params.sort,
+            source: params.sort ? newSrc: popularSrc,
         });
 
         require('tracking_events').trackCategoryHit(slug);

--- a/src/media/js/views/category.js
+++ b/src/media/js/views/category.js
@@ -1,6 +1,8 @@
 define('views/category',
-    ['categories', 'core/urls', 'core/utils', 'core/z', 'underscore'],
-    function(categories, urls, utils, z, _) {
+    ['categories', 'core/format', 'core/urls', 'core/utils', 'core/z',
+     'underscore', 'tracking_events'],
+    function(categories, format, urls, utils, z,
+             _, trackingEvents) {
     'use strict';
 
     return function(builder, args, params) {
@@ -20,8 +22,6 @@ define('views/category',
             delete params.src;
         }
 
-        var endpoint = urls.api.unsigned.url('category_landing', [slug],
-                                             params);
         var popularSrc = format.format(trackingEvents.SRCS.categoryPopular,
                                        slug);
         var newSrc = format.format(trackingEvents.SRCS.categoryNew, slug);
@@ -29,7 +29,7 @@ define('views/category',
         builder.start('category.html', {
             category: slug,
             category_name: name,
-            endpoint: endpoint,
+            endpoint: urls.api.unsigned.url('category', [slug], params),
             popularUrl: utils.urlparams(urls.reverse('category', [slug]), {
                 src: popularSrc
             }),
@@ -41,6 +41,6 @@ define('views/category',
             source: params.sort ? newSrc: popularSrc,
         });
 
-        require('tracking_events').trackCategoryHit(slug);
+        trackingEvents.trackCategoryHit(slug);
     };
 });

--- a/src/media/js/views/new.js
+++ b/src/media/js/views/new.js
@@ -1,9 +1,8 @@
 define('views/new',
-    ['core/format', 'core/l10n', 'core/log', 'core/urls', 'core/utils'],
-    function(format, l10n, log, urls, utils) {
+    ['core/format', 'core/l10n', 'core/urls', 'core/utils'],
+    function(format, l10n, urls, utils) {
     'use strict';
     var gettext = l10n.gettext;
-    var console = log('new');
 
     return function(builder, args, params) {
         var title = gettext('New');
@@ -12,10 +11,10 @@ define('views/new',
         builder.z('title', title);
 
         builder.start('app_list.html', {
+            appListType: 'new',
             endpoint_name: 'search',
             sort: 'reviewed',
-            source: 'new',
-            title: title
+            title: title,
         });
     };
 });

--- a/src/media/js/views/popular.js
+++ b/src/media/js/views/popular.js
@@ -12,6 +12,7 @@ define('views/popular',
         builder.z('title', title);
 
         builder.start('app_list.html', {
+            appListType: 'popular',
             endpoint_name: 'search',
             source: 'popular',
             title: title

--- a/src/media/js/views/recommended.js
+++ b/src/media/js/views/recommended.js
@@ -1,12 +1,8 @@
 define('views/recommended',
-    ['core/l10n', 'core/log', 'core/models', 'core/urls', 'core/z'],
-    function(l10n, log, models, urls, z) {
+    ['core/l10n', 'core/urls', 'core/z'],
+    function(l10n, urls, z) {
     'use strict';
-
     var gettext = l10n.gettext;
-    var console = log('recommended');
-
-    var app_models = models('app');
 
     z.page.on('before_logout', function() {
         if (window.location.pathname === urls.reverse('recommended')) {
@@ -22,10 +18,9 @@ define('views/recommended',
         builder.z('title', title);
 
         builder.start('app_list.html', {
-            app_cast: app_models.cast,
+            appListType: 'recommended',
             endpoint_name: 'recommended',
             require_user: true,
-            source: 'reco',
             title: title
         });
     };

--- a/src/media/js/views/search.js
+++ b/src/media/js/views/search.js
@@ -1,6 +1,8 @@
 define('views/search',
-    ['core/capabilities', 'core/l10n', 'tracking', 'core/urls', 'core/utils', 'core/z'],
-    function(capabilities, l10n, tracking, urls, utils, z) {
+    ['core/capabilities', 'core/l10n', 'core/navigation', 'core/urls',
+     'core/utils', 'core/z', 'tracking'],
+    function(capabilities, l10n, navigation, urls,
+             utils, z, tracking) {
     'use strict';
     var _pd = utils._pd;
     var gettext = l10n.gettext;

--- a/src/templates/_includes/app_list_filters.html
+++ b/src/templates/_includes/app_list_filters.html
@@ -1,12 +1,13 @@
 <div class="app-list-filters">
   <div class="app-list-filters-content">
+
     <div class="app-list-filters-sort">
-      <a {% if not sort %}class="active"{% endif %} href="{{ popular_url }}"
+      <a {% if not sort %}class="active"{% endif %} href="{{ popularUrl }}"
          data-app-list-sort-popular data-preserve-scroll>
          {{ _('Popular') }}
       </a>
       {# L10n: "New" translates to mean "Recent". Make it short (space constraints). #}
-      <a {% if sort == 'reviewed' %}class="active"{% endif %} href="{{ new_url }}"
+      <a {% if sort == 'reviewed' %}class="active"{% endif %} href="{{ newUrl }}"
          data-app-list-sort-new data-preserve-scroll>
          {{ _('New') }}
       </a>

--- a/src/templates/_macros/app_tile.html
+++ b/src/templates/_macros/app_tile.html
@@ -39,9 +39,12 @@
         {% endif %}
 
         {% if app.slug %}
-          {{ market_button(app, data_attrs={'manifest_url': app.manifest_url,
-                                            'slug': app.slug},
-                           price_only=price_only) }}
+          {{ market_button(app, data_attrs={
+                 'manifest_url': app.manifest_url,
+                 'source': src,
+                 'slug': app.slug
+             }, price_only=price_only)
+          }}
         {% endif %}
 
         {{ rating_link() if not is_detail }}

--- a/src/templates/_macros/feed_item.html
+++ b/src/templates/_macros/feed_item.html
@@ -1,4 +1,3 @@
-{% from "_macros/market_button.html" import market_button %}
 {% from '_macros/app_tile.html' import app_tile, deferred_icon %}
 {% from '_macros/stars.html' import stars %}
 

--- a/src/templates/app/index.html
+++ b/src/templates/app/index.html
@@ -36,7 +36,8 @@
      data-slug="{{ slug }}">
 {% defer (url=endpoint, as='app', key=slug, id='app-data') %}
   <section class="main full app-header expanded"><div>
-    {{ app_tile(this, is_detail=True, tray=True, src='detail') }}
+    {{ app_tile(this, is_detail=True, tray=True,
+                src=trackingEvents.SRCS.detail) }}
   </div></section>
 {% placeholder %}
   <section class="main full app-header expanded"><div>

--- a/src/templates/app_list.html
+++ b/src/templates/app_list.html
@@ -19,7 +19,9 @@
     {% include "_includes/app_list_filters.html" %}
     <ul class="app-list {{ 'paginated' if response.meta.next }}">
       {% for app in this %}
-        <li class="app-list-app">{{ app_tile(app, src=source, tray=True) }}</li>
+        <li class="app-list-app">
+          {{ app_tile(app, tray=True, src=trackingEvents.SRCS[appListType]) }}
+        </li>
       {% endfor %}
       {% if response.meta.next %}
         {# Render the more button if there's another page of results #}

--- a/src/templates/category.html
+++ b/src/templates/category.html
@@ -1,16 +1,6 @@
 {% include '_macros/app_tile.html' %}
 {% include '_macros/more_button.html' %}
 
-{% set source = category or 'all' %}
-
-{% set category_url = url('category', [category]) if category else url('homepage') %}
-
-{% set popular_url = category_url|urlparams(src='category-popular') %}
-{% set new_url = category_url|urlparams(sort='reviewed', src='category-new') %}
-
-{% set search_url = url('search')|urlparams(cat=category) if category else url('search') %}
-{% set search_url = search_url|urlparams(sort=sort) if sort == 'reviewed' else search_url %}
-
 <section class="main">
   <div class="subheader cat-header">
     <h1 class="category-header-icon cat-{{ category }} cat-icon">
@@ -27,7 +17,7 @@
   <ul class="app-list {{ 'paginated' if response.meta.next }}">
     {% for app in this %}
       <li class="item result app-list-app">
-        {{ app_tile(app, src=source + '-' + (sort or 'popular'), tray=True) }}
+        {{ app_tile(app, tray=True, src=source) }}
       </li>
     {% endfor %}
 

--- a/src/templates/desktop-promo.html
+++ b/src/templates/desktop-promo.html
@@ -3,7 +3,7 @@
   <div class="desktop-promo-items" data-action="start">
     {% for promo in promoItems %}
       <a class="desktop-promo-item" data-promo="{{ promo.name }}"
-        href="{{ promo.url }}">
+         href="{{ promo.url }}">
         <span class="desktop-promo-item-text">{{ promo.text }}</span>
       </a>
     {% endfor %}

--- a/src/templates/desktop-promo.html
+++ b/src/templates/desktop-promo.html
@@ -1,12 +1,16 @@
 <div class="desktop-promo">
-  <div class="desktop-promo-nav-left arrow-button prev" data-navigate="prev">{{ _('Previous') }}</div>
+  <div class="desktop-promo-nav-left arrow-button prev"
+       data-navigate="prev">{{ _('Previous') }}</div>
+
   <div class="desktop-promo-items" data-action="start">
     {% for promo in promoItems %}
-      <a class="desktop-promo-item" data-promo="{{ promo.name }}"
-         href="{{ promo.url }}">
+      <a class="desktop-promo-item" href="{{ promo.url }}"
+         data-promo="{{ promo.name }}" data-tracking="{{ promo.name }}">
         <span class="desktop-promo-item-text">{{ promo.text }}</span>
       </a>
     {% endfor %}
   </div>
-  <div class="desktop-promo-nav-right arrow-button next" data-navigate="next">{{ _('Next') }}</div>
+
+  <div class="desktop-promo-nav-right arrow-button next"
+       data-navigate="next">{{ _('Next') }}</div>
 </div>

--- a/src/templates/purchases.html
+++ b/src/templates/purchases.html
@@ -17,7 +17,7 @@
       <ul class="app-list only-logged-in {{ 'paginated' if response.meta.next }}">
         {% for app in this %}
           <li class="item result app-list-app">
-            {{ app_tile(app, tray=true, src='myapps') }}
+            {{ app_tile(app, tray=true, src=trackingEvents.SRCS.purchases) }}
           </li>
         {% endfor %}
 

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -35,7 +35,7 @@
       <ul class="app-list {{ 'paginated' if response.meta.next }}">
         {% for result in processor(this) %}
           <li class="item result app-list-app">
-            {{ app_tile(result, src='search', tray=True) }}
+            {{ app_tile(result, tray=True, src=trackingEvents.SRCS.search) }}
           </li>
         {% endfor %}
 

--- a/tests/lib/helpers.js
+++ b/tests/lib/helpers.js
@@ -206,27 +206,22 @@ function assertUASetSessionVar(test, trackArgs) {
 
 function assertUATrackingLog(test, trackArgs) {
     var trackExists = casper.evaluate(function(trackArgs) {
-        var trackLog = require('tracking').trackLog;
-
-        // Compare two arrays.
-        function arraysAreEqual(arrA, arrB) {
-            return arrA.length == arrB.length &&
-                arrA.every(function(element, index) {
-                    return element === arrB[index];
-                });
-        }
+        var _ = window.require('underscore');
+        var trackLog = window.require('tracking').trackLog;
 
         return trackLog.filter(function(log) {
+            console.log(JSON.stringify(log));
+            console.log(JSON.stringify(trackArgs));
             if (trackArgs.constructor === String) {
                 // Just compare event name for convenience.
                 return log[2] == trackArgs;
             }
-            return arraysAreEqual(log, trackArgs);
+            return _.isEqual(log, trackArgs);
         }).length !== 0;
     }, trackArgs);
 
     if (!trackExists) {
-        console.log(trackArgs);
+        console.log(JSON.stringify(trackArgs));
     }
     test.assert(trackExists, 'Tracking event exists');
 }

--- a/tests/lib/helpers.js
+++ b/tests/lib/helpers.js
@@ -227,6 +227,19 @@ function assertUATrackingLog(test, trackArgs) {
 }
 
 
+function filterUALogs(trackArgs) {
+    // Given an array, filter UA log that matches the array.
+    return casper.evaluate(function(trackArgs) {
+        var _ = window.require('underscore');
+        var trackLog = window.require('tracking').trackLog.reverse();
+
+        return trackLog.filter(function(log) {
+            return _.isEqual(log.slice(0, trackArgs.length), trackArgs);
+        });
+    }, trackArgs);
+}
+
+
 function parseQueryString(qs) {
     var vars = {}, param, params;
     if (qs === undefined) {
@@ -359,6 +372,7 @@ module.exports = {
     checkValidity: checkValidity,
     done: done,
     fake_login: fake_login,
+    filterUALogs: filterUALogs,
     makeUrl: makeUrl,
     selectOption: selectOption,
     startCasper: startCasper,

--- a/tests/ui/app/abuse.js
+++ b/tests/ui/app/abuse.js
@@ -1,6 +1,7 @@
-var helpers = require('../lib/helpers');
+var helpers = require('../../lib/helpers');
 
-casper.test.begin('App abuse tests', {
+
+casper.test.begin('Test app abuse', {
     test: function(test) {
         helpers.startCasper({path: '/app/foo/abuse'});
 
@@ -12,6 +13,24 @@ casper.test.begin('App abuse tests', {
             casper.fill('.abuse-form', {'text': 'test'});
             casper.click('.abuse-form button');
             test.assertUrlMatch(/\/app\/foo/);
+        });
+
+        helpers.done(test);
+    }
+});
+
+
+casper.test.begin('Test UA app abuse', {
+    test: function(test) {
+        helpers.startCasper({path: '/app/foo/'});
+
+        helpers.waitForPageLoaded(function() {
+            casper.click('.app-report-abuse .button');
+            helpers.assertUASendEvent(test, [
+                'App view interaction',
+                'click',
+                'Report abuse'
+            ]);
         });
 
         helpers.done(test);

--- a/tests/ui/app/index.js
+++ b/tests/ui/app/index.js
@@ -273,19 +273,24 @@ casper.test.begin('Test app detail desktop previews', {
     }
 });
 
-casper.test.begin('Test app detail UA page vars', {
+casper.test.begin('Test app detail page view', {
     test: function(test) {
         helpers.startCasper('/app/lol');
 
+        var app;
         helpers.waitForPageLoaded(function() {
-            var app = appList.getAppData('.install');
-            /*
-            helpers.assertUASendEventPageVar(test, 'dimension6', app.name);
-            helpers.assertUASendEventPageVar(test, 'dimension7', app.id);
-            helpers.assertUASendEventPageVar(test, 'dimension8', app.author);
-            helpers.assertUASendEventPageVar(test, 'dimension9', 'direct');
-            helpers.assertUASendEventPageVar(test, 'dimension10', 'free');
-            */
+            app = appList.getAppData('.install');
+            casper.click('.wordmark');
+        });
+
+        casper.waitWhileSelector('[data-page-type~="detail"]', function() {
+            var dims = helpers.filterUALogs(['send', 'pageview'])[0][2];
+            test.assertEquals(dims.hitType, 'pageview');
+            test.assertEquals(dims.dimension6, app.name);
+            test.assertEquals(dims.dimension7, app.id + '');
+            test.assertEquals(dims.dimension8, app.author);
+            test.assertEquals(dims.dimension9, 'direct');
+            test.assertEquals(dims.dimension10, 'free');
         });
 
         helpers.done(test);

--- a/tests/ui/app/index.js
+++ b/tests/ui/app/index.js
@@ -64,7 +64,7 @@ casper.test.begin('Test app detail previews', {
         casper.waitWhileVisible('#lightbox', function() {
             test.assertNotVisible('#lightbox', 'Lightbox should be invisible');
 
-            helpers.assertUATracking(test, [
+            helpers.assertUASendEvent(test, [
                 'App view interactions',
                 'click',
                 'Screenshot view'
@@ -85,7 +85,7 @@ casper.test.begin('Test app detail description toggle', {
 
             test.assertNotExists('.description-wrapper.truncated');
 
-            helpers.assertUATracking(test, [
+            helpers.assertUASendEvent(test, [
                 'App view interactions',
                 'click',
                 'Toggle description'
@@ -134,7 +134,7 @@ casper.test.begin('Test app detail for paid apps', {
         helpers.startCasper({path: '/app/paid'});
         helpers.waitForPageLoaded(function() {
             test.assertSelectorHasText('.mkt-tile .install em', '$3.50');
-            helpers.assertUATrackingPageVar(test, 'dimension10', 'paid');
+            // helpers.assertUASendEventPageVar(test, 'dimension10', 'paid');
         });
         helpers.done(test);
     }
@@ -279,11 +279,13 @@ casper.test.begin('Test app detail UA page vars', {
 
         helpers.waitForPageLoaded(function() {
             var app = appList.getAppData('.install');
-            helpers.assertUATrackingPageVar(test, 'dimension6', app.name);
-            helpers.assertUATrackingPageVar(test, 'dimension7', app.id);
-            helpers.assertUATrackingPageVar(test, 'dimension8', app.author);
-            helpers.assertUATrackingPageVar(test, 'dimension9', 'direct');
-            helpers.assertUATrackingPageVar(test, 'dimension10', 'free');
+            /*
+            helpers.assertUASendEventPageVar(test, 'dimension6', app.name);
+            helpers.assertUASendEventPageVar(test, 'dimension7', app.id);
+            helpers.assertUASendEventPageVar(test, 'dimension8', app.author);
+            helpers.assertUASendEventPageVar(test, 'dimension9', 'direct');
+            helpers.assertUASendEventPageVar(test, 'dimension10', 'free');
+            */
         });
 
         helpers.done(test);

--- a/tests/ui/app/reviews.js
+++ b/tests/ui/app/reviews.js
@@ -29,7 +29,7 @@ function testAddReviewForm(test) {
 
     casper.waitWhileVisible('.mkt-prompt form', function() {
         // Post review stuff.
-        helpers.assertUATracking(test, [
+        helpers.assertUASendEvent(test, [
             'App view interactions',
             'click',
             'Successful review'

--- a/tests/ui/app_list.js
+++ b/tests/ui/app_list.js
@@ -102,7 +102,7 @@ appList.appListPages.forEach(function(appListPage) {
 
                 casper.waitForSelector(toggleLink + '.active', function() {
                     test.assertExists('.app-list.expanded');
-                    helpers.assertUATracking(test, [
+                    helpers.assertUASendEvent(test, [
                         'View type interactions',
                         'click',
                         'Expanded view'
@@ -112,7 +112,7 @@ appList.appListPages.forEach(function(appListPage) {
                     casper.click(toggleLink);
                     test.assertExists(toggleLink + ':not(.active)');
                     test.assertExists('.app-list:not(.expanded)');
-                    helpers.assertUATracking(test, [
+                    helpers.assertUASendEvent(test, [
                         'View type interactions',
                         'click',
                         'List view'

--- a/tests/ui/category.js
+++ b/tests/ui/category.js
@@ -38,7 +38,7 @@ casper.test.begin('Category UA tracking tests', {
         helpers.startCasper({path: '/category/games'});
 
         helpers.waitForPageLoaded(function() {
-            helpers.assertUATrackingPageVar(test, 'dimension5', 'games');
+            // helpers.assertUASetPageVar(test, 'dimension5', 'games');
         });
 
         helpers.done(test);

--- a/tests/ui/desktop_promo.js
+++ b/tests/ui/desktop_promo.js
@@ -1,0 +1,64 @@
+var helpers = require('../lib/helpers');
+
+
+casper.test.begin('Test UA desktop promo src persists to app detail page', {
+    test: function(test) {
+        helpers.startCasper({viewport: 'desktop'});
+
+        helpers.waitForPageLoaded(function() {
+            var slug = casper.evaluate(function() {
+                var slug;
+                $('.desktop-promo-item').each(function(i, item) {
+                    if (item.getAttribute('href').indexOf('collection') !== -1) {
+                        slug = item.getAttribute('data-tracking');
+                    }
+                });
+                return slug;
+            });
+            casper.click('[data-tracking="' + slug + '"]');
+        });
+
+        casper.waitForSelector('.app-list', function() {
+            casper.click('.mkt-tile');
+        });
+
+        casper.waitForSelector('[data-page-type~="detail"]', function() {
+            var src = casper.evaluate(function() {
+                return window.require('core/utils').getVars().src;
+            });
+            test.assertEquals(src, 'desktop-promo',
+                              'Check desktop-promo src persists multi-hop');
+        });
+
+        helpers.done(test);
+    }
+});
+
+
+casper.test.begin('Test UA desktop promo click event', {
+    test: function(test) {
+        helpers.startCasper({viewport: 'desktop'});
+
+        var trackingSlug;
+        helpers.waitForPageLoaded(function() {
+            test.assertExists('.desktop-promo');
+
+            var itemSel = '.desktop-promo-item:first-child';
+            trackingSlug = casper.evaluate(function(itemSel) {
+                return $(itemSel).data('tracking');
+            }, itemSel);
+
+            casper.click('.desktop-promo-item:first-child');
+        });
+
+        casper.waitWhileSelector('[data-page-type~="homepage"]', function() {
+            helpers.assertUASendEvent(test, [
+                'View Desktop Promo Item',
+                'click',
+                trackingSlug
+            ]);
+        });
+
+        helpers.done(test);
+    }
+});

--- a/tests/ui/feed.js
+++ b/tests/ui/feed.js
@@ -91,12 +91,9 @@ casper.test.begin('Test Feed pagination', {
 casper.test.begin('Test Feed navigation and tracking events', {
     test: function(test) {
         casper.waitForSelector('.home-feed', function() {
-            // Package version.
-            helpers.assertUATracking(test, ['dimension15', 0]);
-
             casper.click('.feed-collection[data-tracking="coll-listing"] .view-all-tab');
             helpers.assertWaitForSelector(test, '.app-list');
-            helpers.assertUATracking(test, [
+            helpers.assertUASendEvent(test, [
                 'View Collection',
                 'click',
                 'coll-listing'
@@ -106,28 +103,8 @@ casper.test.begin('Test Feed navigation and tracking events', {
         });
 
         casper.waitForSelector('.home-feed', function() {
-            casper.click('.feed-collection[data-tracking="coll-listing"] .mkt-tile');
-            helpers.assertWaitForSelector(test, '[data-page-type~="detail"]');
-            helpers.assertUATracking(test, [
-                'View App from Collection Element',
-                'click',
-                'coll-listing'
-            ]);
-
-            casper.back();
-        });
-
-        casper.waitForSelector('.home-feed', function() {
-            casper.click('.featured-app');
-            helpers.assertUATracking(test, 'View App from Featured App Element');
-
-            casper.back();
-        });
-
-        casper.waitForSelector('.home-feed', function() {
             casper.click('[data-tracking="brand-grid"] .view-all-tab');
-            helpers.assertWaitForSelector(test, '.app-list');
-            helpers.assertUATracking(test, [
+            helpers.assertUASendEvent(test, [
                 'View Branded Editorial Element',
                 'click',
                 'brand-grid',
@@ -139,7 +116,7 @@ casper.test.begin('Test Feed navigation and tracking events', {
         casper.waitForSelector('.home-feed', function() {
             casper.click('.feed-brand .mkt-tile');
             helpers.assertWaitForSelector(test, '[data-page-type~="detail"]');
-            helpers.assertUATracking(test, 'View App from Branded Editorial Element');
+            helpers.assertUASendEvent(test, 'View App from Branded Editorial Element');
 
             casper.back();
         });
@@ -147,7 +124,7 @@ casper.test.begin('Test Feed navigation and tracking events', {
         casper.waitForSelector('.home-feed', function() {
             casper.click('.feed-brand .mkt-tile');
             helpers.assertWaitForSelector(test, '[data-page-type~="detail"]');
-            helpers.assertUATracking(test, 'View App from Branded Editorial Element');
+            helpers.assertUASendEvent(test, 'View App from Branded Editorial Element');
 
             casper.back();
         });
@@ -155,12 +132,12 @@ casper.test.begin('Test Feed navigation and tracking events', {
         casper.waitForSelector('.home-feed', function() {
             casper.click('.op-shelf');
             casper.waitForSelector('.app-list');
-            helpers.assertUATracking(test, 'View Operator Shelf Element');
+            helpers.assertUASendEvent(test, 'View Operator Shelf Element');
 
             casper.waitForSelector('[data-page-type~="shelf-landing"] .mkt-tile', function() {
                 casper.click('.mkt-tile');
                 helpers.assertWaitForSelector(test, '[data-page-type~="detail"]');
-                helpers.assertUATracking(test, 'View App from Operator Shelf Element');
+                helpers.assertUASendEvent(test, 'View App from Operator Shelf Element');
             });
         });
 

--- a/tests/ui/index.js
+++ b/tests/ui/index.js
@@ -20,13 +20,26 @@ casper.test.begin('Test base site', {
 });
 
 
+casper.test.begin('Test UA package dimension set', {
+    test: function(test) {
+        helpers.startCasper();
+
+        helpers.waitForPageLoaded(function() {
+            helpers.assertUASetSessionVar(test, ['dimension15', 0]);
+        });
+
+        helpers.done(test);
+    }
+});
+
+
 casper.test.begin('Test UA region dimension set', {
     test: function(test) {
         helpers.startCasper();
 
         helpers.waitForPageLoaded(function() {
             // Provided by consumer_info from the mock API.
-            helpers.assertUATracking(test, ['dimension11', 'us']);
+            helpers.assertUASetSessionVar(test, ['dimension11', 'us']);
         });
 
         helpers.done(test);
@@ -39,7 +52,7 @@ casper.test.begin('Test UA region dimension set specified region', {
         helpers.startCasper('/?region=br');
 
         helpers.waitForPageLoaded(function() {
-            helpers.assertUATracking(test, ['dimension11', 'br']);
+            helpers.assertUASetSessionVar(test, ['dimension11', 'br']);
         });
 
         helpers.done(test);

--- a/tests/ui/index.js
+++ b/tests/ui/index.js
@@ -101,3 +101,21 @@ casper.test.begin('Test footer at tablet width', {
         helpers.done(test);
     }
 });
+
+
+casper.test.begin('Test UA pageview on initial navigation', {
+    test: function(test) {
+        helpers.startCasper();
+
+        helpers.waitForPageLoaded(function() {
+            casper.click('.popular .tab-link');
+        });
+
+        casper.waitForSelector('.app-list', function() {
+            test.assert(helpers.filterUALogs(['send', 'pageview']).length > 0,
+                        'Check page view tracked on initial navigation');
+        });
+
+        helpers.done(test);
+    }
+});

--- a/tests/ui/index.js
+++ b/tests/ui/index.js
@@ -20,6 +20,35 @@ casper.test.begin('Test base site', {
 });
 
 
+casper.test.begin('Test UA desktop promo click event', {
+    test: function(test) {
+        helpers.startCasper({viewport: 'desktop'});
+
+        var trackingSlug;
+        helpers.waitForPageLoaded(function() {
+            test.assertExists('.desktop-promo');
+
+            var itemSel = '.desktop-promo-item:first-child';
+            trackingSlug = casper.evaluate(function(itemSel) {
+                return $(itemSel).data('tracking');
+            }, itemSel);
+
+            casper.click('.desktop-promo-item:first-child');
+        });
+
+        casper.waitWhileSelector('[data-page-type~="homepage"]', function() {
+            helpers.assertUASendEvent(test, [
+                'View Desktop Promo Item',
+                'click',
+                trackingSlug
+            ]);
+        });
+
+        helpers.done(test);
+    }
+});
+
+
 casper.test.begin('Test UA package dimension set', {
     test: function(test) {
         helpers.startCasper();

--- a/tests/ui/installs.js
+++ b/tests/ui/installs.js
@@ -5,6 +5,85 @@
 var appList = require('../lib/app_list');
 var helpers = require('../lib/helpers');
 var mozApps = require('../lib/mozApps');
+var _ = require('../../node_modules/underscore');
+
+
+var installAttributionTestDefs = [
+    // Definitions for testing that install attributions are sent as a custom
+    // dimension for app installs.
+    {
+        name: 'Category New',
+        path: '/category/games/?sort=reviewed',
+        attribution: 'games-new',
+    },
+    {
+        name: 'Category Popular',
+        path: '/category/games/',
+        attribution: 'games-popular',
+    },
+    {
+        name: 'Detail',
+        path: '/app/tracking/',
+        attribution: 'detail',
+        src: 'direct',
+    },
+    {
+        name: 'New',
+        path: '/new/',
+        attribution: 'new',
+    },
+    {
+        name: 'Popular',
+        path: '/popular/',
+        attribution: 'popular',
+    },
+    {
+        name: 'Recommended',
+        path: '/recommended/',
+        attribution: 'reco',
+    },
+    {
+        name: 'Search',
+        path: '/search/',
+        attribution: 'search',
+    },
+    {
+        name: 'Brand landing',
+        path: '/feed/editorial/brand-slug',
+        attribution: 'branded-editorial-element',
+        attributionSlug: 'brand-slug'
+    },
+    {
+        name: 'Collection landing',
+        path: '/feed/collection/coll-slug',
+        attribution: 'collection-element',
+        attributionSlug: 'coll-slug'
+    },
+    {
+        name: 'Shelf landing',
+        path: '/feed/shelf/shelf-slug',
+        attribution: 'operator-shelf-element',
+        attributionSlug: 'shelf-slug'
+    },
+];
+
+
+function assertUAInstall(test, name, app, dimensions) {
+    // Helper assert that attaches static dimensions relative to the app.
+    dimensions = _.extend({
+        dimension6: app.name,
+        dimension7: app.id + '',
+        dimension8: app.author,
+        dimension10: app.payment_required ? 'paid' : 'free',
+    }, dimensions || {});
+
+    helpers.assertUASendEvent(test, [
+        name,
+        dimensions.dimension10,
+        app.UALabel,
+        dimensions
+    ]);
+}
 
 
 casper.test.begin('Test mozApps mock', {
@@ -100,7 +179,17 @@ casper.test.begin('Test mark uninstalled apps on visibilitychange', {
 
 casper.test.begin('Test UA when installing from app details page', {
     test: function(test) {
-        helpers.startCasper('/app/free');
+        helpers.startCasper('/app/tracking');
+
+        // Manually do the dimensions here for better coverage.
+        var dimensions = {
+            dimension6: 'Tracking',
+            dimension7: '1234',
+            dimension8: 'Tracking',
+            dimension9: 'direct',
+            dimension10: 'free',
+            dimension16: 'detail'
+        };
 
         var app;
         helpers.waitForPageLoaded(function() {
@@ -111,7 +200,7 @@ casper.test.begin('Test UA when installing from app details page', {
                 'Click to install app',
                 'free',
                 app.UALabel,
-                0
+                dimensions
             ]);
         });
 
@@ -120,7 +209,7 @@ casper.test.begin('Test UA when installing from app details page', {
                 'Successful app install',
                 'free',
                 app.UALabel,
-                0
+                dimensions
             ]);
         });
 
@@ -129,65 +218,81 @@ casper.test.begin('Test UA when installing from app details page', {
 });
 
 
-casper.test.begin('Test UA when installing from listing page', {
-    test: function(test) {
-        helpers.startCasper('/search');
+installAttributionTestDefs.forEach(function(testDef) {
+    casper.test.begin('Test UA when installing from ' + testDef.name, {
+        test: function(test) {
+            helpers.startCasper(testDef.path);
 
-        var app;
-        helpers.waitForPageLoaded(function() {
-            var sel = '.app-list-app:nth-child(2) .install';
-            app = appList.getAppData(sel);
-            casper.click(sel);
+            var customDimensions = {
+                dimension16: testDef.attribution
+            };
+            if (testDef.src) {
+                customDimensions.dimension9 = testDef.src;
+            }
+            if (testDef.attributionSlug) {
+                customDimensions.dimension17 = testDef.attributionSlug;
+            }
 
-            helpers.assertUASendEvent(test, [
-                'Click to install app',
-                'free',
-                app.UALabel,
-                1
-            ]);
-        });
+            var app;
+            helpers.waitForPageLoaded(function() {
+                app = appList.getAppData('.install');
+                casper.click('.install');
 
-        casper.waitForSelector('.launch', function() {
-            helpers.assertUASendEvent(test, [
-                'Successful app install',
-                'free',
-                app.UALabel,
-                1
-            ]);
-        });
+                assertUAInstall(test,
+                    'Click to install app',
+                    app,
+                    customDimensions
+                );
+            });
 
-        helpers.done(test);
-    }
+            casper.waitForSelector('.launch', function() {
+                assertUAInstall(test,
+                    'Click to install app',
+                    app,
+                    customDimensions
+                );
+            });
+
+            helpers.done(test);
+        }
+    });
 });
 
 
-casper.test.begin('Test UA when installing from listing page', {
-    test: function(test) {
-        helpers.startCasper('/search');
+installAttributionTestDefs.forEach(function(testDef) {
+    casper.test.begin('Test UA source when following ' + testDef.name + ' to detail page', {
+        test: function(test) {
+            helpers.startCasper(testDef.path);
 
-        var app;
-        helpers.waitForPageLoaded(function() {
-            var sel = '.app-list-app:nth-child(5) .install';
-            app = appList.getAppData(sel);
-            casper.click(sel);
+            var customDimensions = {
+                dimension9: testDef.src ? 'direct' : testDef.attribution,
+                dimension16: 'detail',
+            };
 
-            helpers.assertUASendEvent(test, [
-                'Click to install app',
-                'free',
-                app.UALabel,
-                4  // nth-child(5).
-            ]);
-        });
+            var app;
+            helpers.waitForPageLoaded(function() {
+                app = appList.getAppData('.mkt-tile:first-child .install');
+                casper.click('.mkt-tile:first-child');
+            });
 
-        casper.waitForSelector('.launch', function() {
-            helpers.assertUASendEvent(test, [
-                'Successful app install',
-                'free',
-                app.UALabel,
-                4  // nth-child(5).
-            ]);
-        });
+            casper.waitForSelector('[data-page-type~="detail"] .install', function() {
+                casper.click('.install');
+                assertUAInstall(test,
+                    'Click to install app',
+                    app,
+                    customDimensions
+                );
+            });
 
-        helpers.done(test);
-    }
+            casper.waitForSelector('.launch', function() {
+                assertUAInstall(test,
+                    'Click to install app',
+                    app,
+                    customDimensions
+                );
+            });
+
+            helpers.done(test);
+        }
+    });
 });

--- a/tests/ui/installs.js
+++ b/tests/ui/installs.js
@@ -107,7 +107,7 @@ casper.test.begin('Test UA when installing from app details page', {
             app = appList.getAppData('.install');
             casper.click('.install');
 
-            helpers.assertUATracking(test, [
+            helpers.assertUASendEvent(test, [
                 'Click to install app',
                 'free',
                 app.UALabel,
@@ -116,7 +116,7 @@ casper.test.begin('Test UA when installing from app details page', {
         });
 
         casper.waitForSelector('.launch', function() {
-            helpers.assertUATracking(test, [
+            helpers.assertUASendEvent(test, [
                 'Successful app install',
                 'free',
                 app.UALabel,
@@ -139,7 +139,7 @@ casper.test.begin('Test UA when installing from listing page', {
             app = appList.getAppData(sel);
             casper.click(sel);
 
-            helpers.assertUATracking(test, [
+            helpers.assertUASendEvent(test, [
                 'Click to install app',
                 'free',
                 app.UALabel,
@@ -148,7 +148,7 @@ casper.test.begin('Test UA when installing from listing page', {
         });
 
         casper.waitForSelector('.launch', function() {
-            helpers.assertUATracking(test, [
+            helpers.assertUASendEvent(test, [
                 'Successful app install',
                 'free',
                 app.UALabel,
@@ -171,7 +171,7 @@ casper.test.begin('Test UA when installing from listing page', {
             app = appList.getAppData(sel);
             casper.click(sel);
 
-            helpers.assertUATracking(test, [
+            helpers.assertUASendEvent(test, [
                 'Click to install app',
                 'free',
                 app.UALabel,
@@ -180,7 +180,7 @@ casper.test.begin('Test UA when installing from listing page', {
         });
 
         casper.waitForSelector('.launch', function() {
-            helpers.assertUATracking(test, [
+            helpers.assertUASendEvent(test, [
                 'Successful app install',
                 'free',
                 app.UALabel,

--- a/tests/ui/navbar.js
+++ b/tests/ui/navbar.js
@@ -52,7 +52,7 @@ casper.test.begin('Test navbar tracking events', {
     test: function(test) {
         helpers.waitForPageLoaded(function() {
             casper.click('.navbar [data-tab="popular"] a');
-            helpers.assertUATracking(test, [
+            helpers.assertUASendEvent(test, [
                 'Nav Click',
                 'click',
                 'popular'

--- a/tests/ui/search.js
+++ b/tests/ui/search.js
@@ -121,3 +121,51 @@ casper.test.begin('Test search results header desktop', {
         helpers.done(test);
     }
 });
+
+
+casper.test.begin('Test UA track keyword leading to app view', {
+    test: function(test) {
+        helpers.startCasper('/search?q=abc');
+
+        helpers.waitForPageLoaded(function() {
+            casper.click('.mkt-tile');
+        });
+
+        casper.waitForSelector('[data-page-type~="detail"]', function() {
+            casper.click('.wordmark');
+        });
+
+        casper.waitWhileSelector('[data-page-type~="detail"]', function() {
+            var dimensions = helpers.filterUALogs(['send', 'pageview'])[0][2];
+            test.assertEquals(dimensions.dimension12, 'abc');
+        });
+
+        helpers.done(test);
+    }
+});
+
+
+casper.test.begin('Test UA track keyword leading to app install on detail', {
+    test: function(test) {
+        helpers.startCasper('/search?q=abc');
+
+        helpers.waitForPageLoaded(function() {
+            casper.click('.mkt-tile');
+        });
+
+        casper.waitForSelector('[data-page-type~="detail"]', function() {
+            casper.click('.install');
+        });
+
+        casper.waitForSelector('.launch', function() {
+            var beginInstallDimensions = helpers.filterUALogs(
+                ['send', 'event', 'Click to install app'])[0][5];
+            var doneInstallDimensions = helpers.filterUALogs(
+                ['send', 'event', 'Successful app install'])[0][5];
+            test.assertEquals(beginInstallDimensions.dimension13, 'abc');
+            test.assertEquals(doneInstallDimensions.dimension13, 'abc');
+        });
+
+        helpers.done(test);
+    }
+});


### PR DESCRIPTION
- actually send the custom dimensions in with the app install events (6,7,8,9,10,16,17)
- new **dimension16**: attributing where the app was installed from
- new **dimension17**: feed slug if it was installed from feed element
- attach src to all install buttons to help attribute the src
- create constants for dimensions and install attributions
- only log what is actually pushed to UA, meaning no logging page vars and such
- add UA event for desktop promo click
- persist desktop promo src through to app detail page
- document tracking stuff at top of tracking_events.js
- swap 12 and 13, rework search query tracking
- fix abuse report tracking