### PR TITLE
clean up header of settings page (bug 1229446)

### DIFF
--- a/src/media/css/header--global.styl
+++ b/src/media/css/header--global.styl
@@ -242,7 +242,7 @@ search-sprite() {
     width: 215px;
 }
 
-[data-page-type~="root"] .mkt-header--title {
+[data-page-type~="homepage"] .mkt-header--title {
     display: none;
 }
 

--- a/src/media/css/site.styl
+++ b/src/media/css/site.styl
@@ -283,12 +283,19 @@ a {
     display: none;
 }
 
+.hide-on-mobile-tablet {
+    display: none;
+}
+
 @media $base-tablet {
     .hide-on-mobile {
         display: block;
     }
     .hide-on-tablet {
         display: none !important;
+    }
+    .hide-on-mobile-tablet {
+        display: none;
     }
     html {
         background: $white;
@@ -305,6 +312,9 @@ a {
 @media $base-desktop {
     .hide-on-desktop {
         display: none !important;
+    }
+    .hide-on-mobile-tablet {
+        display: block !important;
     }
     #page {
         padding-top: 18px;

--- a/src/media/js/views/settings.js
+++ b/src/media/js/views/settings.js
@@ -1,11 +1,12 @@
 define('views/settings',
     ['core/cache', 'jquery', 'core/l10n', 'core/notification', 'core/requests', 'core/urls', 'core/user',
-     'user_helpers', 'core/utils', 'core/z'],
+     'user_helpers', 'core/utils', 'core/z', 'utils_local'],
     function(cache, $, l10n, notification, requests, urls, user, user_helpers,
-             utils, z) {
+             utils, z, utilsLocal) {
     var _pd = utils._pd;
     var gettext = l10n.gettext;
     var notify = notification.notification;
+    var title = gettext('Settings');
 
     function update_settings() {
         var acc_sett = $('.account-settings');
@@ -51,8 +52,9 @@ define('views/settings',
 
     return function(builder) {
         builder.z('type', 'root settings');
-        builder.z('title', gettext('Settings'));
+        builder.z('title', title);
         builder.z('parent', urls.reverse('homepage'));
+        utilsLocal.headerTitle(title);
 
         builder.start('settings.html');
     };

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -1,4 +1,4 @@
-<section class="main hide-on-mobile">
+<section class="main hide-on-mobile-tablet">
   <div class="subheader">
     <h1>{{ _('Settings') }}</h1>
   </div>
@@ -62,7 +62,7 @@
     </div>
   </section>
 
-  <section class="main full hide-on-tablet account-settings-links">
+  <section class="main full hide-on-desktop account-settings-links">
     <div>
       <a href="https://wiki.mozilla.org/Marketplace/Contributing"
          target="_blank" class="button">


### PR DESCRIPTION
- [x] Fix the hub/spoke header title
- [x] Sub-header will hide in tablet & only show in desktop
- [x] Account-settings-links will show in tablet & only hide in desktop

## Fix the hub/spoke header title
### Before 
![screen shot 2015-12-02 at 03 38 28](https://cloud.githubusercontent.com/assets/8364578/11526162/9d8b7432-98a6-11e5-8646-79c9cf4709bb.png)
### After
![screen shot 2015-12-02 at 03 38 37](https://cloud.githubusercontent.com/assets/8364578/11526169/b939f1d6-98a6-11e5-81e1-48ea4151229d.png)
## Sub-header will hide in tablet & only show in desktop
### Before
![screen shot 2015-12-02 at 03 39 24](https://cloud.githubusercontent.com/assets/8364578/11526220/f8d759aa-98a6-11e5-88f7-0c3d37d854e3.png)
### After
![screen shot 2015-12-02 at 03 39 06](https://cloud.githubusercontent.com/assets/8364578/11526231/05bd5232-98a7-11e5-8f08-2d4f0e62b259.png)
## Account-settings-links will show in tablet & only hide in desktop
### Before 
![screen shot 2015-12-02 at 03 51 15](https://cloud.githubusercontent.com/assets/8364578/11526409/562ac99c-98a8-11e5-857d-26eab963df0b.png)
### After
![screen shot 2015-12-02 at 03 50 51](https://cloud.githubusercontent.com/assets/8364578/11526419/6207c1e8-98a8-11e5-8dca-bfe9e10dc535.png)
