### PR TITLE
Add button for content tools to settings

### DIFF
--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -75,6 +75,9 @@
         <a href="/reviewers/apps/queue/" class="button action reviewer-tools hide-logged-out"
            rel="external">{{ _('Reviewer Tools') }}</a>
       {% endif %}
+      {% if user.get_permission('content_tools_login') %}
+        <a href="/content/" class="button" rel="external">{{ _('Develop Firefox OS Add-ons') }}</a>
+      {% endif %}
     </div>
   </section>
 </form>


### PR DESCRIPTION
For mobile sized screens as generic footer is hidden.