### PR TITLE
don't flash unexpanded list first (bug 1130451)

### DIFF
--- a/src/media/css/app-list.styl
+++ b/src/media/css/app-list.styl
@@ -25,6 +25,7 @@ $desktop-tile-padding = 20px 50px;
 
 .app-list {
     list-style: none;
+    opacity: 0;
 
     // Masking element to cover the last row's bottom border.
     &:after {
@@ -40,6 +41,9 @@ $desktop-tile-padding = 20px 50px;
     }
     &.expanded .app-list-app {
         padding-bottom: 40px;
+    }
+    &.show-app-list {
+        opacity: 1;
     }
 }
 

--- a/src/media/js/app_list.js
+++ b/src/media/js/app_list.js
@@ -34,9 +34,8 @@ define('app_list',
         if ($('.main:not(.feed-landing-apps) .app-list').length) {
             initTileState();
         }
-    });
-
-    z.page.on('loaded_more', function() {
+        $('.app-list').addClass('show-app-list');
+    }).on('loaded_more', function() {
         // Remove paginated class from app lists if .loadmore goes away.
         if (!$('.loadmore').length) {
             $('.app-list').removeClass('paginated');


### PR DESCRIPTION
2nd version of this PR.

We still need to trigger on 'loaded' but it will now affect any page with `.app-list` so it addresses the issue on collection/brand landing pages.