### PR TITLE
Account for scrollbar in platform select (bug 1160347)

### DIFF
--- a/src/media/js/elements/select.js
+++ b/src/media/js/elements/select.js
@@ -205,7 +205,7 @@ define('elements/select',
                         if (htmlDir === 'rtl') {
                             offset += $selectedText.width();
                             if (offset > 0) {
-                                offset = window.innerWidth - offset;
+                                offset = document.body.clientWidth - offset;
                             }
                         }
                         $('mkt-option', this).css(styleAttr, offset)


### PR DESCRIPTION
Align the platform select based on body width not window width to account for the scrollbar on Windows.

r? @ngokevin