### PR TITLE
Bug 1223354 - unnecessary page reload on marketplace logo click/tap

### DIFF
--- a/src/templates/header.html
+++ b/src/templates/header.html
@@ -2,8 +2,8 @@
 
 <header id="global-header" class="global-header">
   <h1 class="site">
-    <a href="{{ url('homepage') }}" class="mkt-wordmark"><span>Firefox Marketplace</span></a>
-    <a href="{{ url('homepage') }}" class="mkt-site-name">Marketplace</a>
+    <a href="#" class="mkt-wordmark"><span>Firefox Marketplace</span></a>
+    <a href="#" class="mkt-site-name">Marketplace</a>
   </h1>
   <a class="header-back-btn"><b></b><b></b><b></b></a>
   <a class="header-categories-btn">


### PR DESCRIPTION
Initial design used Logo icon as button to move back to homepage, in new design, the Logo is only on homepage so we don't need anchor tag on logo. 