### PR TITLE
attach but hide preview arrows on RTL mobile (bug 1161500)

### DIFF
--- a/src/media/js/previews-buttons.js
+++ b/src/media/js/previews-buttons.js
@@ -14,7 +14,7 @@ define('previews-buttons',
     var isDesktop = caps.device_type() === 'desktop';
 
     function attach(slider, $container, opts) {
-        if (!isDesktop) {
+        if (!isDesktop && !opts.rtl) {
             return;
         }
         var isLightbox = opts && opts.isLightbox;
@@ -28,6 +28,10 @@ define('previews-buttons',
         function setPreviewBtnState() {
             // Toggles whether buttons are hidden or disabled.
             $previewBtns.addClass('arrow-btn-disabled');
+
+            if (!isDesktop && opts.rtl) {
+                $previewBtns.addClass('js-hidden');
+            }
 
             var hasButton = false;
             if (slider.hasNext() &&

--- a/src/media/js/previews.js
+++ b/src/media/js/previews.js
@@ -90,14 +90,17 @@ define('previews',
             // Initialize the bar position.
             updatePreviewBar($bars, slider);
 
-            // Add scroll buttons.
-            var buttons = previewButtons.attach(slider, $slider);
-
             if (document.documentElement.getAttribute('dir') === 'rtl') {
+                // Add scroll buttons.
+                var buttons = previewButtons.attach(slider, $slider, {rtl: true});
+
                 for (var i = 0; i < numBars - 1; i++) {
                     // Start at the end for RTL.
                     buttons.nextBtn.click();
                 }
+            } else {
+                // Add scroll buttons.
+                previewButtons.attach(slider, $slider);
             }
         }
     }


### PR DESCRIPTION
This lets us use ngoke's patented `nextBtn.click()` RTLness on mobile too.