### PR TITLE
Fixed horizontal scroll issue

### DIFF
--- a/src/media/css/detail/reviews.styl
+++ b/src/media/css/detail/reviews.styl
@@ -25,6 +25,7 @@
 
     .stars-wrapper {
         transform: scale(2.5);
+        display: inline-block;
 
         +rtl() {
             transform: scale(-2.5, 2.5);


### PR DESCRIPTION
**What's the issue?**
Devices with screen width less than 700px there's horizontal scroll issue.
This issue is due to transform scale property on ```.stars-wrapper```

**What I did?**
Just added ```display: inline-block;``` property.
This is the easiest fix I found which don't affect any other element or any previous style.

**Screenshot**
Before:
![screen-before](http://i.imgur.com/L16F8qF.png)
After:
![screen-after](http://i.imgur.com/mF84kWC.png)