### PR TITLE
Add Web QA UI tests to Travis-CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ npm-debug.log
 package/archives/*
 package/builds/*
 package/.tmp/*
+results
 settings_local.js
 settings_local.py
 src/index.html
@@ -57,4 +58,5 @@ src/tests/commonplace/
 src/tests/marketplace-core-modules/
 tags
 tests/captures/*
+webqa-tests
 yulelog_*

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ tags
 tests/captures/*
 webqa-tests
 yulelog_*
+virtualenv-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,12 @@ node_js:
 - '0.10'
 addons:
   sauce_connect: true
+  artifacts:
+    paths:
+    - results
+    permissions: public-read
+    bucket: fireplace-tests
+    debug: true
 env:
   matrix:
   - RUN_TEST=uitest-phantom START_SERVER=1 UPLOAD_CAPTURES=1 MAKE_LANGPACKS=1
@@ -30,6 +36,8 @@ env:
   global:
   - secure: ZiW8luJSf9AFCf+ZfMeSeD8Njv4rWjMNrPW31aaZ5axqpdHT1ml23Tsl2H3Lu6sFQ1kYqb/QtXW9PLMkfwsddI7uR52eKDzd1rbrNcyNnt9L2kcrPdK1sJdUEDDlQ3MkdcCQxod3I4hFNYRyD7HbJxOBbgshCYj2T7fv0GVOT2k=
   - secure: dv/0SujZlQ5d/YS0I3bZm51NHq6Fc1BbVxRMbWF1x77LqjGG938uQu5WTgoGVWNc53cW2PIJWygZM/kCxn48l8zUUhwX81ngpQFUOVTMgirI0fvb8xnzG+i27FmVnGz4CI/4Ll0GWlgPfRPYSm6ZtyzDLQFzwGEEsAQTSgaYrRc=
+  - secure: jb0xlSQ+sn8IG0zwJQOhwAPZLASm1qB/B+SartDMD47gV18uPnMPvAT8tlSIR7ZphEEWZfS3z/0Msfe4Akg/LrjaIOheWuwbmKTA4lAoJgbHpElZqsxZ2t4WE7pStYeCHb2bn+XFARagIksSahXHuQcpY5PwvdFoOibj0MMUsj0XWTxlU+YWjdt49lbV3avPeP+SwNi2JCIdlWiwS+ATbQefW+8edbNjcHb7PW0aCpFmYNFqKJK6arQq0wPXMmMFvsfOn08BrhAZUbE+eONIVmEs7bmC/JD0FbTUAY+E545fhaW7ZFyt47faD46dnFePJXlhVnL4b3QrVLJer/T/+lPkrMrWCYsHawo9v5uQ/kEYkwQmEGbjhFQG9Ulgxxsh529SgIDVr8ZP+cTAkac6htkPAcGaSSmfG+oNeyB/QZsigGJuKQczNWjm6uYTQB/UD4epfCcPIT09ggxqNnD+wMoAJgccnMhOqhh7kPOt8PF1I4k3QA9cSvK4BzrJ4qvxcDyQqEdaoTN8/G152s+32Akf/2XKHis7rlPQp2eHcx/nWa81aZPotXnG+FnMnG3zDlVV1kZ0gZ57CJtWZBOXDY2rtO3gQ9fUTPAkXyQAQD/LNRX0BDPAdVhTwJtGxKq9x+ZOdUYUPrYwRas1LLf9zwQ/XXglHoV5FmOXhkO5X9c=
+  - secure: pLoqHoDqhuMXIazK6uYxFq/MUFutiL+Bav1q725ZWkuIr7H2mH+XDE/9h4hTLpLc4SPCAPD+oPJhSSvDtT7b9xqMBxyoYC8GzsXhjgcGmGApjvI+T1DWXRm8JLTK+ba1kIxdfO4C8uYO/qCL/WylJk29LmiGbB6cJJtrwBdQ3rKDchSn1huPxE0VjV9BoIvjipMHBW/dwLASr2NaSG8aZ4OTetkjMYhOW+2Z0zJE7CvEE/Pl+HtMO0fb7ML7r6xh4F/A0+47KY6Avd8MT/AvlNNBy+GJln3dWWcUSQQtyPoKrT9j7f6fdCUY+nDFzlPkNVMCTgTWJRnJUz4qdy/OpwTL6WM1kuHn/jhrF4sM6ozX7PLEMr8fhT4Kb9oGyGftMaEybUAq3E41cZt8zsez9+wy6ak98S9ppPXcEcj5y4GuKJegsPiQMmL9hXbB8iiAUPcZCY4EtY/gS+gQmmbaovBWx//M1/DysfEzeTXy9cEX6LS8lWFhejQk6MDr0V4UIdcWrqmmeZazeVyTQxnRyWwKVRTfnNzzL7TEClu95RwtDfPTKPVd1NUAfyWbmxwlGONjbGYElSxRQ+VOFIH1ftc7jayunx5FNbZHvsmZSzR+xS1sksLgJqH+/wPDPoAaSzSG3R5BBR8C6A8uD7HrpJbrFYzWQQUHzxUQcokCRPg=
 matrix:
   allow_failures:
   - env: RUN_TEST=uitest-phantom START_SERVER=1 UPLOAD_CAPTURES=1 MAKE_LANGPACKS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
   matrix:
   - RUN_TEST=uitest-phantom START_SERVER=1 UPLOAD_CAPTURES=1 MAKE_LANGPACKS=1
   - RUN_TEST=uitest-slimer START_SERVER=1 UPLOAD_CAPTURES=1 MAKE_LANGPACKS=1
+  - RUN_TEST=uitest-webqa START_SERVER=1
   - RUN_TEST=sherlocked API=mock START_SERVER=1 MAKE_LANGPACKS=1
   - RUN_TEST=lint
   - RUN_TEST=unittest
@@ -33,6 +34,7 @@ matrix:
   allow_failures:
   - env: RUN_TEST=uitest-phantom START_SERVER=1 UPLOAD_CAPTURES=1 MAKE_LANGPACKS=1
   - env: RUN_TEST=sherlocked API=mock START_SERVER=1 MAKE_LANGPACKS=1
+  - env: RUN_TEST=uitest-webqa START_SERVER=1
 before_script:
 - export PHANTOMJS_EXECUTABLE='phantomjs --local-to-remote-url-access=yes --ignore-ssl-errors=yes'
 - export SLIMERJSLAUNCHER=$(which firefox)
@@ -42,6 +44,7 @@ before_script:
 - if [ $START_SERVER ]; then bash tests/serve.sh; fi
 - if [ $MAKE_LANGPACKS ]; then commonplace langpacks; fi
 - if [ $RUN_TEST = 'uitest-slimer' ]; then make install-slimer; fi
+- if [ $RUN_TEST = 'uitest-webqa' ]; then make install-webqa; fi
 script:
 - make $RUN_TEST
 - if [ $UPLOAD_CAPTURES ]; then make upload-captures; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
   matrix:
   - RUN_TEST=uitest-phantom START_SERVER=1 UPLOAD_CAPTURES=1 MAKE_LANGPACKS=1
   - RUN_TEST=uitest-slimer START_SERVER=1 UPLOAD_CAPTURES=1 MAKE_LANGPACKS=1
-  - RUN_TEST=uitest-webqa API=dev START_SERVER=1
+  - RUN_TEST=uitest-webqa START_SERVER=1 FIREPLACE_SETTINGS=src/media/js/settings_local_webqa.js
   - RUN_TEST=sherlocked API=mock START_SERVER=1 MAKE_LANGPACKS=1
   - RUN_TEST=lint
   - RUN_TEST=unittest
@@ -42,7 +42,7 @@ matrix:
   allow_failures:
   - env: RUN_TEST=uitest-phantom START_SERVER=1 UPLOAD_CAPTURES=1 MAKE_LANGPACKS=1
   - env: RUN_TEST=sherlocked API=mock START_SERVER=1 MAKE_LANGPACKS=1
-  - env: RUN_TEST=uitest-webqa API=dev START_SERVER=1
+  - env: RUN_TEST=uitest-webqa START_SERVER=1 FIREPLACE_SETTINGS=src/media/js/settings_local_webqa.js
 before_script:
 - export PHANTOMJS_EXECUTABLE='phantomjs --local-to-remote-url-access=yes --ignore-ssl-errors=yes'
 - export SLIMERJSLAUNCHER=$(which firefox)

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ addons:
     - results
     permissions: public-read
     bucket: fireplace-tests
-    debug: true
 env:
   matrix:
   - RUN_TEST=uitest-phantom START_SERVER=1 UPLOAD_CAPTURES=1 MAKE_LANGPACKS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
   matrix:
   - RUN_TEST=uitest-phantom START_SERVER=1 UPLOAD_CAPTURES=1 MAKE_LANGPACKS=1
   - RUN_TEST=uitest-slimer START_SERVER=1 UPLOAD_CAPTURES=1 MAKE_LANGPACKS=1
-  - RUN_TEST=uitest-webqa START_SERVER=1
+  - RUN_TEST=uitest-webqa API=dev START_SERVER=1
   - RUN_TEST=sherlocked API=mock START_SERVER=1 MAKE_LANGPACKS=1
   - RUN_TEST=lint
   - RUN_TEST=unittest
@@ -34,7 +34,7 @@ matrix:
   allow_failures:
   - env: RUN_TEST=uitest-phantom START_SERVER=1 UPLOAD_CAPTURES=1 MAKE_LANGPACKS=1
   - env: RUN_TEST=sherlocked API=mock START_SERVER=1 MAKE_LANGPACKS=1
-  - env: RUN_TEST=uitest-webqa START_SERVER=1
+  - env: RUN_TEST=uitest-webqa API=dev START_SERVER=1
 before_script:
 - export PHANTOMJS_EXECUTABLE='phantomjs --local-to-remote-url-access=yes --ignore-ssl-errors=yes'
 - export SLIMERJSLAUNCHER=$(which firefox)

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,6 @@ install-webqa:
 	tar xvfz virtualenv-${VIRTUALENV_VERSION}.tar.gz
 	test -d ${WEBQA_VENV} || virtualenv-${VIRTUALENV_VERSION}/virtualenv.py ${WEBQA_VENV}
 	${WEBQA_VENV}/bin/pip install -U pytest-timeout pytest-xdist
-	test -d ${WEBQA_TESTS} || git clone --depth 1 https://github.com/mozilla/marketplace-tests/ ${WEBQA_TESTS}
+	test -d ${WEBQA_TESTS} || git clone -b more_search --depth 1 https://github.com/bobsilverberg/marketplace-tests/ ${WEBQA_TESTS}
 	git -C ${WEBQA_TESTS} pull
 	${WEBQA_VENV}/bin/pip install -Ur ${WEBQA_TESTS}/requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -79,3 +79,16 @@ test-package:
 
 sherlocked:
 	sleep 10 && node sherlocked.js
+
+WEBQA_VENV ?= '.virtualenvs/webqa'
+WEBQA_TESTS ?= 'webqa-tests'
+
+uitest-webqa:
+	${WEBQA_VENV}/bin/py.test -r=fsxXR --verbose -n=5 --baseurl=${TEST_URL} --driver=firefox --destructive ${WEBQA_TESTS}/tests/desktop/consumer_pages
+
+install-webqa:
+	test -d ${WEBQA_VENV} || virtualenv ${WEBQA_VENV}
+	${WEBQA_VENV}/bin/pip install -U pytest-timeout pytest-xdist
+	test -d ${WEBQA_TESTS} || git clone --depth 1 https://github.com/mozilla/marketplace-tests/ ${WEBQA_TESTS}
+	git -C ${WEBQA_TESTS} pull
+	${WEBQA_VENV}/bin/pip install -Ur ${WEBQA_TESTS}/requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ test-package:
 sherlocked:
 	sleep 10 && node sherlocked.js
 
+VIRTUALENV_VERSION ?= '13.0.3'
 WEBQA_VENV ?= '.virtualenvs/webqa'
 WEBQA_TESTS ?= 'webqa-tests'
 
@@ -87,7 +88,9 @@ uitest-webqa:
 	${WEBQA_VENV}/bin/py.test -r=fsxXR --verbose -n=5 --baseurl=${TEST_URL} --driver=firefox --destructive ${WEBQA_TESTS}/tests/desktop/consumer_pages
 
 install-webqa:
-	test -d ${WEBQA_VENV} || virtualenv ${WEBQA_VENV}
+	curl -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-${VIRTUALENV_VERSION}.tar.gz
+	tar xvfz virtualenv-${VIRTUALENV_VERSION}.tar.gz
+	test -d ${WEBQA_VENV} || virtualenv-${VIRTUALENV_VERSION}/virtualenv.py ${WEBQA_VENV}
 	${WEBQA_VENV}/bin/pip install -U pytest-timeout pytest-xdist
 	test -d ${WEBQA_TESTS} || git clone --depth 1 https://github.com/mozilla/marketplace-tests/ ${WEBQA_TESTS}
 	git -C ${WEBQA_TESTS} pull

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ WEBQA_VENV ?= '.virtualenvs/webqa'
 WEBQA_TESTS ?= 'webqa-tests'
 
 uitest-webqa:
-	${WEBQA_VENV}/bin/py.test -r=fsxXR --verbose -n=5 --baseurl=${TEST_URL} --driver=firefox --destructive ${WEBQA_TESTS}/tests/desktop/consumer_pages
+	${WEBQA_VENV}/bin/py.test -r=fsxXR --verbose -n=5 --baseurl=${TEST_URL} --driver=firefox --destructive -m "not credentials and not action_chains" ${WEBQA_TESTS}/tests/desktop/consumer_pages
 
 install-webqa:
 	curl -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-${VIRTUALENV_VERSION}.tar.gz

--- a/src/media/js/settings_local_webqa.js
+++ b/src/media/js/settings_local_webqa.js
@@ -1,0 +1,11 @@
+define('settings_local',
+    [],
+    function() {
+
+    return {
+        api_url: 'https://marketplace-dev.allizom.org',
+        manifest_url: 'https://marketplace-dev.allizom.org/packaged.webapp',
+        media_url: 'https://marketplace-dev.allizom.org/media',
+        meowEnabled: true
+    };
+});

--- a/tests/serve.sh
+++ b/tests/serve.sh
@@ -4,7 +4,11 @@ pushd /tmp/marketplace-api-mock
 pip install --user --exists-action=w --download-cache=/tmp/pip-cache -r requirements.txt
 python main.py &
 popd
-mv src/media/js/settings_local_test.js src/media/js/settings_local.js
+if [ $FIREPLACE_SETTINGS ]; then
+    mv $FIREPLACE_SETTINGS src/media/js/settings_local.js
+else
+    mv src/media/js/settings_local_test.js src/media/js/settings_local.js
+fi
 make build
 MKT_COMPILED=1 make serve &
 sleep 10

--- a/tests/serve.sh
+++ b/tests/serve.sh
@@ -6,7 +6,7 @@ python main.py &
 popd
 mv src/media/js/settings_local_test.js src/media/js/settings_local.js
 make build
-MKT_COMPILED=1 API=$API make serve &
+MKT_COMPILED=1 make serve &
 sleep 10
 
 # Make sure flue is ready.

--- a/tests/serve.sh
+++ b/tests/serve.sh
@@ -6,7 +6,7 @@ python main.py &
 popd
 mv src/media/js/settings_local_test.js src/media/js/settings_local.js
 make build
-MKT_COMPILED=1 make serve &
+MKT_COMPILED=1 API=$API make serve &
 sleep 10
 
 # Make sure flue is ready.


### PR DESCRIPTION
This supersedes @davehunt's PR #1300 as I have taken over trying to get this working and passing. The changes I have added are:

- Use the dev api as opposed to the mock api
- Exclude tests that require credentials

I still don't expect this to pass as some changes need to be made to the marketplace tests which include switching them to a newer version of fxapom, but let's see if the change to the API env variable works.
  