### PR TITLE
Handle selecting wrong element on newsletter signup FxOS (bug 1151762)

### DIFF
--- a/src/media/js/views/newsletter_signup.js
+++ b/src/media/js/views/newsletter_signup.js
@@ -10,5 +10,11 @@ define('views/newsletter_signup',
         _.extend(context, newsletter.context());
         builder.start('newsletter.html', context);
         builder.z('type', 'root settings');
+
+        // Tapping before scrolling on FxOS 2.0+ will cause you to select an
+        // element below the one you tapped. Let's do the initial scroll so
+        // things just work (bug 1151762).
+        window.scrollTo(0, 1);
+        window.scrollTo(0, 0);
     };
 });


### PR DESCRIPTION
On FxOS 2.0+ the wrong element would be selected on the first tap when
on the newsletter signup page. This problem goes away if you scroll so
do a quick scroll on page load to make things work right away.

![newsletter-signup-failing mov](https://cloud.githubusercontent.com/assets/211578/7416676/b871b088-ef26-11e4-91b7-2419de40f112.gif)
> Before

![newsletter-signup-working mov](https://cloud.githubusercontent.com/assets/211578/7416675/b87111fa-ef26-11e4-8847-c0bce6ae3f7d.gif)
> After
