### PR TITLE
new nav overlay fixes (bug 1209232)

### DIFF
--- a/src/media/css/nav--global.styl
+++ b/src/media/css/nav--global.styl
@@ -7,16 +7,17 @@ desktop-link-active() {
 }
 
 .global-nav {
-    background-color: $white;
-    box-shadow: 0 -1px 1px rgba(0,0,0,.5);
-    bottom: 0;
+    bottom: 10px;
     height: 60px;
+    padding-top: 10px;
     position: fixed;
     width: 100%;
     z-index: 20;
 }
 
 .global-nav-menu {
+    background-color: $white;
+    box-shadow: 0 -1px 1px rgba(0,0,0,.5);
     display: flex;
     padding: 0 10px;
 
@@ -218,7 +219,7 @@ desktop-link-active() {
 }
 
 .overlay-close {
-    background: url(../img/nav/clear.svg) no-repeat center center / 40px 40px;
+    background: transparent url(../img/nav/clear.svg) no-repeat center center / 40px 40px;
     border: 0;
     border-radius: 50%;
     bottom: 20px;
@@ -253,7 +254,11 @@ desktop-link-active() {
     .overlay-close {
         display: none;
     }
+    .global-nav {
+        padding-top: 0;
+    }
     .global-nav-menu-desktop {
+        background-color: $white;
         display: flex;
         align-items: center;
         justify-content: space-around;

--- a/src/media/js/nav.js
+++ b/src/media/js/nav.js
@@ -46,12 +46,12 @@ define('nav', ['core/log', 'core/navigation', 'core/views', 'core/z'],
         logger.log('header back button pressed');
         resetMenuState();
         navigation.back();
-    }).on('change, input', '#search-q, #search-q-desktop', updateSearchPlaceholder);
+    }).on('change input', '#search-q, #search-q-desktop', updateSearchPlaceholder);
 
     function updateSearchPlaceholder(evt) {
-      var $this = $(this);
-      var isEmpty = $this.val() === '';
-      $this.siblings('label').toggleClass('search-empty', isEmpty);
+        var $this = $(this);
+        var isEmpty = $this.val() === '';
+        $this.siblings('label').toggleClass('search-empty', isEmpty);
     }
 
     function resetMenuState() {
@@ -81,7 +81,10 @@ define('nav', ['core/log', 'core/navigation', 'core/views', 'core/z'],
     }).on('showoverlay', function(e, overlay) {
         $(overlay.selector).addClass('overlay-visible');
         z.page.trigger('clearsearch');
-        z.body.addClass('overlayed');
+
+        if (window.matchMedia('max-width: 1050px').matches) {
+            z.body.addClass('overlayed');
+        }
 
         // Inject overlay clear button.
         setTimeout(function() {


### PR DESCRIPTION
This bordered screenshot describes the bottom nav approach (added top padding) to reduce the chances of a clickthrough to the underlying page. I tried testing this locally quite a bit but always seems to miss really obvious cases so...try locally first also.

The other fix doesn't add the body 'overlayed' class when clicking categories on desktop (since it causes a window resize due to the scrollbar toggle).

![](http://i.imgur.com/7JRZI74.png)