### PR TITLE
fix mobile search btn during active search (bug 1221479)

### DIFF
--- a/src/media/css/header--global.styl
+++ b/src/media/css/header--global.styl
@@ -1,6 +1,10 @@
 @import 'lib';
 
 $symbol-height = 32px;
+search-sprite() {
+    image-replacement('../img/nav/search.svg', $symbol-height, $symbol-height);
+    background-size: $symbol-height 64px;
+}
 
 .global-header {
     background-color: $white;
@@ -41,13 +45,21 @@ $symbol-height = 32px;
 }
 
 .mkt-search-btn {
-    image-replacement('../img/nav/search.svg', $symbol-height, $symbol-height);
-    background-size: $symbol-height 64px;
     border: 0;
+    search-sprite();
     z-index: 3;
 
     &:hover,
-    &.header-nav-link-active {
+    &.header-nav-link-active,
+    &:active {
+        background-position: 0 -32px;
+    }
+}
+
+.global-header,
+.global-nav-menu-desktop {
+    .mkt-search-btn:active {
+        search-sprite();
         background-position: 0 -32px;
     }
 }

--- a/src/media/js/nav.js
+++ b/src/media/js/nav.js
@@ -7,18 +7,25 @@ define('nav', ['core/log', 'core/navigation', 'core/views', 'core/z'],
     // Search.
     z.page.on('showsearch', function(e, args) {
         args = args || {};
+        var $header = $('.global-header');
 
-        $('.global-header').addClass('searching');
+        // Remember whether search was already active.
+        var isSearchActive = $header.hasClass('searching');
+        $header.addClass('searching');
         $('.global-nav-menu-desktop .mkt-search-btn').addClass('header-nav-link-active');
+
         if (args.isDesktop) {
             $('.desktop-search').addClass('searching').find('input').trigger('focus');
             z.page.trigger('clearsettings');
             $('.compat-filter').removeClass('mkt-select--visible');
             z.body.trigger('hideoverlay');
         } else {
-            setTimeout(function() {
-                $('#search-q').trigger('focus');
-            }, 400);
+            // Focus the search input for mobile users (only when the form needs to slide in).
+            if (!isSearchActive) {
+                setTimeout(function() {
+                    $('#search-q').trigger('focus');
+                }, 400);
+            }
         }
     }).on('clearsearch', function() {
         $('#search-q, #search-q-desktop').val('').trigger('input').trigger('blur');


### PR DESCRIPTION
To repro the original bug in mobile:
- tap search icon
- enter search term
- instead of enter/submit/search click the blue search icon in the header (top-left)

This fix still allows searching by clicking the icon a second time but doesn't focus. Tested on desktop but I've found I am terrible at testing.