### PR TITLE
Remove double space from Marketplace shutdown string

### DIFF
--- a/src/templates/shutdown_banner.html
+++ b/src/templates/shutdown_banner.html
@@ -1,3 +1,3 @@
 <mkt-banner id="shutdown-banner" dismiss="off" theme="error">
-  {{ _('The Marketplace will shut down on March 30th, 2018. If there are any apps that you would like, and have not downloaded yet, please do so before that date.  See <a href="{url}">the wiki</a> for more background.')|format(url="https://wiki.mozilla.org/Marketplace/FutureofMarketplaceFAQ") }}
+  {{ _('The Marketplace will shut down on March 30th, 2018. If there are any apps that you would like, and have not downloaded yet, please do so before that date. See <a href="{url}">the wiki</a> for more background.')|format(url="https://wiki.mozilla.org/Marketplace/FutureofMarketplaceFAQ") }}
 </mkt-banner>


### PR DESCRIPTION
The text I copied had two spaces before "See the wiki..." and apparently two spaces gets trimmed to one when it is sent for translation.