### PR TITLE
integrate websites into listing (bug 1161854)

### DIFF
--- a/src/media/css/app-list.styl
+++ b/src/media/css/app-list.styl
@@ -45,7 +45,7 @@ $desktop-tile-padding = $tile-padding-y $tile-padding-x;
         position: absolute;
         width: 100%;
     }
-    &.previews-expanded .app-list-app {
+    &.previews-expanded .app-list-app:not(.app-list-website) {
         padding-bottom: 40px;
     }
 }

--- a/src/media/css/buttons.styl
+++ b/src/media/css/buttons.styl
@@ -48,8 +48,7 @@ $btn-install-font-size = 12px;
     &.incompatible {
         pointer-events: auto;
     }
-    &.t,
-    &.product {
+    &.t {
         height: $btn-tiny;
     }
     &.s {
@@ -134,9 +133,9 @@ a.button {
 .mkt-app-button {
     align-items: center;
     btn_color(transparent, transparent, transparent, false);
-    border-radius: 5px;
     cursor: pointer;
     display: flex;
+    height: $btn-tiny;
     font-size: $btn-install-font-size;
     height: 34px;
     margin-top: 8px;
@@ -153,6 +152,7 @@ a.button {
         // This em becomes the visual button.
         btn_color($btn-color, $action-positive-tapped,
                   $action-positive-hover, false);
+        border-radius: 5px;
         display: inline-block;
         ellipsis();
         font-style: normal;

--- a/src/media/css/tiles.styl
+++ b/src/media/css/tiles.styl
@@ -73,6 +73,14 @@ $greater-than-mobile = unquote('(min-width: 330px)');
     }
 }
 
+[data-content-type="website"] .preview-container {
+    display: none;
+
+    +media--base-tablet() {
+        display: block;
+    }
+}
+
 .mkt-tile-info {
     display: flex;
     flex-direction: column;

--- a/src/media/js/apps.js
+++ b/src/media/js/apps.js
@@ -122,6 +122,20 @@ define('apps',
         return product[COMPAT_REASONS];
     }
 
+    function transform(app) {
+        // Normalize content types.
+        if (app.doc_type == 'website') {
+            app.isWebsite = true;
+            app.name = app.short_name || app.name || app.title;
+            app.previews = [];
+            app.contentType = 'website';
+        } else {
+            app.isApp = true;
+            app.contentType = 'app';
+        }
+        return app;
+    }
+
     return {
         applyUpdate: applyUpdate,
         checkForUpdate: checkForUpdate,
@@ -131,6 +145,7 @@ define('apps',
         launch: launch,
         promise: installer_def.promise(),
         installer: installer,
+        transform: transform,
         _use_compat_cache: function(val) {
             use_compat_cache = val;
         }

--- a/src/media/js/buttons.js
+++ b/src/media/js/buttons.js
@@ -296,11 +296,16 @@ define('buttons',
     }
 
     z.page.on('click', '.mkt-app-button.launch', launchHandler)
-    .on('click', '.mkt-app-button:not(.launch):not(.incompatible)',
+    .on('click', '.mkt-app-button--install:not(.launch):not(.incompatible)',
         _handler(install))
-    .on('click', '.mkt-app-button[disabled]', function(e) {
+    .on('click', '.mkt-app-button--install[disabled]', function(e) {
         e.preventDefault();
         e.stopPropagation();
+    })
+    .on('click', '.mkt-app-button[href]', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        window.open(this.getAttribute('href'), '_blank');
     });
 
     function get_button(manifest_url) {
@@ -371,6 +376,11 @@ define('buttons',
     }
 
     function transformApp(app) {
+        if (app.isWebsite) {
+            // Return here, don't need extra information for websites.
+            return app;
+        }
+
         var isLangpack = app.role == 'langpack';
         var incompatible = apps.incompat(app);
         var installed = z.apps.indexOf(app.manifest_url) !== -1;
@@ -406,10 +416,12 @@ define('buttons',
             return app.installed ? gettext('Installed') : gettext('Install');
         }
 
+        if (app.isWebsite) {
+            return gettext('Open website');
+        }
+
         if (app.installed) {
-            return format.format(gettext('Open {appType}'), {
-                appType: gettext('app'),
-            });
+            return gettext('Open app');
         } else {
             return format.format(gettext('Install for {price}'), {
                 price: app.priceText

--- a/src/media/js/helpers_local.js
+++ b/src/media/js/helpers_local.js
@@ -126,6 +126,7 @@ define('helpers_local',
     }
 
     var helpers = {
+        apps: apps,
         app_notices: app_notices,
         cast_app: models('app').cast,
         format: format.format,

--- a/src/media/js/routes.js
+++ b/src/media/js/routes.js
@@ -1,6 +1,6 @@
 define('routes',
-    ['core/router'],
-    function(router) {
+    ['core/router', 'core/settings'],
+    function(router, settings) {
 
     router.addRoutes([
         {'pattern': '^/(app.html|index.html)?$', 'view_name': 'homepage'},
@@ -34,6 +34,11 @@ define('routes',
         {'pattern': '^/usage$', 'view_name': 'usage'},
     ]);
 
+    var search = '/api/v2/fireplace/search/?cache=1&vary=0';
+    if (settings.meowEnabled) {
+        search = '/api/v2/multi-search/?cache=1&vary=0';
+    }
+
     router.api.addRoutes({
         'account_info': '/api/v2/account/info/{0}',
         'app': '/api/v2/fireplace/app/{0}/?cache=1&vary=0',
@@ -64,7 +69,7 @@ define('routes',
         'regions': '/api/v2/services/region/',
         'review': '/api/v2/apps/rating/{0}/',
         'reviews': '/api/v2/apps/rating/',
-        'search': '/api/v2/fireplace/search/?cache=1&vary=0',
+        'search': search,
         'settings': '/api/v2/account/settings/mine/',
         'site-config': '/api/v2/services/config/site/?cache=1&serializer=commonplace&vary=0',
     });

--- a/src/templates/_macros/app_tile.html
+++ b/src/templates/_macros/app_tile.html
@@ -11,12 +11,15 @@
       tray -- whether or not to attach a preview/screenshot tray
       src -- if tile is a link, attach a src param for analytics purposes
   #}
+  {% set app = apps.transform(app) %}
+
   {% set tag = 'div' if is_detail else 'a' %}
-  <{{ tag }} class="product mkt-tile{{ ' feed-app c' if feed_app }}"
+  <{{ tag }} class="mkt-tile{{ ' feed-app c' if feed_app }}"
              data-slug="{{ app.slug }}" data-id="{{ app.id }}"
              {% if not is_detail %}
                href="{{ app.url or url('app', [app.slug])|urlparams(src=src) }}"
              {% endif %}
+             data-content-type="{{ app.contentType }}"
              {{ 'itemscope itemtype="http://schema.org/SoftwareApplication"' if not is_detail }}>
     <span class="mkt-app-heading">
       {{ deferred_icon(app.icons[is_detail and '128' or '64'] or app.icons['64']) }}
@@ -38,16 +41,15 @@
           </div>
         {% endif %}
 
-        {{ rating_link(is_detail=is_detail) }}
-
-        {% if app.slug %}
-          {{ market_button(app, data_attrs={
-                 'manifest_url': app.manifest_url,
-                 'source': src,
-                 'slug': app.slug
-             })
-          }}
+        {% if app.isApp %}
+          {{ rating_link(is_detail=is_detail) }}
         {% endif %}
+
+        {{ market_button(app, data_attrs={
+               'manifest_url': app.manifest_url,
+               'source': src,
+               'slug': app.slug
+           }) }}
       </span>
     </span>
 

--- a/src/templates/_macros/market_button.html
+++ b/src/templates/_macros/market_button.html
@@ -1,12 +1,15 @@
 {% macro market_button(app, data_attrs) %}
   {% set app = buttons.transformApp(app) %}
-  <button class="button mkt-app-button product install
-               {{ 'launch' if app.installed }}
-               {{ 'paid' if app.payment_required }}
-               {{ 'incompatible' if app.incompatible }}"
+
+  <button class="button mkt-app-button
+                 {{ 'mkt-app-button--install install' if not app.isWebsite }}
+                 {{ 'launch' if app.installed }}
+                 {{ 'paid' if app.payment_required }}
+                 {{ 'incompatible' if app.incompatible }}"
         {{ data_attrs|make_data_attrs }}
         {{ 'disabled' if app.disabled }}
-        data-product="{{ app|json }}">
+        data-product="{{ app|json }}"
+        {% if app.isWebsite %}href="{{ app.url }}"{% endif %}>
     <em>
       <span class="mkt-app-button-text">{{ buttons.getBtnText(app) }}</span>
       <span class="mkt-app-button-spinner spin"></span>

--- a/src/templates/app_list.html
+++ b/src/templates/app_list.html
@@ -19,7 +19,8 @@
     {% include "_includes/app_list_filters.html" %}
     <ul class="app-list {{ 'paginated' if response.meta.next }}">
       {% for app in this %}
-        <li class="app-list-app">
+        {% set app = apps.transform(app) %}
+        <li class="app-list-app {{ 'app-list-website' if app.isWebsite }}">
           {{ app_tile(app, tray=True, src=trackingEvents.SRCS[appListType]) }}
         </li>
       {% endfor %}


### PR DESCRIPTION
Hacking away at it.

- proper display of websites in listing pages (name, no previews, no ratings)
- button links to website
- ```settings.meowEnabled``` switch, switches between search and multi search endpoints

![screen shot 2015-05-13 at 4 42 43 pm](https://cloud.githubusercontent.com/assets/674727/7623432/281a2a24-f98f-11e4-93af-ad115e2bae05.png)
