### PR TITLE
Bug 1433481 - Show a shutdown banner on every page

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "document-register-element": "~0.1.6",
     "flipsnap": "0.3.0",
     "fxpay": "0.0.16",
-    "salvattore-moox": "1.0.9"
+    "salvattore": "1.0.9"
   },
   "devDependencies": {
     "squire": "~0.2.0"

--- a/config.js
+++ b/config.js
@@ -18,7 +18,7 @@ var localConfig = extend(true, {
         'marketplace-constants/dist/img/regions/*': 'src/media/img/icons/regions/',
         'marketplace-elements/marketplace-elements.js': config.LIB_DEST_PATH,
         'marketplace-elements/marketplace-elements.styl': 'src/media/css/',
-        'salvattore-moox/dist/salvattore.js': config.LIB_DEST_PATH,
+        'salvattore/dist/salvattore.js': config.LIB_DEST_PATH,
     },
     cssBundles: {
         'splash.css': ['splash.styl.css']

--- a/src/media/css/forms.styl
+++ b/src/media/css/forms.styl
@@ -96,3 +96,14 @@ textarea {
 .logged-in .only-logged-in.inline {
     display: inline-block;
 }
+
+#shutdown-banner a {
+  background: none;
+  margin: 0;
+  padding: 0;
+  text-decoration: underline;
+}
+
+#shutdown-banner a:hover {
+  text-decoration: none;
+}

--- a/src/media/js/main.js
+++ b/src/media/js/main.js
@@ -86,6 +86,10 @@ require(
         // Do some last minute template compilation.
         logger.log('Reloading chrome');
 
+        if (!document.getElementById('shutdown-banner')) {
+          $('.banners').append(nunjucks.env.render('shutdown_banner.html'));
+        }
+
         if (!caps.firefoxOS && !navigator.userAgent.match(/googlebot/i)) {
             if (!document.getElementById('fxos-only-banner')) {
                 $('.banners').append(nunjucks.env.render('fxos_only_banner.html'));

--- a/src/templates/shutdown_banner.html
+++ b/src/templates/shutdown_banner.html
@@ -1,0 +1,3 @@
+<mkt-banner id="shutdown-banner" dismiss="off" theme="error">
+  {{ _('The Marketplace will shut down on March 30th, 2018. If there are any apps that you would like, and have not downloaded yet, please do so before that date.  See <a href="{url}">the wiki</a> for more background.')|format(url="https://wiki.mozilla.org/Marketplace/FutureofMarketplaceFAQ") }}
+</mkt-banner>


### PR DESCRIPTION
I just threw the styles in a file that looked like it would definitely get loaded.

![banner-mobile](https://user-images.githubusercontent.com/211578/35455902-66117d9e-0299-11e8-8612-1314d3c3ffb3.gif)
