### PR TITLE
MCM v2.13.1 - trailing period in login toasts (bug 1179362)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "marketplace-constants": "0.12.0",
-    "marketplace-core-modules": "2.13.0",
+    "marketplace-core-modules": "2.13.1",
     "marketplace-elements": "0.7.1",
     "marketplace-jquery": "2.0.2",
 


### PR DESCRIPTION
Going to leave this open until the tag for more translation time.