### PR TITLE
reverse appropriate website cat URL (bug 1225113)

### DIFF
--- a/src/media/js/apps.js
+++ b/src/media/js/apps.js
@@ -143,6 +143,12 @@ define('apps',
             product.categories = categories.filter(function(category) {
                 return product.categories.indexOf(category.slug) !== -1;
             }).map(function(category) {
+                // If the product is a website reverse its proper URL.
+                if (product.url) {
+                    return _.extend({
+                        url: urls.reverse('category_websites', [category.slug])
+                    }, category);
+                }
                 return _.extend({
                     url: urls.reverse('category', [category.slug])
                 }, category);

--- a/src/templates/website/index.html
+++ b/src/templates/website/index.html
@@ -6,7 +6,7 @@
 
 {% defer (url=endpoint, as='website', key=pk) %}
   {# Apply transformer to get categories etc. working. #}
-  {% set website = apps.transform(this, 'website') %}
+  {% set website = apps.transform(this) %}
   <section class="main full app-info website-detail">
     <div class="detail-flex-wrap">
       <div class="detail-left-side">


### PR DESCRIPTION
Website categories are now prefixed with `/website`. Tested locally - works fine. Also cleaned a template errant param to `transform()` which is no longer used.