### PR TITLE
long app author name should leave some space for icon (bug 1215662)

### DIFF
--- a/src/media/css/tiles.styl
+++ b/src/media/css/tiles.styl
@@ -97,7 +97,7 @@ $greater-than-mobile = unquote('(min-width: 330px)');
     flex-direction: column;
     flex-grow: 1;
     flex-wrap: wrap;
-    max-width: unquote('calc(100% - 60px)');
+    max-width: unquote('calc(100% - 65px)');
     padding-right: 10px;
 
     +rtl() {


### PR DESCRIPTION
As the `$detail-icon-size` is 64 px `.mkt-tile-info` should leave atleast 64px for the icon in app details page.