### PR TITLE
Always use a white background for feed apps, even when you click on it

### DIFF
--- a/src/media/css/feed/feed.styl
+++ b/src/media/css/feed/feed.styl
@@ -45,10 +45,14 @@
 }
 
 .feed-app {
-    background-color: $white;
     margin-bottom: 0;
     padding: 0 15px 10px;
     position: relative;
+
+    &,
+    &:active {
+        background-color: $white;
+    }
 
     .heading {
         margin-bottom: 10px;


### PR DESCRIPTION
Our Android reset was clearing this, so let's increase our specifity!

<img alt="feed-app-active-broken mov" src="https://cloud.githubusercontent.com/assets/211578/7421060/2fef2b48-ef47-11e4-87bd-8bbf2874c314.gif" width="49%"> <img alt="feed-app-active-fixed mov" src="https://cloud.githubusercontent.com/assets/211578/7421061/2ff67024-ef47-11e4-8bb0-c11430194487.gif" width="49%">
> Before&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;After