### PR TITLE
Set Edit Review header and remove redundant header (bug 1170373)

### DIFF
--- a/src/media/js/views/app/ratings/edit.js
+++ b/src/media/js/views/app/ratings/edit.js
@@ -1,6 +1,8 @@
 define('views/app/ratings/edit',
-    ['core/l10n', 'core/urls', 'core/user', 'core/utils', 'core/z'],
-    function(l10n, urls, user, utils, z) {
+    ['core/l10n', 'core/urls', 'core/user', 'core/utils', 'core/z',
+     'utils_local'],
+    function(l10n, urls, user, utils, z,
+             utilsLocal) {
     var gettext = l10n.gettext;
 
     function normalize(inbound) {
@@ -10,8 +12,10 @@ define('views/app/ratings/edit',
 
     return function(builder, args) {
         var slug = args[0];
+        var title = gettext('Edit Review');
         builder.z('type', 'leaf');
-        builder.z('title', gettext('Edit Review'));
+        builder.z('title', title);
+        utilsLocal.headerTitle(title);
 
         if (!user.logged_in()) {
             // If user not logged in, divert to app detail page.

--- a/src/templates/ratings/add.html
+++ b/src/templates/ratings/add.html
@@ -7,7 +7,7 @@
           {% endif %}>
       {% if isModal %}
         <h3>{{ existingReview and _('Edit Review') or _('Leave a Review') }}</h3>
-	<p class="reviews--guideline">
+        <p class="reviews--guideline">
           {{ _('Please read the <a href="{url}" target="_blank">Review Guidelines</a> for more details about rating apps.
                 Reviews that do not meet these guidelines may be removed by our moderation team without notice.')
             |format(url='https://developer.mozilla.org/Marketplace/User_Review_Guidelines') }}
@@ -42,8 +42,10 @@
 {% endmacro %}
 
 <div class="main add-review">
-  <header class="secondary-header">
-    <h2>{{ _('Leave a Review') }}</h2>
-  </header>
+  {% if not settings.meowEnabled %}
+    <header class="secondary-header">
+      <h2>{{ _('Leave a Review') }}</h2>
+    </header>
+  {% endif %}
   {{ review_prompt(slug) }}
 </div>

--- a/src/templates/ratings/edit.html
+++ b/src/templates/ratings/edit.html
@@ -1,8 +1,10 @@
 {% from "ratings/add.html" import review_prompt %}
 
-<header class="secondary-header">
-  <h2>{{ _('Edit Review') }}</h2>
-</header>
+{% if not settings.meowEnabled %}
+  <header class="secondary-header">
+    <h2>{{ _('Edit Review') }}</h2>
+  </header>
+{% endif %}
 
 {% defer (url=endpoint, id='main') %}
   <div class="main add-review">

--- a/src/templates/ratings/main.html
+++ b/src/templates/ratings/main.html
@@ -13,7 +13,9 @@
               id='ratings', paginate='.reviews-wrapper') %}
       <div class="detail-flex-wrap">
         <div class="detail-left-side">
-          <h3>{{ _('Reviews') }}</h3>
+          {% if not settings.meowEnabled %}
+            <h3>{{ _('Reviews') }}</h3>
+          {% endif %}
           {% include "_includes/reviews_summary.html" %}
 
           <ul class="reviews-wrapper">


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1170379
https://bugzilla.mozilla.org/show_bug.cgi?id=1170373

<img alt="screenshot 2015-06-02 18 57 20" src="https://cloud.githubusercontent.com/assets/211578/7949964/bbd158ee-0959-11e5-9045-159d13584b64.png" width="32%"> <img alt="screenshot 2015-06-02 19 00 44" src="https://cloud.githubusercontent.com/assets/211578/7949965/bbf1b742-0959-11e5-986b-7ee8126cf64d.png" width="32%"> <img alt="screenshot 2015-06-02 18 55 46" src="https://cloud.githubusercontent.com/assets/211578/7949963/bbc37abc-0959-11e5-8694-448d7e6a7e34.png" width="32%"> 

This also removes the header from the read all reviews page on desktop, but it is clearly a page with reviews on it and the header was never very prominent.

<img alt="screenshot 2015-06-05 07 45 10" src="https://cloud.githubusercontent.com/assets/211578/8006178/f894f408-0b56-11e5-96d8-12e24f122beb.png" width="49%"> <img alt="screenshot 2015-06-05 07 42 50" src="https://cloud.githubusercontent.com/assets/211578/8006210/4c72726c-0b57-11e5-94af-ae8cbbf426bb.png" width="49%">
> Before&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;After
