### PR TITLE
Add compatibility for FxOS 2.0, which does not have hasFeature() (bug 1221994)

### DIFF
--- a/package/iframe/js/features.js
+++ b/package/iframe/js/features.js
@@ -55,6 +55,7 @@ FeaturesBitField.prototype.toBase64 = function() {
     return btoa(String.fromCharCode.apply(null, this.values));
 };
 
+
 function buildFeaturesPromises(features, navigator) {
     navigator = navigator || window.navigator;
     var promises = [];
@@ -184,6 +185,13 @@ function mapArrayToObject(arr) {
  */
 function checkForExtraFeatures(navigator) {
     navigator = navigator || window.navigator;
+
+    if (typeof navigator.hasFeature === 'undefined') {
+        return new Promise(function(resolve, reject) {
+            // Resolve immediately with no data if we haven't hasFeature().
+            resolve({});
+        })
+    }
 
    var promises = {
         addonsEnabled: navigator.hasFeature('web-extensions'),

--- a/package/iframe/tests/features.test.js
+++ b/package/iframe/tests/features.test.js
@@ -167,6 +167,16 @@ describe('features', function() {
             done();
         });
     });
+
+    it('checkForExtraFeatures returns empty object without hasFeature()', function(done) {
+        var features = proxyquire('../js/features', {});
+        var navigator = new MockNavigator();
+        navigator.hasFeature = undefined;
+        features.checkForExtraFeatures(navigator).then(function(features) {
+            assert.deepEqual(features, {});
+            done();
+        });
+    });
 });
 
 describe('features bitfield', function() {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1221994

I messed up : we check `getFeature()` but not `hasFeature()` before entering in this branch. 2.0 has the former but not the latter.