### PR TITLE
Check that flue is running in tests/serve.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,6 @@ before_script:
   - 'sh -e /etc/init.d/xvfb start'
 # Start the server if needed
   - 'if [ $START_SERVER ]; then bash tests/serve.sh; fi'
-# Make sure flue is ready.
-  - 'if [ $START_SERVER ]; then curl http://localhost:5000/api/v2/services/config/site/; fi'
 # Make the langpacks if needed.
   - 'if [ $MAKE_LANGPACKS ]; then commonplace langpacks; fi'
 # Install the latest slimer if we're running slimer.

--- a/tests/serve.sh
+++ b/tests/serve.sh
@@ -10,3 +10,6 @@ mv src/media/js/settings_local_test.js src/media/js/settings_local.js
 make build
 MKT_COMPILED=1 make serve &
 sleep 10
+
+# Make sure flue is ready.
+curl http://localhost:5000/api/v2/services/config/site/


### PR DESCRIPTION
After this the `.travis.yml` is pretty much the same.

```diff
diff --git a/marketplace-template/.travis.yml b/fireplace/.travis.yml
index aef972f..c22cc51 100644
--- a/marketplace-template/.travis.yml
+++ b/fireplace/.travis.yml
@@ -21,6 +21,7 @@ env:
   - RUN_TEST=lint
   - RUN_TEST=unittest
   - RUN_TEST=test-langpacks
+  - RUN_TEST=test-package
 before_script:
   - "export PHANTOMJS_EXECUTABLE='phantomjs --local-to-remote-url-access=yes --ignore-ssl-errors=yes'"
   - 'export SLIMERJSLAUNCHER=$(which firefox)'
