### PR TITLE
tweak app list alignment (bug 1138414)

### DIFF
--- a/src/media/css/app-list-filters.styl
+++ b/src/media/css/app-list-filters.styl
@@ -89,8 +89,8 @@ App listing filters.
     display: none;
 }
 
-.app-list-filters + .app-list .app-list-app:first-child {
-    padding-top: 0;
+.app-list-filters + .app-list {
+    margin-top: -15px;
 }
 
 @media $base-tablet {
@@ -129,7 +129,7 @@ App listing filters.
     .app-list-filters-expand-toggle.show {
         display: none;
     }
-    .app-list-filters + .app-list .app-list-app:first-child {
-        padding-top: 15px;
+    .app-list-filters + .app-list  {
+        margin-top: 25px;
     }
 }


### PR DESCRIPTION
I think the change that broke this was meant to shift the app lists up by 5px when preceded by the filters so I redid it via margins of the entire list and not just the first child. The result on mobile is visually the same...on desktop the first two app tiles also align.

![](http://i.imgur.com/7mRj9pk.png)