### PR TITLE
No need of utils header for categories pages

### DIFF
--- a/src/media/js/views/new_websites.js
+++ b/src/media/js/views/new_websites.js
@@ -1,6 +1,6 @@
 define('views/new_websites',
-    ['core/l10n', 'utils_local'],
-    function(l10n, utils) {
+    ['core/l10n'],
+    function(l10n) {
     'use strict';
     var gettext = l10n.gettext;
 
@@ -9,7 +9,7 @@ define('views/new_websites',
 
         builder.z('type', 'root new site-categories nav-websites');
         builder.z('title', title);
-        utils.headerTitle(title);
+
         builder.start('product_list.html', {
             productListType: 'newWebsites',
             endpoint_name: 'search',

--- a/src/media/js/views/popular_websites.js
+++ b/src/media/js/views/popular_websites.js
@@ -1,6 +1,6 @@
 define('views/popular_websites',
-    ['core/l10n', 'utils_local'],
-    function(l10n, utils) {
+    ['core/l10n'],
+    function(l10n) {
     'use strict';
     var gettext = l10n.gettext;
 
@@ -9,7 +9,7 @@ define('views/popular_websites',
 
         builder.z('type', 'root popular site-categories nav-websites');
         builder.z('title', title);
-        utils.headerTitle(title);
+
         builder.start('product_list.html', {
             productListType: 'popularWebsites',
             endpoint_name: 'search',


### PR DESCRIPTION
We don't need ``utils.header`` for category pages. It shows UI/UX issue for enabling the `root` `.mkt-header--title` in pr #1583 . Merge it before #1583  
## Before
![screen shot 2015-12-02 at 05 07 31](https://cloud.githubusercontent.com/assets/8364578/11528099/a6900ef6-98b2-11e5-926d-6ac457dae6e2.png)
## After
![screen shot 2015-12-02 at 05 07 43](https://cloud.githubusercontent.com/assets/8364578/11528108/b4c699ea-98b2-11e5-9d4f-6da977c09936.png)

