### PR TITLE
Desktop promo right arrow class fix

### DIFF
--- a/src/templates/desktop-promo.html
+++ b/src/templates/desktop-promo.html
@@ -13,6 +13,6 @@
     {% endfor %}
   </div>
 
-  <div class="desktop-promo-nav-right arrow-button arrow-btn-next"
+  <div class="desktop-promo-nav-right arrow-btn arrow-btn-next"
        data-navigate="next">{{ _('Next') }}</div>
 </div>


### PR DESCRIPTION
`arrow-button` was renamed to `arrow-btn` and this class didn't change so the button just said "Next" instead of being an arrow.

Grepping for `arrow-button` this is all that came up so hopefully that's all of them.

r? @ngokevin 

<blockquote>
<img alt="screenshot 2015-03-30 13 16 00" src="https://cloud.githubusercontent.com/assets/211578/6903344/4c116da2-d6df-11e4-8e6f-218032190f96.png">
Before
</blockquote>
<blockquote>
<img alt="screenshot 2015-03-30 13 18 05" src="https://cloud.githubusercontent.com/assets/211578/6903345/4c134924-d6df-11e4-9c5a-3a2e3ea6fbb3.png">
After
</blockquote>
