### PR TITLE
Use Event('input') instead of InputEvent('input')

### DIFF
--- a/src/media/js/elements/header.js
+++ b/src/media/js/elements/header.js
@@ -204,7 +204,7 @@ define('elements/header',
                     '[data-header-child--input] input'), function(input) {
             setTimeout(function() {
                 input.value = '';
-                input.dispatchEvent(new InputEvent('input'));
+                input.dispatchEvent(new Event('input'));
             }, 50);
         });
     })


### PR DESCRIPTION
`InputEvent` doesn't exist on Chrome so it errors. Just use a regular `Event` instead.