### PR TITLE
Send feature profile to app endpoint as well (bug 1221345)

### DIFF
--- a/src/media/js/compat_filter.js
+++ b/src/media/js/compat_filter.js
@@ -30,7 +30,7 @@ define('compat_filter',
 
     // Endpoints where feat. profile enabled if conditions met. See apiArgs().
     var ENDPOINTS_WITH_FEATURE_PROFILE = [
-        'category', 'feed', 'feed-app', 'feed-brand', 'feed-collection',
+        'app', 'category', 'feed', 'feed-app', 'feed-brand', 'feed-collection',
         'feed-items', 'feed-shelf', 'installed', 'recommended', 'search'
     ];
     var featureProfile = utils.getVars().pro || '7fffffffffff0.51.6';

--- a/tests/unit/compat_filter.js
+++ b/tests/unit/compat_filter.js
@@ -2,7 +2,9 @@ define('tests/unit/compat_filter',
     ['tests/unit/helpers'],
     function(helpers) {
 
-    var TEST_ENDPOINTS = ['category', 'recommended', 'installed', 'search'];
+    var TEST_ENDPOINTS = [
+        'app', 'category', 'recommended', 'installed', 'search'
+    ];
 
     function testApiArgs(compatFilter, expectedArgs) {
         TEST_ENDPOINTS.forEach(function(endpoint) {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1221345

Needed to make the 'feature_compatibility' property work, since it depends on the profile being send to the API.