### PR TITLE
Label for review modal stars but really RTL but it worked (bug 1148619)

### DIFF
--- a/src/media/css/reviews.styl
+++ b/src/media/css/reviews.styl
@@ -205,6 +205,12 @@ mkt-prompt .simple-field.rating {
     }
 }
 
+.rating-label {
+    font-size: 12px;
+    font-style: italic;
+    text-align: center;
+}
+
 mkt-prompt[data-modal="flag-review"] {
     .reasons {
         padding-bottom: 10px;

--- a/src/templates/ratings/add.html
+++ b/src/templates/ratings/add.html
@@ -19,6 +19,7 @@
           {% endfor %}
         </select>
       </p>
+      <p class="rating-label">{{ _('Please select a star rating.') }}</p>
       <textarea id="review-body" rows="2" cols="40" name="body"
                 placeholder="{{ _('Tell us what you love about this app!') }}"
                 required maxlength="150">{{ existingReview.body }}</textarea>


### PR DESCRIPTION
The modal just worked, probably got handled by another `<mkt-prompt>` bug. I added the label that was in the mocks.

![screenshot 2015-04-23 14 51 14](https://cloud.githubusercontent.com/assets/211578/7306387/87e98f3c-e9ca-11e4-9055-a7701f4e0627.png)
![screenshot 2015-04-23 14 51 27](https://cloud.githubusercontent.com/assets/211578/7306388/87edae64-e9ca-11e4-807d-c6fe9f40c081.png)
