### PR TITLE
Make ACL app install button spin when installing through activity (bug 1194464)

### DIFF
--- a/src/media/js/buttons.js
+++ b/src/media/js/buttons.js
@@ -23,19 +23,24 @@ define('buttons',
         markBtnsAsUninstalled();
     });
 
-    function setInstallBtnState($button, text, cls) {
+    function setInstallBtnState($button, css_class) {
         // Sets install button state (its text and its classes, which
         // currently determines its click handler).
-        revertButton($button, text);
-        $button.addClass(cls);
+        revertButton($button);
+        $button.addClass(css_class);
     }
 
-    function revertButton($button, text) {
+    function revertButton($button) {
         // Revert button from a state of installing or a state of being
         // installed.
         $button.removeClass('purchasing installing error spinning');
         $button.find('em').text(getBtnText(getAppFromBtn($button),
                                            $button.data('isGame')));
+    }
+
+    function spinButton($button) {
+        $button.data('old-text', $button.find('em').text())
+               .addClass('spinning');
     }
 
     function getAppFromBtn($btn) {
@@ -114,7 +119,7 @@ define('buttons',
 
             // Save the old text of the button.
             $button.data('old-text', $button.find('em').text());
-            setInstallBtnState($button, gettext('Purchasing'), 'purchasing');
+            setInstallBtnState($button, 'purchasing');
 
             var purchaseOpts = {
                 // This will be undefined unless a window was created
@@ -128,7 +133,7 @@ define('buttons',
                 user.update_purchased(product.id);
 
                 // Update the button to say Install.
-                setInstallBtnState($button, gettext('Install'), 'purchased');
+                setInstallBtnState($button, 'purchased');
                 // Save the old text of the button.
                 $button.data('old-text', $button.find('em').text());
 
@@ -178,8 +183,7 @@ define('buttons',
             trackingEvents.trackAppInstallBegin($button);
 
             // Make the button a spinner.
-            $button.data('old-text', $button.find('em').text())
-                 .addClass('spinning');
+            spinButton($button);
 
             // Temporary timeout for hosted apps until we catch the appropriate
             // download error event for hosted apps (in iframe).
@@ -320,7 +324,7 @@ define('buttons',
         if (app.role == 'langpack') {
             $btn.attr('disabled', true).find('em').text(gettext('Installed'));
         } else {
-            setInstallBtnState($btn, app, 'launch install');
+            setInstallBtnState($btn, 'launch install');
         }
     }
 
@@ -367,7 +371,7 @@ define('buttons',
                 if (z.apps.indexOf($button.data('manifest_url')) === -1) {
                     // If it is no longer installed, revert button.
                     if ($button.hasClass('launch')) {
-                        revertButton($button, gettext('Install'));
+                        revertButton($button);
                     }
                     $button.removeClass('launch');
                 }
@@ -466,6 +470,8 @@ define('buttons',
         install: install,
         markBtnsAsInstalled: markBtnsAsInstalled,
         markBtnsAsUninstalled: markBtnsAsUninstalled,
+        revertButton: revertButton,
+        spinButton: spinButton,
         transformApp: transformApp
     };
 });

--- a/src/media/js/webactivities.js
+++ b/src/media/js/webactivities.js
@@ -16,9 +16,9 @@
     });
 */
 define('webactivities',
-    ['apps', 'core/capabilities', 'core/defer', 'core/log', 'core/login',
+    ['apps', 'buttons', 'core/capabilities', 'core/defer', 'core/log', 'core/login',
      'core/requests', 'core/urls', 'core/utils', 'core/z'],
-    function(apps, capabilities, defer, log, login,
+    function(apps, buttons, capabilities, defer, log, login,
              req, urls, utils, z) {
     var logger = log('webactivities');
 
@@ -100,6 +100,12 @@ define('webactivities',
                 if (slug) {
                     // Navigate to the ACL app detail page, it will be shown
                     // during the install.
+                    var buttonSelector = '.install[data-slug=' + slug + ']';
+                    z.page.one('loaded', function(e) {
+                        // When we load the detail page we are going to, set
+                        // the install button as already spinning.
+                        buttons.spinButton($(buttonSelector));
+                    });
                     url = urls.reverse('app', [slug]);
                     z.page.trigger('navigate',
                                    [utils.urlparams(url, {src: src})]);
@@ -109,8 +115,10 @@ define('webactivities',
                       .done(function(app) {
                           apps.install(app, {}).then(function() {
                             apps.launch(app.manifest_url);
+                            buttons.markBtnsAsInstalled();
                             def.resolve('SUCCESS');
                           }).fail(function() {
+                            buttons.revertButton($(buttonSelector));
                             def.reject('COULD_NOT_INSTALL_APP');
                           });
                       });


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1194464

Since we don't have tests for webactivities (working on that) here is how to test manually:

1. Load fireplace locally, paste in your console:
`window.postMessage({'name': 'marketplace-openmobile-acl', data: {acl_version: 'P172R12;P172R12;'}}, 'http://localhost:8675')`
2. Notice you are taken to the acl app detail page and the install button is spinning.
3. Accept the install
4. Notice that the app is installed then launched, and the button reverted back to an "installed, open app" state.