### PR TITLE
Disable install button when device is incompatible (bug 1221345)

### DIFF
--- a/src/media/js/apps.js
+++ b/src/media/js/apps.js
@@ -117,6 +117,15 @@ define('apps',
             (!capabilities.packagedWebApps && product.is_packaged) ||
             !_.contains(product.device_types, device)) {
             reasons.push(gettext('not available for your platform'));
+        } else if (product.feature_compatibility === false) {
+            // If feature_compatibility is false (and not just null!), then it
+            // means the app requires features we don't have.
+            reasons.push(gettext('not compatible with your device'));
+        } else if (product.isAddon && !settings.addonsEnabled) {
+            // If we're dealing with an Addon but the setting is false, it
+            // means we're using an older version of Firefox OS or that we are
+            // in the browser and can't detect compatibility.
+            reasons.push(gettext('not compatible with your device'));
         }
 
         product[COMPAT_REASONS] = reasons.length ? reasons : undefined;
@@ -134,8 +143,9 @@ define('apps',
             product.categories = categories.filter(function(category) {
                 return product.categories.indexOf(category.slug) !== -1;
             }).map(function(category) {
-                return _.extend({url: urls.reverse('category', [category.slug])},
-                                category);
+                return _.extend({
+                    url: urls.reverse('category', [category.slug])
+                }, category);
             });
         }
 
@@ -158,6 +168,7 @@ define('apps',
             product.short_name = product.name;
             product.key = product.slug;
         }
+        product.isLangpack = product.role == 'langpack';
 
         product.__transformed = true;
         return product;

--- a/src/media/js/buttons.js
+++ b/src/media/js/buttons.js
@@ -390,22 +390,21 @@ define('buttons',
     }
 
     function transform(product) {
+        product = apps.transform(product);
+
         if (product.isWebsite) {
             // Return here, don't need extra information for websites.
             return product;
         }
 
-        var isAddon = _isAddon(product);
-        var manifest_url = (isAddon ? product.mini_manifest_url :
+        var manifest_url = (product.isAddon ? product.mini_manifest_url :
                             product.manifest_url);
-        var isLangpack = product.role == 'langpack';
         var incompatible = apps.incompat(product);
         var installed = z.apps.indexOf(manifest_url) !== -1;
 
-        if (isLangpack) {
+        if (product.isLangpack) {
             return _.extend(product, {
                 disabled: incompatible || installed,
-                isLangpack: true,
             });
         }
 
@@ -418,9 +417,7 @@ define('buttons',
         }
 
         return _.extend(product, {
-            disabled: isAddon ? installed : incompatible,
-            isAddon: isAddon,
-            isLangpack: isLangpack,
+            disabled: incompatible,
             incompatible: incompatible,
             installed: installed,
             installedBefore: user.has_installed(product.id) ||

--- a/tests/unit/buttons.js
+++ b/tests/unit/buttons.js
@@ -13,7 +13,8 @@ define('tests/unit/buttons',
                     var app = {};
                     assert.equal(buttons.getBtnText(app), 'yo');
                 });
-            }));
+            }
+        ));
 
         it('is "Install for <amount>" when paid', h.injector(
                 h.mockSettings({
@@ -26,7 +27,8 @@ define('tests/unit/buttons',
                     var app = {price: '10.25', price_locale: '$10.25'};
                     assert.equal(buttons.getBtnText(app), 'pay me $10.25');
                 });
-            }));
+            }
+        ));
 
         it('is "Install" when paid and purchased', h.injector(
                 h.mockSettings({
@@ -38,6 +40,99 @@ define('tests/unit/buttons',
                 assert.equal(buttons.getBtnText(app), 'Install for $10.25');
                 user.update_purchased(app.id);
                 assert.equal(buttons.getBtnText(app), 'Install');
-            }));
+            }
+        ));
+
+        it('is "Install Add-on" for Add-ons', h.injector(
+                h.mockSettings({
+                    addonsEnabled: true,
+                    model_prototypes: {app: 'slug'},
+                })
+            ).run(['buttons'], function(buttons) {
+                h.setL10nStrings({'Install Add-on': 'yo dawg'}, function() {
+                    var app = {
+                        // For now transform() needs a mini_manifest_url to
+                        // properly detect add-ons as such.
+                        mini_manifest_url: '/extension/lol.webapp',
+                    };
+                    assert.equal(buttons.getBtnText(app), 'yo dawg');
+                });
+            }
+        ));
     });
+
+    describe('install button', function() {
+
+        it('is enabled for add-ons depending on device_type', h.injector(
+                h.mockSettings({
+                    addonsEnabled: true,
+                    model_prototypes: {app: 'slug'},
+                })
+            ).run(['buttons'], function(buttons) {
+                var product = {
+                    // Tests are running on a desktop browser.
+                    device_types: ['desktop'],
+                    // For now transform() needs a mini_manifest_url to
+                    // properly detect add-ons as such.
+                    mini_manifest_url: '/extension/lol.webapp',
+                };
+                result = buttons.transform(product);
+                console.log(result);
+                assert.equal(result.disabled, undefined);
+                assert.equal(result.isAddon, true);
+                assert.equal(result.isLangpack, false);
+                assert.equal(result.incompatible, undefined);
+                assert.equal(result.installed, false);
+            }
+        ));
+
+        it('is disabled for add-ons depending on device_type', h.injector(
+                h.mockSettings({
+                    addonsEnabled: true,
+                    model_prototypes: {app: 'slug'},
+                })
+            ).run(['buttons'], function(buttons) {
+                var product = {
+                    // Tests are running on a desktop browser.
+                    device_types: ['foooooobar'],
+                    // For now transform() needs a mini_manifest_url to
+                    // properly detect add-ons as such.
+                    mini_manifest_url: '/extension/lol.webapp',
+                };
+                result = buttons.transform(product);
+                assert.deepEqual(result.disabled,
+                                 ['not available for your platform']);
+                assert.equal(result.isAddon, true);
+                assert.equal(result.isLangpack, false);
+                assert.deepEqual(result.incompatible,
+                                 ['not available for your platform']);
+                assert.equal(result.installed, false);
+            }
+        ));
+
+        it('is disabled for add-ons if setting is set to false', h.injector(
+                h.mockSettings({
+                    addonsEnabled: false,
+                    model_prototypes: {app: 'slug'},
+                })
+            ).run(['buttons'], function(buttons) {
+                var product = {
+                    // Tests are running on a desktop browser.
+                    device_types: ['desktop'],
+                    // For now transform() needs a mini_manifest_url to
+                    // properly detect add-ons as such.
+                    mini_manifest_url: '/extension/lol.webapp',
+                };
+                result = buttons.transform(product);
+                assert.deepEqual(result.disabled,
+                                 ['not compatible with your device']);
+                assert.equal(result.isAddon, true);
+                assert.equal(result.isLangpack, false);
+                assert.deepEqual(result.incompatible,
+                                 ['not compatible with your device']);
+                assert.equal(result.installed, false);
+            }
+        ));
+    });
+
 });

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -11,6 +11,14 @@ define('tests/unit/helpers',
             });
             return injector;
         },
+        mockDeviceTypeCapabilities: function(hasWebApps) {
+            return function(injector) {
+                return injector.mock('core/capabilities', {
+                    device_type: function() {return 'foo';},
+                    webApps: hasWebApps
+                });
+            };
+        },
         mockSettings: function(settings) {
             return function(injector) {
                 injector.mock('core/settings', settings || {});


### PR DESCRIPTION
- Follow feature_compatibility property from the API if present
- Correctly use `app.incompat()` result to disable button for Add-ons depending on device
- Set Add-ons as incompatible if Add-ons are not enabled