### PR TITLE
Use position: fixed to prevent fennec sidebar scrolling (bug 1153203)

### DIFF
--- a/src/media/css/elements--nav.styl
+++ b/src/media/css/elements--nav.styl
@@ -62,6 +62,9 @@ main:after {
     &.mkt-nav--visible {
         // Disable scroll on main content when nav is visible.
         overflow-y: hidden;
+        // overflow: hidden doesn't work properly on fennec so set
+        // position: fixed also. (bug 1153203).
+        position: fixed;
     }
     &.mkt-nav--visible main {
         position: relative;
@@ -281,6 +284,8 @@ mkt-nav-child {
 @media $wide-tablet {
     [data-mkt-nav--enabled].mkt-nav--visible {
         overflow-y: auto;
+        // We had to set position: fixed for fennec (bug 1153203).
+        position: static;
     }
     [data-mkt-nav--enabled].mkt-nav--visible main:after {
         display: none;


### PR DESCRIPTION
I couldn't find a way to keep the background from turning white when scrolling down on the sidebar. But at least the layout doesn't break.

Before video: ﻿https://www.dropbox.com/s/b6urnnsc4dg4kmo/sidebar-content-scroll.mp4?dl=0.
After video: https://www.dropbox.com/s/s0vg44jsm3nvh7h/sidebar-no-content-scroll.mp4?dl=0.