### PR TITLE
alt tile types for cat/search/coll pages (bug 1189324)

### DIFF
--- a/src/templates/_macros/app_tile.html
+++ b/src/templates/_macros/app_tile.html
@@ -4,12 +4,13 @@
 {% from "_macros/previews.html" import preview_tray %}
 {% from "_macros/stars.html" import stars %}
 
-{% macro app_tile(product, feed_app=None, is_detail=False, tray=False, src=None) %}
+{% macro app_tile(product, feed_app=None, is_detail=False, tray=False, alt_style=False, src=None) %}
   {#
       product -- market item (app/website)
       feed_app - feed-app specific data
       is_detail - whether part of a detail page
       tray -- whether or not to attach a preview/screenshot tray
+      alt_style -- is this an alternate representation of the tile (cat hidden, author shown)
       src -- if tile is a link, attach a src param for analytics purposes
   #}
   {% set product = apps.transform(product) %}
@@ -29,7 +30,7 @@
         {{ name|translate(product) }}
       </h3>
       <span class="info mkt-tile-info">
-        {% if product.author and is_detail %}
+        {% if product.author and (is_detail or alt_style) %}
           {# TODO: When we get user profiles, update to be Person itemprop. #}
           <div class="author mkt-product-author" itemprop="creator"
                title="{{ product.author }}">
@@ -41,7 +42,7 @@
           </div>
         {% endif %}
 
-        {% if not is_detail %}
+        {% if not (is_detail or alt_style) %}
           <ul class="app-tile-categories">
             {% for cat in product.categories %}
               <li>{{ cat.name }}</li>

--- a/src/templates/_macros/feed_item.html
+++ b/src/templates/_macros/feed_item.html
@@ -259,7 +259,7 @@
           <h3 class="collection-group-header">{{ group.name }}</h3>
           <ul class="app-list collection-group">
             {% for app in group.apps %}
-              <li class="app-list-app">{{ app_tile(app, src=feed_item.src) }}</li>
+              <li class="app-list-app">{{ app_tile(app, alt_style=True, src=feed_item.src) }}</li>
             {% endfor %}
           </ul>
         </div>
@@ -270,7 +270,7 @@
       <div>
         <ul class="app-list">
           {% for app in feed_item.apps %}
-            <li class="app-list-app">{{ app_tile(app, src=feed_item.src) }}</li>
+            <li class="app-list-app">{{ app_tile(app, alt_style=True, src=feed_item.src) }}</li>
           {% endfor %}
         </ul>
       </div>

--- a/src/templates/category.html
+++ b/src/templates/category.html
@@ -27,7 +27,7 @@
   <ul class="app-list {{ 'paginated' if response.meta.next }}">
     {% for app in this %}
       <li class="item result app-list-app">
-        {{ app_tile(app, tray=True, src=source) }}
+        {{ app_tile(app, tray=True, alt_style=True, src=source) }}
       </li>
     {% endfor %}
 

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -45,7 +45,7 @@
             {% if getProductType(result) == 'addon' %}
               {{ addon_tile(result, src=trackingEvents.SRCS.search) }}
             {% else %}
-              {{ app_tile(result, tray=True, src=trackingEvents.SRCS.search) }}
+              {{ app_tile(result, tray=True, alt_style=True, src=trackingEvents.SRCS.search) }}
             {% endif %}
           </li>
         {% endfor %}


### PR DESCRIPTION
Idea is to hide categories but show author. Affects and checked on search, editorial brand detail (list), collection detail (list), category.

![](http://i.imgur.com/tAYfM7L.png)