### PR TITLE
Remove outdated CSS file links from dev.html.

### DIFF
--- a/src/dev.html
+++ b/src/dev.html
@@ -27,7 +27,6 @@
       <link rel="stylesheet" href="/media/css/header.styl.css">
       <link rel="stylesheet" href="/media/css/header--search.styl.css">
       <link rel="stylesheet" href="/media/css/header--settings.styl.css">
-      <link rel="stylesheet" href="/media/css/navbar.styl.css">
       <link rel="stylesheet" href="/media/css/tiles.styl.css">
       <link rel="stylesheet" href="/media/css/infobox.styl.css">
       <!-- These styles don't need to be in an order. -->
@@ -37,7 +36,6 @@
       <link rel="stylesheet" href="/media/css/buttons.styl.css">
       <link rel="stylesheet" href="/media/css/buttons-loadmore.styl.css">
       <link rel="stylesheet" href="/media/css/categories.styl.css">
-      <link rel="stylesheet" href="/media/css/category-dropdown-desktop.styl.css">
       <link rel="stylesheet" href="/media/css/compat-filter.styl.css">
       <link rel="stylesheet" href="/media/css/content-filter.styl.css">
       <link rel="stylesheet" href="/media/css/debug.styl.css">
@@ -81,7 +79,6 @@
       <link rel="stylesheet" href="/media/css/previews.styl.css">
       <link rel="stylesheet" href="/media/css/reviews.styl.css">
       <link rel="stylesheet" href="/media/css/search.styl.css">
-      <link rel="stylesheet" href="/media/css/settings-hover-desktop.styl.css">
       <link rel="stylesheet" href="/media/css/standalone.styl.css">
       <link rel="stylesheet" href="/media/css/view-all-tab.styl.css">
 


### PR DESCRIPTION
In e056d1f9cafb56c0a569375bc697df25be26886a @ngokevin removed some old CSS files, but forgot to remove the associated `<link/>` tags in dev.html.

r? @ngokevin 