### PR TITLE
Bug 1219227 - [Dev] Screen can be swiped to left on Android

### DIFF
--- a/src/media/css/header--global.styl
+++ b/src/media/css/header--global.styl
@@ -6,6 +6,7 @@ $symbol-height = 32px;
     background-color: $white;
     display: flex;
     min-height: 60px;
+    overflow: hidden;
     padding: 10px;
 
     > * {


### PR DESCRIPTION
Applied overflow hidden on .global-header, which was responsible for increased screen width on android mobile. 