### PR TITLE
Bug 1172457 - Settings page head title should be changed

### DIFF
--- a/src/media/js/views/settings.js
+++ b/src/media/js/views/settings.js
@@ -51,7 +51,7 @@ define('views/settings',
 
     return function(builder) {
         builder.z('type', 'root settings');
-        builder.z('title', gettext('Account Settings'));
+        builder.z('title', gettext('Settings'));
         builder.z('parent', urls.reverse('homepage'));
 
         builder.start('settings.html');


### PR DESCRIPTION
The head title of the settings page is now changed to Settings | Firefox Marketplace