### PR TITLE
do not rely on preview arrows for RTL mobile (bug 1161500)

### DIFF
--- a/src/media/js/previews.js
+++ b/src/media/js/previews.js
@@ -96,8 +96,9 @@ define('previews',
 
             if (document.documentElement.getAttribute('dir') === 'rtl') {
                 for (var i = 0; i < numBars - 1; i++) {
-                    // Start at the end for RTL.
-                    buttons.nextBtn.click();
+                    // Start at the end for RTL - simulate clicking "next" numBars times.
+                    slider.toNext();
+                    $tray.trigger('previews--button-update');
                 }
             }
         }


### PR DESCRIPTION
We could alternatively reverse the calculation for `numBars` to do something like `slider.moveToPoint(lastBar)`. The cause of the bug was relying on clicking the preview arrows which don't get attached on mobile devices. 

![](http://i.imgur.com/xtBvwbq.png)