### PR TITLE
Don't use [title] to header title (bug 1169565)

### DIFF
--- a/src/media/js/elements/header.js
+++ b/src/media/js/elements/header.js
@@ -63,7 +63,7 @@ define('elements/header',
             },
             attributeChangedCallback: {
                 value: function(attr, oldVal, newVal, namespace) {
-                    if (attr === 'title') {
+                    if (attr === 'header-title') {
                         this.setTitle();
                     }
                 },
@@ -77,7 +77,7 @@ define('elements/header',
             setTitle: {
                 value: function() {
                     this.querySelector('.mkt-header--title')
-                        .textContent = this.getAttribute('title');
+                        .textContent = this.getAttribute('header-title');
                 },
             },
             statusElement: {

--- a/src/media/js/utils_local.js
+++ b/src/media/js/utils_local.js
@@ -132,7 +132,8 @@ define('utils_local',
     }
 
     function headerTitle(title) {
-        document.getElementById('site-header').setAttribute('title', title);
+        document.getElementById('site-header')
+                .setAttribute('header-title', title);
     }
 
     return {

--- a/tests/unit/elements__header.js
+++ b/tests/unit/elements__header.js
@@ -15,6 +15,7 @@ define('tests/unit/elements__header',
         var div = document.createElement('div');
         div.setAttribute('id', 'mkt-test-wrapper');
         div.innerHTML = '<mkt-header>' +
+          '<h1 class="mkt-header--title"></h1>' +
           '<mkt-header-child-toggle for="foo-child">' +
           '</mkt-header-child-toggle>' +
           '<mkt-header-child-toggle for="bar-child">' +
@@ -111,6 +112,21 @@ define('tests/unit/elements__header',
                 assert.notOk(header.parentNode.classList.contains(
                              Header.classes.SHOWING_CHILD));
                 done();
+            });
+        });
+
+        it('sets its title', function(done) {
+            createMktHeader(function(header) {
+                var title = header.querySelector('.mkt-header--title');
+
+                assert.ok(title);
+                assert.equal(title.textContent, '');
+
+                header.setAttribute('header-title', 'New title');
+                setTimeout(function() {
+                    assert.equal(title.textContent, 'New title');
+                    done();
+                }, 1);
             });
         });
     });


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1169565

Set the `header-title` attribute instead of the `title` attribute so that the text doesn't appear on hover.