### PR TITLE
use palette instead of filters-X colors

### DIFF
--- a/src/media/css/app-list-filters.styl
+++ b/src/media/css/app-list-filters.styl
@@ -7,7 +7,7 @@ App listing filters.
 
 .app-list-filters {
     bottom: 15px;
-    color: $filters-label;
+    color: $greyscale-black;
     margin: 0 auto;
     min-height: 20px;
     position: relative;
@@ -92,7 +92,7 @@ App listing filters.
 @media $base-tablet {
     .app-list-filters {
         bottom: 0;
-        border-bottom: 2px solid $filters-border;
+        border-bottom: 2px solid $greyscale-light-grey;
         padding: 0 0 30px;
         width: $desktop-content;
     }

--- a/src/media/css/app-list.styl
+++ b/src/media/css/app-list.styl
@@ -48,7 +48,7 @@ $desktop-tile-padding = 20px 50px;
 }
 
 .app-list-app {
-    border-bottom: 1px solid $filters-border;
+    border-bottom: 1px solid $greyscale-light-grey;
     padding-bottom: 15px;
     padding-top: 15px;
 }

--- a/src/media/css/lib/colors.styl
+++ b/src/media/css/lib/colors.styl
@@ -41,9 +41,6 @@ $greyscale-white-tapped = #bfbfbf;
 
 // From desktop refresh.
 $drop-arrow = #60bffc;
-$filters-border = #d3d3d3;
-$filters-label = #2c2c2c;
-$filters-link = #5bbfff;
 $footer-border = #e5e4e5;
 $page-background = $greyscale-light-grey;
 $tile-border = $greyscale-light-grey;

--- a/src/media/css/pretty-select.styl
+++ b/src/media/css/pretty-select.styl
@@ -3,7 +3,7 @@
 $select-height = 30px;
 
 .pretty-select {
-    border: 1px solid $filters-border;
+    border: 1px solid $greyscale-grey;
     border-radius: 5px;
     font-weight: normal;
     font-size: 20px;

--- a/src/media/css/previews-tray.styl
+++ b/src/media/css/previews-tray.styl
@@ -12,7 +12,7 @@ $desktop-tray-height = 540px;
 }
 
 .previews-tray {
-    background: $filters-border;
+    background: $greyscale-grey;
     display: none;
     height: $tray-height + $bar-height;
     overflow: hidden;


### PR DESCRIPTION
Custom colors with specific names that stray from the palette are sometimes not a good idea. In this case, we named a color "filters-border", which wasn't in the palette, and started using it for dropdown borders, preview tray backgrounds, etc. Then the name loses all meaning.

So this PR just sticks to the palette. 

Also lightens up the filters border, which I found to be too thick and dark.