### PR TITLE
fix search icon cutoff (bug 1220797)(1515)

### DIFF
--- a/src/media/css/header--global.styl
+++ b/src/media/css/header--global.styl
@@ -17,7 +17,7 @@ $symbol-height = 32px;
     }
     &.searching {
         .header--search-content {
-            transform: translate(0, 0);
+            transform: translate(8px, 0);
         }
         > *:not(.header--search-form) {
             opacity: 0;
@@ -63,7 +63,7 @@ $symbol-height = 32px;
     display: flex;
     justify-content: space-between;
     min-width: 300px;
-    margin-left: - $symbol-height;
+    margin-left: - $symbol-height - 10;
     position: relative;
     transform: translate(calc(100% - 34px), 0);
     transition: transform 200ms ease;


### PR DESCRIPTION
Not the most elegant but it works. The math will be redone because the header elements will all share the same animated parent with a fix that's coming later this week.

![](http://i.imgur.com/Qzxcyln.png)

![](http://i.imgur.com/N852YB6.png)

![](http://i.imgur.com/VZ8CRjm.png)