### PR TITLE
Bug 1184864 - [Android] Horizontal scroll

### DIFF
--- a/src/media/css/feed/landing.styl
+++ b/src/media/css/feed/landing.styl
@@ -20,6 +20,7 @@
 }
 
 .feed-landing-header-mobile {
+    overflow: hidden;
     width: 100%;
 }
 


### PR DESCRIPTION
So added overflow:hidden to .feed-landing-header-mobile instead of .feed-landing-header, so that it doesnt regress to desktop :)