### PR TITLE
Add Web QA UI tests to Travis-CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ npm-debug.log
 package/archives/*
 package/builds/*
 package/.tmp/*
+results
 settings_local.js
 settings_local.py
 src/index.html
@@ -57,5 +58,7 @@ src/tests/commonplace/
 src/tests/marketplace-core-modules/
 tags
 tests/captures/*
+webqa-tests
 yulelog_*
 package/iframe/bundle.js
+virtualenv-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,17 @@ python:
 node_js:
 - '0.10'
 addons:
+  artifacts:
+    paths:
+    - results
+  firefox: "latest-esr"
   sauce_connect: true
   firefox: "latest-esr"
 env:
   matrix:
   - RUN_TEST=uitest-phantom START_SERVER=1 UPLOAD_CAPTURES=1 MAKE_LANGPACKS=1
   - RUN_TEST=uitest-slimer START_SERVER=1 UPLOAD_CAPTURES=1 MAKE_LANGPACKS=1
+  - RUN_TEST=uitest-webqa START_SERVER=1 FIREPLACE_SETTINGS=src/media/js/settings_local_webqa.js
   - RUN_TEST=sherlocked API=mock START_SERVER=1 MAKE_LANGPACKS=1
   - RUN_TEST=lint
   - RUN_TEST=unittest
@@ -34,6 +39,7 @@ matrix:
   allow_failures:
   - env: RUN_TEST=uitest-phantom START_SERVER=1 UPLOAD_CAPTURES=1 MAKE_LANGPACKS=1
   - env: RUN_TEST=sherlocked API=mock START_SERVER=1 MAKE_LANGPACKS=1
+  - env: RUN_TEST=uitest-webqa START_SERVER=1 FIREPLACE_SETTINGS=src/media/js/settings_local_webqa.js
 before_script:
 - export PHANTOMJS_EXECUTABLE='phantomjs --local-to-remote-url-access=yes --ignore-ssl-errors=yes'
 - export SLIMERJSLAUNCHER=firefox/firefox
@@ -45,6 +51,7 @@ before_script:
 - if [ $RUN_TEST = 'uitest-slimer' ]; then make install-slimer; fi
 # Install the Firefox needed for slimer if we don't have it.
 - test "$RUN_TEST" = 'uitest-slimer' && test ! -e 'firefox/firefox' && make install-firefox; return 0
+- if [ $RUN_TEST = 'uitest-webqa' ]; then make install-webqa; fi
 script:
 - make $RUN_TEST
 - if [ $UPLOAD_CAPTURES ]; then make upload-captures; fi
@@ -55,3 +62,6 @@ cache:
   - node_modules
   - bower_components
   - firefox
+  - $HOME/.cache/pip
+  - .virtualenvs
+  - "webqa-tests"

--- a/Makefile
+++ b/Makefile
@@ -86,3 +86,19 @@ sherlocked:
 install-firefox:
 	curl -O http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/latest-31.0esr/linux-x86_64/en-US/firefox-31.8.0esr.tar.bz2
 	tar jxf firefox-31.8.0esr.tar.bz2
+
+VIRTUALENV_VERSION ?= '13.0.3'
+WEBQA_VENV ?= '.virtualenvs/webqa'
+WEBQA_TESTS ?= 'webqa-tests'
+
+uitest-webqa:
+	${WEBQA_VENV}/bin/py.test -r=fsxXR --verbose -n=5 --baseurl=${TEST_URL} --driver=firefox --destructive -m "not credentials and not action_chains" ${WEBQA_TESTS}/tests/desktop/consumer_pages
+
+install-webqa:
+	curl -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-${VIRTUALENV_VERSION}.tar.gz
+	tar xvfz virtualenv-${VIRTUALENV_VERSION}.tar.gz
+	test -d ${WEBQA_VENV} || virtualenv-${VIRTUALENV_VERSION}/virtualenv.py ${WEBQA_VENV}
+	${WEBQA_VENV}/bin/pip install -U pytest-timeout pytest-xdist
+	test -d ${WEBQA_TESTS}/.git || git clone --depth 1 https://github.com/mozilla/marketplace-tests/ ${WEBQA_TESTS}
+	git -C ${WEBQA_TESTS} pull
+	${WEBQA_VENV}/bin/pip install -Ur ${WEBQA_TESTS}/requirements.txt

--- a/src/media/js/settings_local_webqa.js
+++ b/src/media/js/settings_local_webqa.js
@@ -1,0 +1,11 @@
+define('settings_local',
+    [],
+    function() {
+
+    return {
+        api_url: 'https://marketplace-dev.allizom.org',
+        manifest_url: 'https://marketplace-dev.allizom.org/packaged.webapp',
+        media_url: 'https://marketplace-dev.allizom.org/media',
+        meowEnabled: true
+    };
+});

--- a/tests/serve.sh
+++ b/tests/serve.sh
@@ -4,7 +4,11 @@ pushd /tmp/marketplace-api-mock
 pip install --user --exists-action=w --download-cache=/tmp/pip-cache -r requirements.txt
 python main.py &
 popd
-mv src/media/js/settings_local_test.js src/media/js/settings_local.js
+if [ $FIREPLACE_SETTINGS ]; then
+    mv $FIREPLACE_SETTINGS src/media/js/settings_local.js
+else
+    mv src/media/js/settings_local_test.js src/media/js/settings_local.js
+fi
 make build
 MKT_COMPILED=1 make serve &
 sleep 10


### PR DESCRIPTION
This supercedes pull #1323. I think we can go ahead and review this for landing. Any failures will not currently cause the build to fail. We should finish the test audit, set up S3 for storing the HTML reports, and update the documentation for running the tests locally, but these can be taken care of independently.