### PR TITLE
bug No. 1170667 Bug title :red warning "not for your platform" flashes

### DIFF
--- a/src/media/js/views/app.js
+++ b/src/media/js/views/app.js
@@ -20,6 +20,7 @@ define('views/app',
         builder.start('app/index.html', {
             iarc: iarc,
             placeholder_app: {
+		loading: true,
                 author: gettext('Loading...'),
                 name: gettext('Loading...'),
                 previews: [{

--- a/src/templates/_macros/app_tile.html
+++ b/src/templates/_macros/app_tile.html
@@ -68,7 +68,7 @@
         'slug': app.slug
       }) }}
     {% endif %}
-    {% set notices = app_notices(app) %}
+    {% set notices = [] if app.loading == true else app_notices(app) %}
     {% if notices.length %}
       <div class="app-notices full">
         {% for notice in notices %}

--- a/src/templates/_macros/app_tile.html
+++ b/src/templates/_macros/app_tile.html
@@ -68,7 +68,7 @@
         'slug': app.slug
       }) }}
     {% endif %}
-    {% set notices = app_notices(app) %}
+    {% set notices =  [] if app.loading == 'loading' else app_notices(app) %}
     {% if notices.length %}
       <div class="app-notices full">
         {% for notice in notices %}

--- a/src/templates/_macros/app_tile.html
+++ b/src/templates/_macros/app_tile.html
@@ -68,7 +68,7 @@
         'slug': app.slug
       }) }}
     {% endif %}
-    {% set notices =  [] if app.loading == true else app_notices(app) %}
+    {% set notices =  [] if app.loading else app_notices(app) %}
     {% if notices.length %}
       <div class="app-notices full">
         {% for notice in notices %}

--- a/src/templates/_macros/app_tile.html
+++ b/src/templates/_macros/app_tile.html
@@ -68,11 +68,7 @@
         'slug': app.slug
       }) }}
     {% endif %}
-<<<<<<< HEAD
-    {% set notices = [] if app.loading == true else app_notices(app) %}
-=======
-    {% set notices = [] if app.slug == 'loading' else app_notices(app) %}
->>>>>>> 72d2f5407ffdaa96b09039d7173109194e18028c
+    {% set notices = app_notices(app) %}
     {% if notices.length %}
       <div class="app-notices full">
         {% for notice in notices %}

--- a/src/templates/_macros/app_tile.html
+++ b/src/templates/_macros/app_tile.html
@@ -68,7 +68,7 @@
         'slug': app.slug
       }) }}
     {% endif %}
-    {% set notices =  [] if app.loading == 'loading' else app_notices(app) %}
+    {% set notices =  [] if app.loading == true else app_notices(app) %}
     {% if notices.length %}
       <div class="app-notices full">
         {% for notice in notices %}


### PR DESCRIPTION
fixed on basis of changes recommended by mstriemer on bugzilla.
"You should be able to set `notices = []` in [1] if the app's slug in `loading` (which comes from [2]).

> {% set notices = [] if app.slug == 'loading' else app_notices(app) %}

[1] https://github.com/mozilla/fireplace/blob/65a024b449d981e9019f1eabbf2ed4f70491a45a/src/templates/_macros/app_tile.html#L71
[2] https://github.com/mozilla/fireplace/blob/65a024b449d981e9019f1eabbf2ed4f70491a45a/src/media/js/views/app.js#L35"