### PR TITLE
Fix redundancy header issue in terms & privacy page (bug 1180428)

### DIFF
--- a/src/templates/privacy.html
+++ b/src/templates/privacy.html
@@ -1,10 +1,10 @@
 <section class="main">
-  <div class="subheader">
+  <div class="subheader hide-on-mobile-tablet">
     <h1>{{ _('Privacy Policy') }}</h1>
   </div>
 </section>
 
-<section class="site-privacy-policy main full prose">
+<section class="site-privacy-policy main full prose mobile-margined">
   {% set url = '/docs/privacy/' + language + '.html?20151106' %}
   {% set fallback = '/docs/privacy/' + settings.default_locale + '.html?20151106' %}
   {% fetch (url=media(url), fallback=media(fallback), filters=['rewriteCdnUrls']) %}

--- a/src/templates/terms.html
+++ b/src/templates/terms.html
@@ -1,10 +1,10 @@
 <section class="main">
-  <div class="subheader">
+  <div class="subheader hide-on-mobile-tablet">
     <h1>{{ _('Terms of Use') }}</h1>
   </div>
 </section>
 
-<section class="site-terms-of-use main full prose">
+<section class="site-terms-of-use main full prose mobile-margined">
   {% set url = '/docs/terms/' + language + '.html?20151106' %}
   {% set fallback = '/docs/terms/' + settings.default_locale + '.html?20151106' %}
   {% fetch (url=media(url), fallback=media(fallback), filters=['rewriteCdnUrls']) %}


### PR DESCRIPTION
### Privacy page
#### Before
![screen shot 2015-12-05 at 03 24 29](https://cloud.githubusercontent.com/assets/8364578/11606882/bd8d2040-9aff-11e5-977a-d7d28328bdbb.png)
#### After
##### Mobile
![screen shot 2015-12-05 at 03 24 32](https://cloud.githubusercontent.com/assets/8364578/11606885/d2ed6c38-9aff-11e5-88d0-f1d04aec7f81.png)
##### Desktop
![screen shot 2015-12-05 at 03 26 51](https://cloud.githubusercontent.com/assets/8364578/11606891/0d7c1d9a-9b00-11e5-88af-a94b3643577f.png)
### Terms of use page
#### Before
![screen shot 2015-12-05 at 03 27 59](https://cloud.githubusercontent.com/assets/8364578/11606893/3ce0ac40-9b00-11e5-8ac9-dc138d94ce02.png)
#### After
##### Mobile 
![screen shot 2015-12-05 at 03 27 55](https://cloud.githubusercontent.com/assets/8364578/11606894/48439ad4-9b00-11e5-81b9-15d8dc070250.png)
##### Desktop
![screen shot 2015-12-05 at 03 28 12](https://cloud.githubusercontent.com/assets/8364578/11606896/5894428a-9b00-11e5-8fb8-5cd45ad82f87.png)
