### PR TITLE
RTL-ify the splash page

### DIFF
--- a/src/media/css/splash.styl
+++ b/src/media/css/splash.styl
@@ -55,14 +55,13 @@
     border-radius: 2px;
     display: inline-block;
     height: 17px;
-    margin-left: 10px;
+    margin: 0 5px;
     opacity: .5;
     transition: opacity .5s ease-in-out;
     width: 17px;
 
     &:nth-child(1) {
         animation-delay: 0s;
-        margin: 0;
     }
     &:nth-child(2) {
         animation-delay: .16s;


### PR DESCRIPTION
![rtl-splash-page mov](https://cloud.githubusercontent.com/assets/211578/7209405/fee3646c-e50d-11e4-8971-c76c2dac36ae.gif)

It does a fun LTR->RTL switcheroo. I'll address that in [bug 1155826](https://bugzilla.mozilla.org/show_bug.cgi?id=1155826).