### PR TITLE
Always set is_packaged to true for FxOS Add-ons (bug 1218105)

### DIFF
--- a/src/media/js/apps.js
+++ b/src/media/js/apps.js
@@ -151,6 +151,7 @@ define('apps',
               !!product.mini_manifest_url &&
               product.mini_manifest_url.indexOf('/extension/') !== -1);
             if (product.isAddon) {
+              product.is_packaged = true;
               product.manifest_url = product.mini_manifest_url;
             }
             product.contentType = 'app';


### PR DESCRIPTION
They need to be installed through `navigator.mozApps.installPackage()`
to work correctly. Without `is_packaged` set to `true`, our install code uses `navigator.mozApps.install()`, which is incorrect.

r? @chuckharmston - I think this broke in #1519