### PR TITLE
Move banners based on window width

### DIFF
--- a/src/media/css/elements--nav.styl
+++ b/src/media/css/elements--nav.styl
@@ -38,6 +38,10 @@ $zindex--page-overlay = 100;
     min-height: 480px;
 }
 
+.mkt-nav--wrapper {
+    position: relative;
+}
+
 main:after {
     // Disable main content interaction when nav is visible.
     background: rgba($greyscale-dark-grey, .8);

--- a/src/media/js/header_footer.js
+++ b/src/media/js/header_footer.js
@@ -10,17 +10,16 @@ define('header_footer',
 
     function renderHeader() {
         if (settings.mktNavEnabled) {
-            $('#site-header').remove();
+            $('#mkt-nav--site-header, #site-header, main #site-nav').remove();
 
-            $(nunjucks.env.render('header.html')).insertBefore('main');
-
-            $(nunjucks.env.render('mkt_nav.html', {
-                categories: categories
-            })).insertAfter('#site-header');
+            $('<div id="mkt-nav--site-header" class="mkt-nav--wrapper"></div>')
+                .append(nunjucks.env.render('header.html'))
+                .append(nunjucks.env.render('mkt_nav.html', {
+                    categories: categories
+                }))
+                .insertBefore('main');
 
             z.body.attr('data-mkt-nav--enabled', true);
-
-            $('main #site-nav').remove();
         } else {
             $('#site-header').html(nunjucks.env.render('header.html'));
         }
@@ -39,10 +38,29 @@ define('header_footer',
         }
     }
 
+    function renderBanners() {
+        var bannerDiv = $('#banners');
+
+        if (bannerDiv.length === 0) {
+            bannerDiv = '<div id="banners"></div>';
+        }
+
+        if (settings.mktNavEnabled) {
+            if (window.matchMedia('(min-width: 800px)').matches) {
+                $('#mkt-nav--site-header').before(bannerDiv);
+            } else {
+                $('#page').before(bannerDiv);
+            }
+        } else {
+            $('#page').before(bannerDiv);
+        }
+    }
+
     z.page.on('reload_chrome', function() {
         renderHeader();
         renderFooter();
         renderPlatformSelector();
+        renderBanners();
     });
 
     return {

--- a/src/media/js/main.js
+++ b/src/media/js/main.js
@@ -87,11 +87,11 @@ require(
         if (!caps.webApps && !navigator.userAgent.match(/googlebot/i)) {
             if (!document.getElementById('incompatibility-banner')) {
                 logger.log('Adding incompatibility banner');
-                $('#site-nav').after(nunjucks.env.render('incompatible.html'));
+                $('#banners').append(nunjucks.env.render('incompatible.html'));
             }
         } else if (caps.osXInstallIssues) {
             if ($('mkt-banner[name="mac-banner"]').length === 0) {
-                $('#site-nav').after(
+                $('#banners').append(
                     nunjucks.env.render('_includes/os_x_banner.html'));
             }
         }

--- a/src/media/js/update_banner.js
+++ b/src/media/js/update_banner.js
@@ -41,7 +41,7 @@ define('update_banner',
                 apps.checkForUpdate(manifestURL).done(function(result) {
                     if (result) {
                         logger.log('Update found, inserting banner.');
-                        $('#site-nav').after(
+                        $('#banners').append(
                             nunjucks.env.render('marketplace-update.html'));
                     } else {
                         logger.log('No update found.');

--- a/src/media/js/views/debug.js
+++ b/src/media/js/views/debug.js
@@ -22,9 +22,7 @@ define('views/debug',
 
     .on('click', '#enable-mkt-nav', function() {
         settings.mktNavEnabled = true;
-        headerFooter.renderHeader();
-        headerFooter.renderPlatformSelector();
-        z.page.trigger('navigate');
+        z.page.trigger('reload_chrome').trigger('navigate');
     })
 
     .on('click', '#enable-offline-cache', function() {

--- a/tests/ui/index.js
+++ b/tests/ui/index.js
@@ -66,3 +66,50 @@ casper.test.begin('Test l10n initialized for non en-US', {
         helpers.done(test);
     }
 });
+
+casper.test.begin('Test that the banner is first on desktop', {
+    test: function(test) {
+        helpers.startCasper('/debug', {viewport: 'desktop'});
+
+        helpers.waitForPageLoaded();
+        casper.thenClick('#enable-mkt-nav');
+        casper.waitForSelector('.mkt-nav--wrapper');
+        casper.then(function() {
+            test.assertExists('#banners ~ #mkt-nav--site-header');
+        });
+
+        helpers.done(test);
+    },
+});
+
+casper.test.begin('Test that the banner is last on mobile', {
+    test: function(test) {
+        helpers.startCasper('/debug');
+
+        helpers.waitForPageLoaded();
+        casper.thenClick('#enable-mkt-nav');
+        casper.waitForSelector('.mkt-nav--wrapper');
+        casper.then(function() {
+            test.assertExists('#mkt-nav--site-header ~ main mkt-select.compat-filter');
+            test.assertExists('#mkt-nav--site-header ~ main #banners');
+            test.assertExists('mkt-select.compat-filter + #banners');
+        });
+
+        helpers.done(test);
+    },
+});
+
+casper.test.begin('Test that the banner is last on desktop without mkt-nav', {
+    test: function(test) {
+        helpers.startCasper('/debug', {viewport: 'desktop'});
+
+        helpers.waitForPageLoaded();
+        casper.then(function() {
+            test.assertExists('#site-header ~ main #site-nav');
+            test.assertExists('#site-header ~ main #banners');
+            test.assertExists('#site-nav + #banners');
+        });
+
+        helpers.done(test);
+    },
+});


### PR DESCRIPTION
<img alt="screen shot 2015-04-09 at 16 46 28" src="https://cloud.githubusercontent.com/assets/211578/7077689/7dc69f74-ded8-11e4-9faa-edc507bfb1fe.png"> <img alt="screen shot 2015-04-09 at 16 47 20" src="https://cloud.githubusercontent.com/assets/211578/7077690/7dc78cea-ded8-11e4-952b-4e839c9b5f4b.png">
<img alt="screen shot 2015-04-09 at 16 46 39" src="https://cloud.githubusercontent.com/assets/211578/7077688/7dc68b1a-ded8-11e4-81ea-586322e0ca55.png" width="49%"> <img width="49%" alt="screen shot 2015-04-09 at 16 47 30" src="https://cloud.githubusercontent.com/assets/211578/7077691/7dca02ae-ded8-11e4-8bb7-2d741cc7791b.png">

Resizing the window does not move the banners, their position is set when the header is rendered on desktop and at the first `reload_chrome` event otherwise.
