### PR TITLE
remove getInstalled loop, do markBtnsAsInstalled on page.loaded (bug 1092463)

### DIFF
--- a/src/media/js/apps.js
+++ b/src/media/js/apps.js
@@ -2,11 +2,12 @@
     Provides the apps module, a wrapper around navigator.mozApps
 */
 define('apps',
-    ['capabilities', 'defer', 'installer_direct', 'installer_iframe', 'l10n', 'log', 'nunjucks', 'settings', 'underscore', 'utils'],
-    function(capabilities, defer, installer_direct, installer_iframe, l10n, log, nunjucks, settings, _, utils) {
+    ['capabilities', 'defer', 'installer_direct', 'installer_iframe', 'l10n',
+     'nunjucks', 'settings', 'underscore', 'utils'],
+    function(capabilities, defer, installer_direct, installer_iframe, l10n,
+             nunjucks, settings, _, utils) {
     'use strict';
     var gettext = l10n.gettext;
-    var console = log('apps');
     var installer;
 
     /*
@@ -35,10 +36,10 @@ define('apps',
 
            See also: https://developer.mozilla.org/docs/DOM/Apps.install
 
-           data -- optional dict to pass as navigator.apps.install(url, data, ...)
+           data -- optional dict to pass as navigator.apps.install(url, data)
            success -- optional callback for when app installation was successful
-           error -- optional callback for when app installation resulted in error
-           navigator -- something other than the global navigator, useful for testing
+           error -- optional callback for when app install resulted in error
+           navigator -- something other than global navigator, for testing
         */
         var def = defer.Deferred();
 
@@ -115,6 +116,8 @@ define('apps',
         launch: launch,
         incompat: incompat,
         install: install,
-        _use_compat_cache: function(val) {use_compat_cache = val;}
+        _use_compat_cache: function(val) {
+            use_compat_cache = val;
+        }
     };
 });

--- a/src/media/js/main.js
+++ b/src/media/js/main.js
@@ -61,10 +61,8 @@ define(
     ],
 function(_) {
     var apps = require('apps');
-    var buttons = require('apps_buttons');
     var capabilities = require('capabilities');
     var consumer_info = require('consumer_info');
-    var flipsnap = require('flipsnap');
     var format = require('format');
     var $ = require('jquery');
     var settings = require('settings');
@@ -148,22 +146,15 @@ function(_) {
     }
 
     if (capabilities.webApps) {
-        // Mark installed apps, look for Marketplace update. If in packaged
-        // app, wait for the iframe to load. Else we use direct installer and
-        // just need to wait for normal loaded event.
+        // Look for Marketplace update.
         var is_packaged_app = window.location.protocol === 'app:';
-        var is_iframed_app = window.top !== window.self;  //  Good enough.
-        var event_for_apps = is_packaged_app ? 'iframe-install-loaded' : 'loaded';
-        z.page.one(event_for_apps, function() {
-            apps.getInstalled().done(function() {
-                z.page.trigger('mozapps_got_installed');
-                buttons.mark_btns_as_installed();
-            });
-
+        var is_iframed_app = window.top !== window.self;
+        var appEvent = is_packaged_app ? 'iframe-install-loaded' : 'loaded';
+        z.page.one(appEvent, function() {
             var manifest_url = settings.manifest_url;
             var email = user.get_setting('email') || '';
-            // Need the manifest url to check for update.  Only want to show
-            // update notification banner if inside an app. Only to mozilla.com
+            // Need manifest URL to check for update. Only want to show
+            // update notification banner if inside app. Only to mozilla.com
             // users for now.
             if (manifest_url && (is_packaged_app || is_iframed_app) &&
                 email.substr(-12) === '@mozilla.com') {
@@ -194,12 +185,9 @@ function(_) {
 
         document.addEventListener('visibilitychange', function() {
             if (!document.hidden) {
-                // Refresh list of installed apps in case user uninstalled apps
-                // and switched back.
                 if (user.logged_in()) {
                     consumer_info.fetch(true);
                 }
-                apps.getInstalled().done(buttons.mark_btns_as_uninstalled);
             }
         }, false);
     }

--- a/tests/lib/mozApps.js
+++ b/tests/lib/mozApps.js
@@ -77,6 +77,10 @@ function initialize() {
 
                 return request;
             },
+            _resetInstalled: function() {
+                // Helper to clear installed apps. Not a part of the API.
+                manifests = [];
+            }
         };
 
         window.navigator.mozApps.installPackage = window.navigator.mozApps.install;

--- a/tests/ui/installs.js
+++ b/tests/ui/installs.js
@@ -73,6 +73,31 @@ casper.test.begin('Test install packaged app', {
 });
 
 
+casper.test.begin('Test mark uninstalled apps on visibilitychange', {
+    test: function(test) {
+        helpers.startCasper('/app/someapp');
+
+        helpers.waitForPageLoaded(function() {
+            casper.click('.install');
+        });
+
+        casper.waitForSelector('.launch', function() {
+            casper.evaluate(function() {
+                window.navigator.mozApps._resetInstalled();
+                window.require('z').doc.trigger('visibilitychange');
+            });
+
+        });
+
+        casper.waitWhileSelector('.launch', function() {
+            test.assertDoesntExist('.launch');
+        });
+
+        helpers.done(test);
+    }
+});
+
+
 casper.test.begin('Test UA when installing from app details page', {
     test: function(test) {
         helpers.startCasper('/app/free');


### PR DESCRIPTION
For some reason, we needed to call apps.getInstalled() at the end of markInstalled to make sure that installed apps were given Launch buttons. That didn't make sense, and I don't know why it was needed.

But we were able to remove it by calling markBtnsAsInstalled on z.page.loaded and loaded_more.

- Do some clean up
- Move some code out of main.js