### PR TITLE
allow 6 grid edbrand apps on homepage (bug 1140066)

### DIFF
--- a/src/media/js/feed.js
+++ b/src/media/js/feed.js
@@ -55,6 +55,7 @@ define('feed',
                 feedItem.color = get_brand_color_class(feedItem);
                 feedItem.name = brands.get_brand_type(feedItem.type, feedItem.apps.length);
                 feedItem.src = trackingEvents.SRCS.brand;
+                feedItem.maxApps = feedItem.layout === 'grid' ? 6 : 4;
                 break;
             case 'collection':
                 if (feedItem.type == 'promo') {
@@ -63,6 +64,7 @@ define('feed',
                     feedItem.isCollListing = true;
                 }
                 feedItem.src = trackingEvents.SRCS.collection;
+                feedItem.maxApps = 4;
                 break;
             case 'shelf':
                 feedItem.src = trackingEvents.SRCS.shelf;

--- a/src/templates/_macros/feed_item.html
+++ b/src/templates/_macros/feed_item.html
@@ -55,20 +55,19 @@
 
 {% macro brand(brand) %}
   {% set brand = feed.transformer(brand) %}
-  {% set max_apps = 4 %}
 
   <section class="feed-brand feed-layout-{{ brand.layout }} multi-app-tile c"
            data-tracking="{{ brand.slug }}">
     {{ brand_header(brand) }}
     <ul>
       {% for app in brand.apps %}
-        {% if loop.index0 < max_apps %}
+        {% if loop.index0 < brand.maxApps %}
           {{ app_tile(app, src=brand.src, price_only=True) }}
         {% endif %}
       {% endfor %}
     </ul>
 
-    {% if brand.app_count > 4 %}
+    {% if brand.app_count > brand.maxApps %}
       <a href="{{ brand.landingUrl }}"
          class="view-all-tab feed-view-all-tab">
         {{ _('View all apps') }}
@@ -148,7 +147,6 @@
 
 {% macro collection_listing(coll) %}
   {% set coll = feed.transformer(coll) %}
-  {% set max_apps = 4 %}
 
   <section class="feed-collection feed-collection-listing feed-layout-list
                   multi-app-tile mkt-tile c"
@@ -156,13 +154,13 @@
     {{ collection_listing_header(coll) }}
     <ul>
       {% for app in coll.apps %}
-        {% if loop.index0 < max_apps %}
+        {% if loop.index0 < coll.maxApps %}
           {{ app_tile(app, src=coll.src) }}
         {% endif %}
       {% endfor %}
     </ul>
 
-    {% if coll.app_count > 4 %}
+    {% if coll.app_count > coll.maxApps %}
       <a href="{{ coll.landingUrl }}"
          class="view-all-tab feed-view-all-tab">
         {{ _('View all apps') }}

--- a/tests/ui/feed.js
+++ b/tests/ui/feed.js
@@ -103,7 +103,7 @@ casper.test.begin('Test Feed navigation and tracking events', {
         });
 
         casper.waitForSelector('.home-feed', function() {
-            casper.click('[data-tracking="brand-grid"] .view-all-tab');
+            casper.click('[data-tracking="brand-grid"] .brand-header');
             helpers.assertUASendEvent(test, [
                 'View Branded Editorial Element',
                 'click',
@@ -201,7 +201,7 @@ casper.test.begin('Test clicking on brand sets correct src', {
         helpers.startCasper();
 
         helpers.waitForPageLoaded(function() {
-            casper.click('[data-tracking="brand-grid"] .feed-view-all-tab');
+            casper.click('[data-tracking="brand-grid"] .brand-header');
         });
 
         casper.waitForSelector('[data-brand-landing]', function() {


### PR DESCRIPTION
I added the "getting around" listing on the "restofworld" homepage to easily test this on the -dev endpoint.