### PR TITLE
Update rewriters to fix "load more" when going back & forth (bug 1226426)

### DIFF
--- a/src/media/js/rewriters.js
+++ b/src/media/js/rewriters.js
@@ -42,16 +42,25 @@ define('rewriters',
         return [];
     }
 
-    var rewriteEndpoints = [
-        'feed',
-        'installed',
-        'recommended',
-        'reviews',
-        'search',
-        'langpacks'
+    // List of URLs to rewrite.
+    var rewriteURLs = [
+        urls.api.base.url('addon_list'),
+        // Do not include category endpoints: they are already covered, because
+        // we are rewriting search a few lines below, which is using the same
+        // base URL.
+        urls.api.base.url('feed'),
+        urls.api.base.url('installed'),
+        urls.api.base.url('langpacks'),
+        urls.api.base.url('late-customization'),
+        urls.api.base.url('recommended'),
+        urls.api.base.url('reviews'),
+        urls.api.base.url('search'),
     ];
 
-    return rewriteEndpoints.map(function(endpoint) {
-        return pagination(urls.api.base.url(endpoint));
+    // Return the list of rewriter functions. Caching code will call them all
+    // every time it writes something in the cache, so we filter them to make
+    // sure there are no duplicates.
+    return _.uniq(rewriteURLs).map(function(url) {
+        return pagination(url);
     });
 });

--- a/tests/unit/rewriters.js
+++ b/tests/unit/rewriters.js
@@ -6,7 +6,7 @@ define('tests/unit/rewriters',
         it('rewrites pagination stuff',
            helpers.injector()
            .mock('settings_app', {})
-           .mock('core/settings', {cache_rewriting_enabled: true,
+           .mock('core/settings', {addonsEnabled: true, cache_rewriting_enabled: true,
                                    api_url: 'https://foo.com'})
            .run(['core/urls', 'rewriters', 'route_api_args', 'routes'],
                 function(urls, rewriters, apiArgs, routes) {
@@ -31,6 +31,7 @@ define('tests/unit/rewriters',
                     }
                 };
 
+                // Call all rewriters like the cache module does.
                 for (var i = 0; i < rewriters.length; i++) {
                     rewriters[i](key, value, cache);
                 }


### PR DESCRIPTION
Also add safeguard against adding the same URL twice in rewriters, since they will *all* be called by caching code all the time.