### PR TITLE
Fixed translation errors (credit: pollti)

### DIFF
--- a/locale/de/LC_MESSAGES/messages.po
+++ b/locale/de/LC_MESSAGES/messages.po
@@ -817,11 +817,11 @@ msgstr "Nicht verfügbar"
 
 #: /media/js/buttons.js:422
 msgid "Open website"
-msgstr "Offene Website"
+msgstr "Website öffnen"
 
 #: /media/js/buttons.js:426
 msgid "Open app"
-msgstr "Offene App"
+msgstr "App öffnen"
 
 #: /media/js/buttons.js:428
 msgid "Install for {price}"


### PR DESCRIPTION
Verbatim complains because

> Failed to update from version control: [GIT] pull failed (['git', '--git-dir', u'/data
> /www/localize.mozilla.org/verbatim/pootle_env/Pootle-git/l10n_github_repos/fireplace/.git', 'pull']):
> Pull is not possible because you have unmerged files. Please, fix them up in the work tree, and then
> use 'git add/rm ' as appropriate to mark resolution, or use 'git commit -a'. 

so it’ll have to be done this way.