### PR TITLE
Empty out <body> after each unit test

### DIFF
--- a/test-main.js
+++ b/test-main.js
@@ -9,6 +9,11 @@ beforeEach(function() {
 afterEach(function() {
     sinon.restore();
     sinon = realSinon;
+
+    // Ensure that body is empty for the next test.
+    Array.prototype.forEach.call(document.body.children, function(child) {
+        document.body.removeChild(child);
+    });
 });
 
 function withSettings(changes, test) {

--- a/tests/unit/elements--nav.js
+++ b/tests/unit/elements--nav.js
@@ -119,9 +119,6 @@ define('tests/unit/elements--nav',
 
             assert.ok(mktNav.statusElement.classList.contains(
                       nav.classes.VISIBLE));
-
-            document.body.removeChild(mktNav);
-            document.body.removeChild(mktNavToggle);
         });
     });
 
@@ -144,9 +141,6 @@ define('tests/unit/elements--nav',
             assert.notOk(mktNavChild.visible);
             mktNavChildToggle.click();
             assert.ok(mktNavChild.visible);
-
-            document.body.removeChild(mktNav);
-            document.body.removeChild(mktNavChildToggle);
         });
     });
 });


### PR DESCRIPTION
The `mkt-nav-child-toggle toggles nav child` test was flaky because previous tests didn't clean up after themselves. So this will clean up any elements that were created automatically after each test.

r? @ngokevin 