### PR TITLE
Add-ons must always be localized

### DIFF
--- a/src/templates/nav.html
+++ b/src/templates/nav.html
@@ -12,7 +12,7 @@
     {% if addonsEnabled %}
       <li>
         <a class="global-nav-link" data-nav-type="addons"
-           href="{{ url('addons') }}">Add-ons</a>
+           href="{{ url('addons') }}">{{ _('Add-ons') }}</a>
       </li>
     {% endif %}
     <li>


### PR DESCRIPTION
Please see copy rules for Add-ons https://www.mozilla.org/en-US/styleguide/communications/copy-rules/
If there are other occurrences of "Add-ons", please wrap them for l10n.