### PR TITLE
Open categories menu from hambacker on category page (bug 1166413)

### DIFF
--- a/src/media/js/elements/nav.js
+++ b/src/media/js/elements/nav.js
@@ -151,6 +151,13 @@ define('elements/nav',
                         if (this.isLeafPage) {
                             logger.log('hambacker button pressed (back)');
                             navigation.back();
+                        } else if (this.isCategoryPage) {
+                            logger.log('hambacker button pressed (cats)');
+                            var target = document.getElementById('categories');
+                            target.parentNode.toggle();
+                            if (!target.visible) {
+                                target.parentNode.toggleChildren(target.id);
+                            }
                         } else {
                             logger.log('hambacker button pressed (menu)');
                             document.querySelector('mkt-nav').toggle();
@@ -158,11 +165,21 @@ define('elements/nav',
                     });
                 }
             },
+            isCategoryPage: {
+                get: function() {
+                    return this.pageTypes.indexOf('category') !== -1;
+                }
+            },
             isLeafPage: {
                 get: function() {
-                    var pageTypes = z.body.attr('data-page-type') || '';
-                    return pageTypes.split(' ').indexOf('leaf') !== -1;
+                    return this.pageTypes.indexOf('leaf') !== -1;
                 },
+            },
+            pageTypes: {
+                get: function() {
+                    var pageTypes = z.body.attr('data-page-type') || '';
+                    return pageTypes.split(' ');
+                }
             },
         })
     });

--- a/tests/ui/category.js
+++ b/tests/ui/category.js
@@ -42,3 +42,37 @@ casper.test.begin('Category UA tracking tests', {
         helpers.done(test);
     }
 });
+
+
+casper.test.begin('Category mobile nav opens categories', {
+    test: function(test) {
+        helpers.startCasper('/category/games');
+
+        helpers.waitForPageLoaded();
+
+        casper.thenClick('mkt-nav-toggle', function() {
+            test.assert(casper.evaluate(function() {
+                return document.getElementById('categories').visible;
+            }));
+        });
+
+        helpers.done(test);
+    }
+});
+
+
+casper.test.begin('Category mobile does not nav open non-categories', {
+    test: function(test) {
+        helpers.startCasper();
+
+        helpers.waitForPageLoaded();
+
+        casper.thenClick('mkt-nav-toggle', function() {
+            test.assertNot(casper.evaluate(function() {
+                return document.getElementById('categories').visible;
+            }));
+        });
+
+        helpers.done(test);
+    }
+});


### PR DESCRIPTION
Should I just rename `<mkt-nav-toggle>` to `<mkt-hambacker>` now?