### PR TITLE
Treat detail websites as website

### DIFF
--- a/src/media/js/apps.js
+++ b/src/media/js/apps.js
@@ -129,7 +129,7 @@ define('apps',
             });
         }
         // Normalize content types.
-        if (app.doc_type == 'website') {
+        if (app.url) {
             app.isWebsite = true;
             app.previews = [];
             app.contentType = 'website';


### PR DESCRIPTION
The website detail endpoint doesn't specify a `doc_type` so websites were being treated as apps. Let's call it a website if it has a `url` instead.