### PR TITLE
Bug 1135145 - Search field should be larger at tablet width so text is not truncated

### DIFF
--- a/src/media/css/header.styl
+++ b/src/media/css/header.styl
@@ -342,7 +342,7 @@ body {
     }
 }
 
-@media (max-width: 540px) {
+@media (max-width: 699px) {
     // TODO: get rid of this media query.
     .site-header {
         .search {


### PR DESCRIPTION
Now text in the search box will not truncated. 