### PR TITLE
nuke display flex on settings btns for fxos1.1 (bug 1132461)

### DIFF
--- a/src/media/css/account.styl
+++ b/src/media/css/account.styl
@@ -84,11 +84,6 @@
 
 .account-settings-save,
 .account-settings-links div {
-    align-items: center;
-    display-flex();
-    flex-wrap(wrap);
-    justify-content(center);
-
     p {
         type_body();
         margin: 30px 0 20px;
@@ -135,5 +130,12 @@
         &:nth-child(2) {
             margin-right: 10px;
         }
+    }
+    .account-settings-save,
+    .account-settings-links div {
+        display-flex();
+        align-items: center;
+        flex-wrap(wrap);
+        justify-content(center);
     }
 }


### PR DESCRIPTION
This is how it looks in FF18 (which should be the same as fxos1.1):

![](http://i.imgur.com/fZfg15E.png)

This is on desktop on FF Dev:

![](http://i.imgur.com/mChG5sd.png)